### PR TITLE
Fix #35: Remove forced dark mode; respect system appearance

### DIFF
--- a/HealthMd/Shared/Theme/DesignSystem.swift
+++ b/HealthMd/Shared/Theme/DesignSystem.swift
@@ -1,25 +1,31 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 // MARK: - Color Palette
-// iOS: Health.md custom dark theme with signature purple accent
-// macOS: Uses system colors for native appearance
+// Health.md adaptive theme with signature purple accent.
+// These tokens follow the user's system appearance instead of requiring a
+// global color-scheme override.
 
 extension Color {
     #if os(iOS)
-    // Neutral background - deep greys
-    static let bgPrimary = Color(hex: "141414")      // Deep dark grey
-    static let bgSecondary = Color(hex: "1E1E1E")    // Slightly lighter for elevation
-    static let bgTertiary = Color(hex: "262626")     // Cards and surfaces
+    // Neutral backgrounds
+    static let bgPrimary = adaptiveColor(light: "FAFAFA", dark: "141414")
+    static let bgSecondary = adaptiveColor(light: "F1F1F4", dark: "1E1E1E")
+    static let bgTertiary = adaptiveColor(light: "FFFFFF", dark: "262626")
 
-    // Borders - subtle separation
-    static let borderSubtle = Color(hex: "2E2E2E")   // Minimal contrast
-    static let borderDefault = Color(hex: "3E3E3E")  // Standard borders
-    static let borderStrong = Color(hex: "4E4E4E")   // Focused/hover
+    // Borders
+    static let borderSubtle = adaptiveColor(light: "E1E1E6", dark: "2E2E2E")
+    static let borderDefault = adaptiveColor(light: "CACAD2", dark: "3E3E3E")
+    static let borderStrong = adaptiveColor(light: "A8A8B3", dark: "4E4E4E")
 
-    // Text hierarchy - high contrast, readable
-    static let textPrimary = Color(hex: "E8E8E8")    // Primary text
-    static let textSecondary = Color(hex: "A8A8A8")  // Secondary text
-    static let textMuted = Color(hex: "6A6A6E")      // Muted/disabled
+    // Text hierarchy
+    static let textPrimary = adaptiveColor(light: "18181B", dark: "E8E8E8")
+    static let textSecondary = adaptiveColor(light: "4B4B55", dark: "A8A8A8")
+    static let textMuted = adaptiveColor(light: "73737F", dark: "9A9AA2")
 
     // Signature purple accent (matching app icon crystal heart)
     static let accent = Color(hex: "9B6DD7")         // Medium purple (from icon heart)
@@ -31,19 +37,17 @@ extension Color {
     static let error = Color(hex: "C74545")          // Muted red
     static let warning = Color(hex: "D4A958")        // Muted amber
     #elseif os(macOS)
-    // macOS: HealthMD brand — dark palette with warm purple accent
-    // Derived from healthmd.isolated.tech brand identity
-    static let bgPrimary = Color(hex: "0f0c0e")       // Deep warm black
-    static let bgSecondary = Color(hex: "171316")      // Slightly elevated
-    static let bgTertiary = Color(hex: "211b1f")       // Cards / surfaces
+    static let bgPrimary = adaptiveColor(light: "fbf9fa", dark: "0f0c0e")
+    static let bgSecondary = adaptiveColor(light: "f2edf1", dark: "171316")
+    static let bgTertiary = adaptiveColor(light: "ffffff", dark: "211b1f")
 
-    static let borderSubtle = Color(hex: "2d2429")     // Warm dark border
-    static let borderDefault = Color(hex: "3a2f36")    // Standard border
-    static let borderStrong = Color(hex: "4a3d45")     // Focused / hover
+    static let borderSubtle = adaptiveColor(light: "e5dce2", dark: "2d2429")
+    static let borderDefault = adaptiveColor(light: "d1c3cc", dark: "3a2f36")
+    static let borderStrong = adaptiveColor(light: "b8a8b2", dark: "4a3d45")
 
-    static let textPrimary = Color(hex: "f6f1f3")      // Warm off-white
-    static let textSecondary = Color(hex: "c9c0c5")    // Secondary copy
-    static let textMuted = Color(hex: "8e8188")         // Muted / disabled
+    static let textPrimary = adaptiveColor(light: "1d171b", dark: "f6f1f3")
+    static let textSecondary = adaptiveColor(light: "554950", dark: "c9c0c5")
+    static let textMuted = adaptiveColor(light: "7d7078", dark: "8e8188")
 
     // Signature purple — matches website --accent: #7A57A7
     static let accent = Color(hex: "7A57A7")
@@ -54,6 +58,21 @@ extension Color {
     static let error = Color(hex: "C74545")
     static let warning = Color(hex: "D4A958")
     #endif
+
+    private static func adaptiveColor(light: String, dark: String) -> Color {
+        #if canImport(UIKit)
+        return Color(UIColor { traitCollection in
+            UIColor(hex: traitCollection.userInterfaceStyle == .dark ? dark : light)
+        })
+        #elseif canImport(AppKit)
+        return Color(NSColor(name: nil) { appearance in
+            let bestMatch = appearance.bestMatch(from: [.darkAqua, .aqua])
+            return NSColor(hex: bestMatch == .darkAqua ? dark : light)
+        })
+        #else
+        return Color(hex: light)
+        #endif
+    }
 
     init(hex: String) {
         let hex = hex.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
@@ -78,6 +97,56 @@ extension Color {
             opacity: Double(a) / 255
         )
     }
+}
+
+#if canImport(UIKit)
+private extension UIColor {
+    convenience init(hex: String) {
+        let components = rgbaComponents(from: hex)
+        self.init(
+            red: components.red,
+            green: components.green,
+            blue: components.blue,
+            alpha: components.alpha
+        )
+    }
+}
+#elseif canImport(AppKit)
+private extension NSColor {
+    convenience init(hex: String) {
+        let components = rgbaComponents(from: hex)
+        self.init(
+            calibratedRed: components.red,
+            green: components.green,
+            blue: components.blue,
+            alpha: components.alpha
+        )
+    }
+}
+#endif
+
+private func rgbaComponents(from hexString: String) -> (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
+    let hex = hexString.trimmingCharacters(in: CharacterSet.alphanumerics.inverted)
+    var int: UInt64 = 0
+    Scanner(string: hex).scanHexInt64(&int)
+    let a, r, g, b: UInt64
+    switch hex.count {
+    case 3:
+        (a, r, g, b) = (255, (int >> 8) * 17, (int >> 4 & 0xF) * 17, (int & 0xF) * 17)
+    case 6:
+        (a, r, g, b) = (255, int >> 16, int >> 8 & 0xFF, int & 0xFF)
+    case 8:
+        (a, r, g, b) = (int >> 24, int >> 16 & 0xFF, int >> 8 & 0xFF, int & 0xFF)
+    default:
+        (a, r, g, b) = (255, 0, 0, 0)
+    }
+
+    return (
+        red: CGFloat(Double(r) / 255),
+        green: CGFloat(Double(g) / 255),
+        blue: CGFloat(Double(b) / 255),
+        alpha: CGFloat(Double(a) / 255)
+    )
 }
 
 // MARK: - No Gradients

--- a/HealthMd/Shared/Views/ExportConfirmationView.swift
+++ b/HealthMd/Shared/Views/ExportConfirmationView.swift
@@ -110,7 +110,6 @@ struct ExportConfirmationView: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
     }
 
     private func confirmationRow(_ title: String, value: String) -> some View {

--- a/HealthMd/iOS/Components/ExportModal.swift
+++ b/HealthMd/iOS/Components/ExportModal.swift
@@ -142,7 +142,6 @@ struct ExportModal: View {
                                 }
                                 .datePickerStyle(.graphical)
                                 .tint(.accent)
-                                .colorScheme(.dark)
                                 .padding(Spacing.md)
                                 .background(
                                     RoundedRectangle(cornerRadius: 20, style: .continuous)
@@ -173,7 +172,6 @@ struct ExportModal: View {
                                 }
                                 .datePickerStyle(.graphical)
                                 .tint(.accent)
-                                .colorScheme(.dark)
                                 .padding(Spacing.md)
                                 .background(
                                     RoundedRectangle(cornerRadius: 20, style: .continuous)
@@ -283,7 +281,6 @@ struct ExportModal: View {
             }
             #endif
         }
-        .preferredColorScheme(.dark)
         .sheet(isPresented: $showFilenameEditor) {
             FilenameFormatEditor(filenameFormat: $exportSettings.filenameFormat)
         }
@@ -533,7 +530,6 @@ struct FilenameFormatEditor: View {
                 tempFormat = filenameFormat
             }
         }
-        .preferredColorScheme(.dark)
     }
 
     private var previewFilename: String {
@@ -794,7 +790,6 @@ struct FolderStructureEditor: View {
                 tempStructure = folderStructure
             }
         }
-        .preferredColorScheme(.dark)
     }
 
     private var previewPath: String {
@@ -1031,7 +1026,6 @@ struct SubfolderEditor: View {
                 tempSubfolder = subfolder
             }
         }
