### PR TITLE
Fix #18: Export Settings tracked metrics counter doesn't update until settings are reopened

### DIFF
--- a/.symphony/issue.json
+++ b/.symphony/issue.json
@@ -1,0 +1,17 @@
+{
+  "id": "I_kwDOQ4rJSc74E4xm",
+  "identifier": "CodyBontecou/health-md#18",
+  "title": "Export Settings tracked metrics counter doesn't update until settings are reopened",
+  "description": "## Summary\nWhen toggling tracked metrics in **Export Settings**, the selected metrics counter does not refresh immediately.\n\n## Steps to Reproduce\n1. Open Export Settings.\n2. Toggle one or more tracked metrics on/off.\n3. Observe the selected metrics counter while still in the same settings view.\n\n## Expected Behavior\nThe counter updates immediately to reflect the current selection state after each toggle.\n\n## Actual Behavior\nThe counter remains stale and only shows the correct value after closing and re-opening Export Settings.\n\n## Impact\n- Creates confusion about whether metric toggles were applied.\n- Increases risk of exporting with unintended tracked metrics.\n\n## Notes / Discussion\n- Likely state sync issue between toggle state and computed/displayed counter.\n- Could be missing observable update, callback wiring, or derived-state recomputation trigger on toggle.\n\n## Acceptance Criteria\n- Counter updates live as each metric toggle changes.\n- No need to close/re-open settings to get an accurate count.\n- Covered by a regression test for live counter updates.",
+  "author": "CodyBontecou",
+  "priority": null,
+  "state": "open",
+  "branch_name": null,
+  "url": "https://github.com/CodyBontecou/health-md/issues/18",
+  "labels": [
+    "bug"
+  ],
+  "blocked_by": [],
+  "created_at": "2026-03-29T00:13:19Z",
+  "updated_at": "2026-05-08T22:21:23Z"
+}

--- a/.symphony/prompt.md
+++ b/.symphony/prompt.md
@@ -1,0 +1,40 @@
+You are Symphony, an autonomous coding agent working on GitHub issue CodyBontecou/health-md#18: Export Settings tracked metrics counter doesn't update until settings are reopened.
+
+Issue URL: https://github.com/CodyBontecou/health-md/issues/18
+Issue author: CodyBontecou
+
+Issue body:
+## Summary
+When toggling tracked metrics in **Export Settings**, the selected metrics counter does not refresh immediately.
+
+## Steps to Reproduce
+1. Open Export Settings.
+2. Toggle one or more tracked metrics on/off.
+3. Observe the selected metrics counter while still in the same settings view.
+
+## Expected Behavior
+The counter updates immediately to reflect the current selection state after each toggle.
+
+## Actual Behavior
+The counter remains stale and only shows the correct value after closing and re-opening Export Settings.
+
+## Impact
+- Creates confusion about whether metric toggles were applied.
+- Increases risk of exporting with unintended tracked metrics.
+
+## Notes / Discussion
+- Likely state sync issue between toggle state and computed/displayed counter.
+- Could be missing observable update, callback wiring, or derived-state recomputation trigger on toggle.
+
+## Acceptance Criteria
+- Counter updates live as each metric toggle changes.
+- No need to close/re-open settings to get an accurate count.
+- Covered by a regression test for live counter updates.
+
+Instructions:
+
+1. Work only inside the current repository/workspace.
+2. Inspect the codebase and implement the issue as completely as possible.
+3. Run the most relevant formatter, tests, typecheck, or build that is practical for this repository.
+4. Do not create a pull request yourself; Symphony will commit, push, and open the PR after you exit.
+5. Do not wait for human input. If blocked, make the best safe progress and leave notes in your final response.

