### PR TITLE
First pass: add export confirmation checkpoint to prevent accidental taps

### DIFF
--- a/HealthMd/iOS/Views/ExportTabView.swift
+++ b/HealthMd/iOS/Views/ExportTabView.swift
@@ -24,6 +24,7 @@ struct ExportTabView: View {
     @State private var showFolderStructureEditor = false
     @State private var showSubfolderEditor = false
     @State private var showPreview = false
+    @State private var showExportConfirmation = false
     @State private var pearlPulse = false
 
     var body: some View {
@@ -71,6 +72,17 @@ struct ExportTabView: View {
                 if !newValue.isEmpty && newValue != oldValue {
                     UIAccessibility.post(notification: .announcement, argument: newValue)
                 }
+            }
+            .confirmationDialog("Start export?", isPresented: $showExportConfirmation, titleVisibility: .visible) {
+                Button("Preview First") {
+                    showPreview = true
+                }
+                Button("Export Now") {
+                    onExportTapped()
+                }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                Text(exportConfirmationMessage)
             }
         }
         .sheet(isPresented: $showFilenameEditor) {
@@ -489,7 +501,9 @@ struct ExportTabView: View {
     }
 
     private var pearlExportButton: some View {
-        Button(action: onExportTapped) {
+        Button {
+            showExportConfirmation = true
+        } label: {
             HStack(spacing: 6) {
                 if isExporting {
                     ProgressView()
@@ -542,6 +556,21 @@ struct ExportTabView: View {
 
     private var canPreview: Bool {
         !advancedSettings.exportFormats.isEmpty && healthKitManager.isAuthorized
+    }
+
+    private var exportConfirmationMessage: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        let dateRange = "\(formatter.string(from: startDate)) – \(formatter.string(from: endDate))"
+        let formats = advancedSettings.exportFormats
+            .map(\.rawValue)
+            .sorted()
+            .joined(separator: ", ")
+        let destination = vaultManager.vaultURL == nil
+            ? "No folder selected"
+            : "\(vaultManager.vaultName)/\(vaultManager.healthSubfolder.isEmpty ? "Health" : vaultManager.healthSubfolder)"
+
+        return "Date range: \(dateRange)\nFormats: \(formats)\nDestination: \(destination)"
     }
 
     private var pearlStopButton: some View {


### PR DESCRIPTION
### Motivation
- Prevent accidental consumption of limited exports by adding an explicit confirmation step before starting an export. 
- Encourage users to preview their chosen options (date range, formats, vault/subfolder) before committing to an export.

### Description
- Added a new `@State private var showExportConfirmation` to the iOS export UI and present a `confirmationDialog` when the primary Export CTA is tapped. (Modified file: `HealthMd/iOS/Views/ExportTabView.swift`.)
- Changed the primary Export button to open the confirmation dialog instead of immediately calling `onExportTapped` so users get a last checkpoint before export begins. 
- The confirmation dialog exposes two clear actions: **Preview First** (opens `ExportPreviewView`) and **Export Now** (calls `onExportTapped`).
- Added `exportConfirmationMessage`, a short summary string that shows the selected date range, chosen export formats, and destination vault/subfolder in the dialog message.

### Testing
- Ran repository checks and inspection commands: `git status --short` completed successfully. 
- Verified the diff with `git diff -- HealthMd/iOS/Views/ExportTabView.swift` and reviewed inserted dialog and message code successfully. 
- Committed the change with `git commit -m "Add export confirmation step to iOS export CTA"` and created the PR, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4983c4cc83279d4e85d18f761a77)