### PR TITLE
Follow-up: expose configurable N in Shortcuts ‘Export Last N Days’ phrases

### DIFF
--- a/HealthMd/iOS/AppIntents/HealthMdAppShortcuts.swift
+++ b/HealthMd/iOS/AppIntents/HealthMdAppShortcuts.swift
@@ -20,7 +20,8 @@ struct HealthMdAppShortcuts: AppShortcutsProvider {
         AppShortcut(
             intent: ExportLastNDaysIntent(),
             phrases: [
-                "Export the last week of health data with \(.applicationName)",
+                "Export the last \(\.$days) days of health data with \(.applicationName)",
+                "Export last \(\.$days) days with \(.applicationName)",
                 "Catch up \(.applicationName) export"
             ],
             shortTitle: "Export Last N Days",


### PR DESCRIPTION
### Motivation
- Make the Shortcuts/App Intents phrasing surface the dynamic `days` parameter so Shortcuts/Siri can bind a user-configurable “N days” value instead of implying a fixed “last week”.

### Description
- Updated `HealthMd/iOS/AppIntents/HealthMdAppShortcuts.swift` to replace the week-centric phrase with two parameterized phrases that include the `\(\.$days)` token so the `ExportLastNDaysIntent` exposes the configurable N in shortcut setup.

### Testing
- No unit or CI test suite was run for this trivial metadata change; the file update was validated by confirming the new phrases and `\(\.$days)` token are present with `nl`/`sed` and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6176d9e883278a374079817ca6f8)