-        .preferredColorScheme(.dark)
     }
 
     private var previewPath: String {

--- a/HealthMd/iOS/Components/LiquidGlassNavBar.swift
+++ b/HealthMd/iOS/Components/LiquidGlassNavBar.swift
@@ -120,5 +120,4 @@ struct TabButton: View {
             LiquidGlassNavBar(selectedTab: .constant(.export))
         }
     }
-    .preferredColorScheme(.dark)
 }

--- a/HealthMd/iOS/Components/SectionCard.swift
+++ b/HealthMd/iOS/Components/SectionCard.swift
@@ -263,7 +263,6 @@ struct ExportSettingsCard: View {
                         }
                         .datePickerStyle(.graphical)
                         .tint(.accent)
-                        .colorScheme(.dark)
                         .padding(Spacing.md)
                         .background(
                             RoundedRectangle(cornerRadius: 20, style: .continuous)
@@ -292,7 +291,6 @@ struct ExportSettingsCard: View {
                         }
                         .datePickerStyle(.graphical)
                         .tint(.accent)
-                        .colorScheme(.dark)
                         .padding(Spacing.md)
                         .background(
                             RoundedRectangle(cornerRadius: 20, style: .continuous)

--- a/HealthMd/iOS/ContentView.swift
+++ b/HealthMd/iOS/ContentView.swift
@@ -165,7 +165,6 @@ struct ContentView: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
         .sheet(isPresented: $showFolderPicker) {
             FolderPicker { url in
                 pendingFolderURL = url

--- a/HealthMd/iOS/Views/ExportTabView.swift
+++ b/HealthMd/iOS/Views/ExportTabView.swift
@@ -219,7 +219,6 @@ struct ExportTabView: View {
                 )
                 .datePickerStyle(.compact)
                 .tint(Color.accent)
-                .colorScheme(.dark)
                 .accessibilityHint("Select the start date for your export range")
                 .disabled(advancedSettings.useRollingDateRange)
 
@@ -233,7 +232,6 @@ struct ExportTabView: View {
                 )
                 .datePickerStyle(.compact)
                 .tint(Color.accent)
-                .colorScheme(.dark)
                 .accessibilityHint("Select the end date for your export range")
                 .disabled(advancedSettings.useRollingDateRange)
             }

--- a/HealthMd/iOS/Views/OnboardingView.swift
+++ b/HealthMd/iOS/Views/OnboardingView.swift
@@ -156,7 +156,6 @@ struct OnboardingView: View {
                 .animation(.easeOut(duration: 0.4).delay(0.3), value: animateIn)
             }
         }
-        .preferredColorScheme(.dark)
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                 withAnimation {

--- a/HealthMd/iOS/Views/PaywallView.swift
+++ b/HealthMd/iOS/Views/PaywallView.swift
@@ -148,7 +148,6 @@ struct PaywallView: View {
         .onChange(of: purchaseManager.isUnlocked) { _, unlocked in
             if unlocked { dismiss() }
         }
-        .preferredColorScheme(.dark)
     }
 
     // MARK: - Helpers

--- a/HealthMd/iPad/iPadContentView.swift
+++ b/HealthMd/iPad/iPadContentView.swift
@@ -75,7 +75,6 @@ struct iPadContentView: View {
                 }
             }
         }
-        .preferredColorScheme(.dark)
         .tint(.accent)
         .sheet(isPresented: $showFolderPicker) {
             FolderPicker { url in

--- a/HealthMd/macOS/HealthMdApp+macOS.swift
+++ b/HealthMd/macOS/HealthMdApp+macOS.swift
@@ -114,7 +114,6 @@ struct HealthMdApp: App {
                 .environmentObject(syncService)
                 .environmentObject(healthDataStore)
                 .frame(minWidth: 700, minHeight: 500)
-                .preferredColorScheme(.dark)
                 .tint(Color.accent)
                 .task {
                     setupSyncMessageHandler()
@@ -146,7 +145,6 @@ struct HealthMdApp: App {
                 .environmentObject(advancedSettings)
                 .environmentObject(syncService)
                 .environmentObject(healthDataStore)
-                .preferredColorScheme(.dark)
                 .tint(Color.accent)
         }
     }

--- a/HealthMd/macOS/Views/MacOnboardingView.swift
+++ b/HealthMd/macOS/Views/MacOnboardingView.swift
@@ -52,7 +52,6 @@ struct MacOnboardingView: View {
                 navigationFooter
             }
         }
-        .preferredColorScheme(.dark)
         .onAppear {
             if !animateIn {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {

--- a/HealthMdTests/Utilities/AppearanceRegressionTests.swift
+++ b/HealthMdTests/Utilities/AppearanceRegressionTests.swift
@@ -1,0 +1,67 @@
+//
+//  AppearanceRegressionTests.swift
+//  HealthMdTests
+//
+//  Guards the app's system-appearance behavior.
+//
+
+import XCTest
+
+final class AppearanceRegressionTests: XCTestCase {
+
+    private static let projectRoot: URL = {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // Utilities
+            .deletingLastPathComponent() // HealthMdTests
+            .deletingLastPathComponent() // project root
+    }()
+
+    func testProductionSwiftUIDoesNotForceDarkAppearance() throws {
+        let productionRoot = Self.projectRoot.appendingPathComponent("HealthMd")
+        let swiftFiles = try Self.swiftFiles(under: productionRoot)
+            .filter { !$0.pathComponents.contains("Debug") }
+
+        let disallowedPatterns = [
+            ".preferredColorScheme(.dark)",
+            ".environment(\\.colorScheme, .dark)",
+            ".colorScheme(.dark)",
+        ]
+
+        let violations = try swiftFiles.flatMap { file -> [String] in
+            let content = try String(contentsOf: file, encoding: .utf8)
+            return disallowedPatterns.compactMap { pattern in
+                guard content.contains(pattern) else { return nil }
+                return file.path.replacingOccurrences(of: Self.projectRoot.path + "/", with: "") + ": \(pattern)"
+            }
+        }
+
+        XCTAssertTrue(
+            violations.isEmpty,
+            "Production UI must follow system Light/Dark appearance. Remove or scope dark appearance overrides:\n\(violations.joined(separator: "\n"))"
+        )
+    }
+
+    func testAppearanceAuditDocumentsDarkOnlyScope() throws {
+        let auditURL = Self.projectRoot.appendingPathComponent("docs/testing/appearance-audit.md")
+        let content = try String(contentsOf: auditURL, encoding: .utf8)
+
+        XCTAssertTrue(content.contains("## Dark-only Scope"))
+        XCTAssertTrue(content.contains("No production UI currently forces a dark color scheme."))
+    }
+
+    private static func swiftFiles(under root: URL) throws -> [URL] {
+        guard let enumerator = FileManager.default.enumerator(
+            at: root,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return []
+        }
+
+        return try enumerator.compactMap { item in
+            guard let url = item as? URL, url.pathExtension == "swift" else { return nil }
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+            return values.isRegularFile == true ? url : nil
+        }
+    }
+}

--- a/docs/testing/appearance-audit.md
+++ b/docs/testing/appearance-audit.md
@@ -1,0 +1,23 @@
+# Appearance Audit
+
+## Summary
+
+Health.md should follow the user's system Light/Dark appearance on iOS, iPadOS, and macOS. Production SwiftUI must not apply app-wide `.preferredColorScheme(.dark)`, `.environment(\.colorScheme, .dark)`, or `.colorScheme(.dark)` overrides.
+
+The shared design tokens in `HealthMd/Shared/Theme/DesignSystem.swift` use adaptive light/dark colors, so custom backgrounds, borders, and text colors can respond to system appearance without a global override.
+
+## Dark-only Scope
+
+No production UI currently forces a dark color scheme.
+
+No preview, marketing capture, or isolated visual treatment currently requires a dark-only appearance override. If a future capture or preview intentionally needs one, keep it outside production view composition, document the file here, and exclude only that scoped debug/preview path from `AppearanceRegressionTests`.
+
+## Manual Check Matrix
+
+- Onboarding: check Light and Dark appearance for welcome, permission, and completion screens.
+- Export: check Light and Dark appearance for main export, advanced export sheets, progress, and confirmation.
+- Settings: check Light and Dark appearance for vault, format, tracking, subscription, and support sections.
+- Schedule: check Light and Dark appearance for enablement, frequency, time/day controls, and notifications.
+- Sync: check Light and Dark appearance for disconnected, connecting, connected, and transfer states.
+- Paywall: check Light and Dark appearance for product loading, purchase, restore, and error states.
+- iPad split view: check Light and Dark appearance for sidebar selection, export, settings, schedule, sync, and history panes.


### PR DESCRIPTION
Closes CodyBontecou/health-md#35

Implemented by Symphony agent automation.

## Issue

https://github.com/CodyBontecou/health-md/issues/35

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 96
Videos: 7
Other artifacts: 7

- other: `.symphony/qa-artifacts/health-launch-console.txt`
### .symphony/qa-artifacts/ios-light-after-console-launch.png

![.symphony/qa-artifacts/ios-light-after-console-launch.png](https://imghost.isolated.tech/62f6fe95.png)

### .symphony/qa-artifacts/ios-light-current.png

![.symphony/qa-artifacts/ios-light-current.png](https://imghost.isolated.tech/3d7b5ac9.png)

### .symphony/qa-artifacts/ios-light-export.png

![.symphony/qa-artifacts/ios-light-export.png](https://imghost.isolated.tech/5b70cc28.png)

- other: `.symphony/qa-artifacts/ios-light-stderr.log`
- other: `.symphony/qa-artifacts/ios-light-stdout.log`
- video: [.symphony/qa-artifacts/ipad-appearance-flow.mp4](https://imghost.isolated.tech/edc6d715.mp4)
### .symphony/qa-artifacts/ipad-dark-export-after-dismiss.png

![.symphony/qa-artifacts/ipad-dark-export-after-dismiss.png](https://imghost.isolated.tech/9d865555.png)

### .symphony/qa-artifacts/ipad-dark-export-splitview.png

![.symphony/qa-artifacts/ipad-dark-export-splitview.png](https://imghost.isolated.tech/f83337a9.png)

### .symphony/qa-artifacts/ipad-dark-export.png

![.symphony/qa-artifacts/ipad-dark-export.png](https://imghost.isolated.tech/b4d004c4.png)

### .symphony/qa-artifacts/ipad-dark-paywall-attempt.png

![.symphony/qa-artifacts/ipad-dark-paywall-attempt.png](https://imghost.isolated.tech/8eda9400.png)

### .symphony/qa-artifacts/ipad-dark-schedule.png

![.symphony/qa-artifacts/ipad-dark-schedule.png](https://imghost.isolated.tech/470c4161.png)

### .symphony/qa-artifacts/ipad-dark-settings.png

![.symphony/qa-artifacts/ipad-dark-settings.png](https://imghost.isolated.tech/a66c1103.png)

### .symphony/qa-artifacts/ipad-dark-split-export.png

![.symphony/qa-artifacts/ipad-dark-split-export.png](https://imghost.isolated.tech/cb3a04f5.png)

### .symphony/qa-artifacts/ipad-launch-debug.png

![.symphony/qa-artifacts/ipad-launch-debug.png](https://imghost.isolated.tech/8edfcf71.png)

### .symphony/qa-artifacts/ipad-light-export-relaunch.png

![.symphony/qa-artifacts/ipad-light-export-relaunch.png](https://imghost.isolated.tech/0af5fdd7.png)

### .symphony/qa-artifacts/ipad-light-export-splitview.png

![.symphony/qa-artifacts/ipad-light-export-splitview.png](https://imghost.isolated.tech/da56f121.png)

### .symphony/qa-artifacts/ipad-light-export.png

![.symphony/qa-artifacts/ipad-light-export.png](https://imghost.isolated.tech/fb8701a3.png)

### .symphony/qa-artifacts/ipad-light-onboarding-splitview.png

![.symphony/qa-artifacts/ipad-light-onboarding-splitview.png](https://imghost.isolated.tech/f6f022f5.png)

### .symphony/qa-artifacts/ipad-light-schedule.png

![.symphony/qa-artifacts/ipad-light-schedule.png](https://imghost.isolated.tech/8ecb6312.png)

- ...and 90 more artifact(s)

<details>
<summary>QA report</summary>

# Symphony QA Report: health-md#35

## Result

PASS for the forced-dark-mode removal behavior, with one follow-up: the new `HealthMdTests/Utilities/AppearanceRegressionTests.swift` file is not referenced by `HealthMd.xcodeproj/project.pbxproj`, so that regression test will not run until it is added to the test target.

## Simulator / Device Used

- iPhone 17 Pro simulator, iOS 26.3, UDID `0335EECF-93B3-4F95-9D5E-DC339BC055DB`
- iPad Pro 13-inch (M5) simulator, iOS 26.3, UDID `C3A1CAD9-9497-4A22-842A-4A35F0CD84E0`
- macOS target build on My Mac, macOS SDK 26.2, arm64

## Mocked Data Setup

- Launched the app with simulator-only `--uitesting` mode.
- Used `UITEST_HEALTH_AUTHORIZED=true`, `UITEST_VAULT_SELECTED=true`, `UITEST_PURCHASE_UNLOCKED=true`, `UITEST_FREE_EXPORTS_USED=0`, `UITEST_SYNC_STATE=connected`, and `UITEST_SCHEDULE_ENABLED=true`.
- Used the debug marketing-capture path only for deterministic local screenshots of onboarding, export, settings, schedule, sync, and paywall layouts.
- Did not call production APIs, real HealthKit authorization, StoreKit purchase/restore, Apple Account sign-in, or production auth/sync flows.

## Steps Performed

1. Inspected working-tree changes and identified the feature as removal of production dark appearance overrides plus documentation/regression coverage.
2. Searched `HealthMd/` and `HealthMd.xcodeproj` for `.preferredColorScheme(.dark)`, `.colorScheme(.dark)`, `.environment(\\.colorScheme, .dark)`, `UIUserInterfaceStyle`, and related appearance overrides; no matches remained.
3. Confirmed `docs/testing/appearance-audit.md` documents that no production UI currently forces dark appearance.
4. Built iOS app: `xcodebuild -project HealthMd.xcodeproj -scheme HealthMd -configuration Debug-iOS -destination 'platform=iOS Simulator,id=0335EECF-93B3-4F95-9D5E-DC339BC055DB' -derivedDataPath .symphony/DerivedData-QA-issue35 build`.
5. Built iOS test bundle: `xcodebuild -project HealthMd.xcodeproj -scheme HealthMd-Tests-iOS -destination 'platform=iOS Simulator,id=0335EECF-93B3-4F95-9D5E-DC339BC055DB' -derivedDataPath .symphony/DerivedData-QA-issue35-tests build-for-testing`.
6. Built macOS app: `xcodebuild -project HealthMd.xcodeproj -scheme HealthMd-macOS -configuration Debug -derivedDataPath .symphony/DerivedData-QA-issue35-mac build`.
7. Installed and launched the iOS build on iPhone and iPad simulators with mocked state.
8. Set simulator content size to standard `large`, toggled Light/Dark simulator appearance, and captured iPhone and iPad evidence.
9. Captured deterministic Light/Dark screenshots for onboarding, export, settings, schedule, sync, paywall, and iPad split-view export.
10. Recorded an iPhone video showing the export UI responding to simulator Light/Dark appearance changes.

## Pass / Fail Details

- PASS: iOS app build succeeded.
- PASS: iOS test bundle build-for-testing succeeded.
- PASS: macOS target build succeeded.
- PASS: Source scan found no remaining production forced-dark appearance modifiers or plist/project appearance overrides.
- PASS: iPhone export UI changed between Light and Dark simulator appearance.
- PASS: iPad split-view export UI changed between Light and Dark simulator appearance.
- PASS: Onboarding, export, settings, schedule, sync, and paywall screenshots were captured in both Light and Dark appearance using mocked/demo state.
- PASS: Reviewed captured screens for readable contrast in both appearances; no dark-mode forcing or obvious light-mode contrast regression was observed.
- FOLLOW-UP: Add `HealthMdTests/Utilities/AppearanceRegressionTests.swift` to the Xcode test target if this regression test is intended to run in CI.

## Evidence Files

- `issue35-iphone-appearance-toggle.mp4`
- `issue35-iphone-light-export.png`
- `issue35-iphone-dark-export.png`
- `issue35-iphone-light-export-after-toggle.png`
- `issue35-light-onboarding-capture.png`
- `issue35-dark-onboarding-capture.png`
- `issue35-light-export-capture.png`
- `issue35-dark-export-capture.png`
- `issue35-light-schedule-capture.png`
- `issue35-dark-schedule-capture.png`
- `issue35-light-sync-capture.png`
- `issue35-dark-sync-capture.png`
- `issue35-light-settings-capture.png`
- `issue35-dark-settings-capture.png`
- `issue35-light-paywall-capture.png`
- `issue35-dark-paywall-capture.png`
- `issue35-ipad-light-split-export.png`
- `issue35-ipad-dark-split-export.png`

## Limitations / Follow-Up

- macOS was validated by successful target build and source scan only; I did not perform a native macOS UI walkthrough to avoid interacting with any real account, StoreKit, or sync flows outside the simulator/mock setup.
- The added appearance regression test file is currently untracked and not included in the Xcode project file, so it is not active in the test bundle yet.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