--- a/HealthMd/Shared/Models/HealthMetrics.swift
+++ b/HealthMd/Shared/Models/HealthMetrics.swift
@@ -491,11 +491,14 @@ class MetricSelectionState: ObservableObject, Codable {
            metric.isPendingAppleApproval {
             return
         }
-        if enabledMetrics.contains(metricId) {
-            enabledMetrics.remove(metricId)
+
+        var updatedMetrics = enabledMetrics
+        if updatedMetrics.contains(metricId) {
+            updatedMetrics.remove(metricId)
         } else {
-            enabledMetrics.insert(metricId)
+            updatedMetrics.insert(metricId)
         }
+        enabledMetrics = updatedMetrics
         updateCategoryState(for: metricId)
     }
 
@@ -506,19 +509,25 @@ class MetricSelectionState: ObservableObject, Codable {
         let metrics = HealthMetrics.byCategory[category] ?? []
         let metricIds = metrics.map { $0.id }
 
+        var updatedMetrics = enabledMetrics
+        var updatedCategories = enabledCategories
+
         if isCategoryFullyEnabled(category) {
             // Disable all metrics in category
             for id in metricIds {
-                enabledMetrics.remove(id)
+                updatedMetrics.remove(id)
             }
-            enabledCategories.remove(category.rawValue)
+            updatedCategories.remove(category.rawValue)
         } else {
             // Enable all metrics in category
             for id in metricIds {
-                enabledMetrics.insert(id)
+                updatedMetrics.insert(id)
             }
-            enabledCategories.insert(category.rawValue)
+            updatedCategories.insert(category.rawValue)
         }
+
+        enabledMetrics = updatedMetrics
+        enabledCategories = updatedCategories
     }
 
     func isCategoryFullyEnabled(_ category: HealthMetricCategory) -> Bool {
@@ -547,24 +556,32 @@ class MetricSelectionState: ObservableObject, Codable {
         let category = metric.category
 
         if isCategoryFullyEnabled(category) {
-            enabledCategories.insert(category.rawValue)
+            var updatedCategories = enabledCategories
+            updatedCategories.insert(category.rawValue)
+            enabledCategories = updatedCategories
         } else {
-            enabledCategories.remove(category.rawValue)
+            var updatedCategories = enabledCategories
+            updatedCategories.remove(category.rawValue)
+            enabledCategories = updatedCategories
         }
     }
 
     func selectAll() {
-        for metric in HealthMetrics.all where !metric.isPendingAppleApproval {
-            enabledMetrics.insert(metric.id)
-        }
-        for category in HealthMetricCategory.allCases where !category.isPendingAppleApproval {
-            enabledCategories.insert(category.rawValue)
-        }
+        enabledMetrics = Set(
+            HealthMetrics.all
+                .filter { !$0.isPendingAppleApproval }
+                .map { $0.id }
+        )
+        enabledCategories = Set(
+            HealthMetricCategory.allCases
+                .filter { !$0.isPendingAppleApproval }
+                .map { $0.rawValue }
+        )
     }
 
     func deselectAll() {
-        enabledMetrics.removeAll()
-        enabledCategories.removeAll()
+        enabledMetrics = []
+        enabledCategories = []
     }
 
     var totalEnabledCount: Int {

--- a/HealthMdTests/Models/ModelTests.swift
+++ b/HealthMdTests/Models/ModelTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import Combine
 @testable import HealthMd
 
 // MARK: - ExportSchedule Tests
@@ -456,6 +457,41 @@ final class AdvancedExportSettingsMigrationTests: XCTestCase {
 
     private func cleanup(_ defaults: UserDefaults, suiteName: String) {
         defaults.removePersistentDomain(forName: suiteName)
+    }
+}
+
+// MARK: - MetricSelectionState Observation Tests
+
+final class MetricSelectionStateObservationTests: XCTestCase {
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() {
+        cancellables.removeAll()
+        super.tearDown()
+    }
+
+    func testToggleMetricPublishesChangeForLiveCounterUpdates() {
+        let state = MetricSelectionState()
+        LifecycleHarness.retain(state)
+
+        guard let metric = HealthMetrics.all.first(where: { !$0.isPendingAppleApproval }) else {
+            return XCTFail("Expected at least one metric available for selection")
+        }
+
+        let initialCount = state.totalEnabledCount
+        let published = expectation(description: "Metric selection publishes a live counter update")
+        published.assertForOverFulfill = false
+
+        state.objectWillChange
+            .sink { _ in
+                published.fulfill()
+            }
+            .store(in: &cancellables)
+
+        state.toggleMetric(metric.id)
+
+        wait(for: [published], timeout: 1.0)
+        XCTAssertEqual(state.totalEnabledCount, initialCount - 1)
     }
 }
 


### PR DESCRIPTION
Closes CodyBontecou/health-md#18

Implemented by Symphony agent automation.

## Issue

https://github.com/CodyBontecou/health-md/issues/18

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.
