### PR TITLE
Fix stale tracked metrics counter in Export Settings

### DIFF
--- a/HealthMd/Shared/Models/HealthMetrics.swift
+++ b/HealthMd/Shared/Models/HealthMetrics.swift
@@ -486,6 +486,7 @@ class MetricSelectionState: ObservableObject, Codable {
     }
 
     func toggleMetric(_ metricId: String) {
+        objectWillChange.send()
         // Pending-approval metrics can never be toggled on.
         if let metric = HealthMetrics.all.first(where: { $0.id == metricId }),
            metric.isPendingAppleApproval {
@@ -500,6 +501,7 @@ class MetricSelectionState: ObservableObject, Codable {
     }
 
     func toggleCategory(_ category: HealthMetricCategory) {
+        objectWillChange.send()
         // Pending-approval categories can never be toggled on.
         guard !category.isPendingAppleApproval else { return }
 
@@ -554,6 +556,7 @@ class MetricSelectionState: ObservableObject, Codable {
     }
 
     func selectAll() {
+        objectWillChange.send()
         for metric in HealthMetrics.all where !metric.isPendingAppleApproval {
             enabledMetrics.insert(metric.id)
         }
@@ -563,6 +566,7 @@ class MetricSelectionState: ObservableObject, Codable {
     }
 
     func deselectAll() {
+        objectWillChange.send()
         enabledMetrics.removeAll()
         enabledCategories.removeAll()
     }

--- a/HealthMdTests/Models/ModelTests.swift
+++ b/HealthMdTests/Models/ModelTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Combine
 @testable import HealthMd
 
 // MARK: - ExportSchedule Tests
@@ -395,6 +396,32 @@ final class HealthDataTests: XCTestCase {
     }
 }
 
+
+
+// MARK: - MetricSelectionState Tests
+
+final class MetricSelectionStateTests: XCTestCase {
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    func testToggleMetric_publishesChangeImmediately() {
+        let state = LifecycleHarness.create({ MetricSelectionState() })
+        let expectedCount = state.totalEnabledCount - 1
+
+        let exp = expectation(description: "Metric toggle publishes")
+        state.objectWillChange
+            .dropFirst()
+            .sink { _ in
+                exp.fulfill()
+            }
+            .store(in: &cancellables)
+
+        state.toggleMetric("steps")
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(state.totalEnabledCount, expectedCount)
+    }
+}
 // MARK: - AdvancedExportSettings Migration Tests
 
 final class AdvancedExportSettingsMigrationTests: XCTestCase {


### PR DESCRIPTION
### Motivation
- Export Settings showed a stale selected-metrics counter because toggling metrics performed in-place `Set` mutations on an `ObservableObject` without guaranteeing a change notification to SwiftUI. 
- The UI needs immediate updates when the user toggles a metric, toggles a category, or selects/deselects all metrics to avoid confusion and accidental exports.

### Description
- Emit `objectWillChange.send()` before in-place mutations in `MetricSelectionState` for `toggleMetric(_:)`, `toggleCategory(_:)`, `selectAll()`, and `deselectAll()` in `HealthMd/Shared/Models/HealthMetrics.swift` to ensure SwiftUI views refresh immediately.
- Add `import Combine` and a regression unit test `MetricSelectionStateTests.testToggleMetric_publishesChangeImmediately` to `HealthMdTests/Models/ModelTests.swift`, which subscribes to `objectWillChange`, toggles the `"steps"` metric, and asserts the publish occurred and the enabled count updated.

### Testing
- Added the unit test `HealthMdTests/MetricSelectionStateTests/testToggleMetric_publishesChangeImmediately` and attempted to run it locally with `xcodebuild`; the run failed because `xcodebuild` is not available in this environment (`xcodebuild: command not found`).
- No other automated test runs were executed here; the change is small and the added test should run in CI/macOS environments with Xcode installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe6171e5748327b705bf5d29b91f89)