### PR TITLE
Follow-up: add configurable past-N-days scheduled export window

### DIFF
--- a/HealthMd/Shared/Models/ExportSchedule.swift
+++ b/HealthMd/Shared/Models/ExportSchedule.swift
@@ -19,6 +19,10 @@ struct ExportSchedule: Codable {
     /// schedules without this field decode cleanly.
     var weekday: Int
 
+    /// Number of past days to include in each scheduled export.
+    /// For example, 1 exports yesterday only; 2 exports yesterday + the day before.
+    var lookbackDays: Int
+
     /// The date of the last successful export
     var lastExportDate: Date?
 
@@ -28,6 +32,7 @@ struct ExportSchedule: Codable {
         preferredHour: Int = 8,
         preferredMinute: Int = 0,
         weekday: Int = 1,
+        lookbackDays: Int = 1,
         lastExportDate: Date? = nil
     ) {
         self.isEnabled = isEnabled
@@ -35,6 +40,7 @@ struct ExportSchedule: Codable {
         self.preferredHour = preferredHour
         self.preferredMinute = preferredMinute
         self.weekday = weekday
+        self.lookbackDays = max(1, lookbackDays)
         self.lastExportDate = lastExportDate
     }
 
@@ -45,6 +51,7 @@ struct ExportSchedule: Codable {
         self.preferredHour = try c.decode(Int.self, forKey: .preferredHour)
         self.preferredMinute = try c.decode(Int.self, forKey: .preferredMinute)
         self.weekday = try c.decodeIfPresent(Int.self, forKey: .weekday) ?? 1
+        self.lookbackDays = max(1, try c.decodeIfPresent(Int.self, forKey: .lookbackDays) ?? 1)
         self.lastExportDate = try c.decodeIfPresent(Date.self, forKey: .lastExportDate)
     }
 }

--- a/HealthMd/iOS/SchedulingManager.swift
+++ b/HealthMd/iOS/SchedulingManager.swift
@@ -248,7 +248,7 @@ class SchedulingManager: ObservableObject {
         }
 
         let calendar = Calendar.current
-        let daysToExport = schedule.frequency == .weekly ? 7 : 1
+        let daysToExport = max(1, schedule.lookbackDays)
         let endDate = calendar.startOfDay(for: calendar.date(byAdding: .day, value: -1, to: Date())!)
         let startDate = calendar.startOfDay(for: calendar.date(byAdding: .day, value: -daysToExport, to: Date())!)
 
@@ -300,7 +300,7 @@ class SchedulingManager: ObservableObject {
         }
 
         let calendar = Calendar.current
-        let daysToExport = schedule.frequency == .weekly ? 7 : 1
+        let daysToExport = max(1, schedule.lookbackDays)
         let endDate = calendar.startOfDay(for: calendar.date(byAdding: .day, value: -1, to: Date())!)
         let startDate = calendar.startOfDay(for: calendar.date(byAdding: .day, value: -daysToExport, to: Date())!)
 
@@ -362,13 +362,8 @@ class SchedulingManager: ObservableObject {
 
         // Determine the oldest date we should export
         let oldestDateToExport: Date
-        if schedule.frequency == .weekly {
-            // For weekly, go back 7 days
-            oldestDateToExport = calendar.date(byAdding: .day, value: -7, to: today)!
-        } else {
-            // For daily, just yesterday
-            oldestDateToExport = yesterday
-        }
+        let lookbackDays = max(1, schedule.lookbackDays)
+        oldestDateToExport = calendar.date(byAdding: .day, value: -lookbackDays, to: today)!
 
         // Check what dates are missing
         // lastExportDate is when the export RAN, but exports are for the previous day's data
@@ -489,7 +484,7 @@ class SchedulingManager: ObservableObject {
         // Calculate date range for history recording
         let calendar = Calendar.current
         let currentSchedule = await MainActor.run { schedule }
-        let daysToExport = currentSchedule.frequency == .weekly ? 7 : 1
+        let daysToExport = max(1, currentSchedule.lookbackDays)
         let endDate = calendar.startOfDay(for: calendar.date(byAdding: .day, value: -1, to: Date())!)
         let startDate = calendar.startOfDay(for: calendar.date(byAdding: .day, value: -(daysToExport), to: Date())!)
 
@@ -590,7 +585,7 @@ class SchedulingManager: ObservableObject {
 
         // Daily: export yesterday only
         // Weekly: export last 7 days
-        let daysToExport = currentSchedule.frequency == .weekly ? 7 : 1
+        let daysToExport = max(1, currentSchedule.lookbackDays)
         let dates: [Date] = (1...daysToExport).compactMap { daysAgo in
             let date = calendar.date(byAdding: .day, value: -daysAgo, to: Date())!
             return calendar.startOfDay(for: date)

--- a/HealthMd/iOS/Views/ScheduleSettingsView.swift
+++ b/HealthMd/iOS/Views/ScheduleSettingsView.swift
@@ -77,6 +77,17 @@ struct ScheduleSettingsView: View {
         )
     }
 
+    private var lookbackDaysBinding: Binding<Int> {
+        Binding(
+            get: { schedulingManager.schedule.lookbackDays },
+            set: { newValue in
+                var updated = schedulingManager.schedule
+                updated.lookbackDays = max(1, newValue)
+                schedulingManager.schedule = updated
+            }
+        )
+    }
+
     var body: some View {
         Form {
             automaticExportSection
@@ -145,15 +156,21 @@ struct ScheduleSettingsView: View {
             .accessibilityValue(schedulingManager.schedule.frequency.description)
 
             timeRow
+
+            Stepper(value: lookbackDaysBinding, in: 1...30) {
+                HStack {
+                    Text("Export past days")
+                    Spacer()
+                    Text("\(schedulingManager.schedule.lookbackDays)")
+                        .foregroundStyle(Color.textSecondary)
+                }
+            }
         } header: {
             Text("Schedule")
                 .font(Typography.caption())
                 .foregroundStyle(Color.textSecondary)
         } footer: {
-            Text(schedulingManager.schedule.frequency == .daily
-                ? "Exports yesterday's data daily."
-                : "Exports the last 7 days of data weekly."
-            )
+            Text("Each run exports the past \(schedulingManager.schedule.lookbackDays) day\(schedulingManager.schedule.lookbackDays == 1 ? "" : "s") ending with yesterday.")
             .font(Typography.caption())
             .foregroundStyle(Color.textSecondary)
         }


### PR DESCRIPTION
### Motivation
- Provide a user-configurable scheduled export window so scheduled exports can include the past N days (e.g., today-1, today-2) without manually adjusting the calendar each time.

### Description
- Add a persisted `lookbackDays` integer to `ExportSchedule` with a safe default (`1`) and decoder fallback to preserve backward compatibility (clamped to a minimum of 1). (HealthMd/Shared/Models/ExportSchedule.swift)
- Expose a new iOS UI control (`Stepper` 1...30) to configure the number of past days exported per run and update the schedule footer copy. (HealthMd/iOS/Views/ScheduleSettingsView.swift)
- Update iOS scheduling paths to use the configured `lookbackDays` instead of hard-coded daily/weekly windows in notification-triggered, silent-push, catch-up, background task, and background export flows. (HealthMd/iOS/SchedulingManager.swift)

### Testing
- Performed a codebase search to confirm scheduling paths reference `lookbackDays` and replaced fixed windows with `max(1, lookbackDays)`, which succeeded.
- Ran an automated commit step and created the follow-up PR metadata successfully via the internal `make_pr` flow.
- No unit tests were modified; changes are limited to model, UI, and scheduling logic and validated by static inspection and targeted searches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe4948e0608327b21f27ea83d7f2fe)