### PR TITLE
Fix #36: Replace fixed fonts with semantic/scaled Dynamic Type styles

### DIFF
--- a/HealthMd/Shared/Theme/DesignSystem.swift
+++ b/HealthMd/Shared/Theme/DesignSystem.swift
@@ -155,6 +155,18 @@ struct Typography {
         .subheadline.weight(.medium).monospaced()
     }
 
+    static func monoCaption() -> Font {
+        .caption.monospaced()
+    }
+
+    static func monoCaptionEmphasis() -> Font {
+        .caption.weight(.medium).monospaced()
+    }
+
+    static func monoLabel() -> Font {
+        .footnote.weight(.medium).monospaced()
+    }
+
     // Keep old bodyMono for compatibility
     static func bodyMono() -> Font {
         .subheadline.monospaced()

--- a/HealthMd/Shared/Views/ExportConfirmationView.swift
+++ b/HealthMd/Shared/Views/ExportConfirmationView.swift
@@ -9,6 +9,7 @@ struct ExportConfirmationView: View {
     let onConfirm: () -> Void
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @ObservedObject private var purchaseManager = PurchaseManager.shared
 
     private var dates: [Date] {
@@ -114,15 +115,43 @@ struct ExportConfirmationView: View {
     }
 
     private func confirmationRow(_ title: String, value: String) -> some View {
-        HStack(alignment: .firstTextBaseline) {
-            Text(title)
-                .foregroundStyle(Color.textSecondary)
-            Spacer(minLength: 16)
-            Text(value)
-                .multilineTextAlignment(.trailing)
-                .foregroundStyle(Color.textPrimary)
-                .font(.footnote.monospaced())
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: 4) {
+                    confirmationTitle(title)
+                    confirmationValue(value)
+                        .multilineTextAlignment(.leading)
+                }
+            } else {
+                ViewThatFits(in: .horizontal) {
+                    HStack(alignment: .firstTextBaseline) {
+                        confirmationTitle(title)
+                        Spacer(minLength: 16)
+                        confirmationValue(value)
+                            .multilineTextAlignment(.trailing)
+                    }
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        confirmationTitle(title)
+                        confirmationValue(value)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+            }
         }
+    }
+
+    private func confirmationTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.body)
+            .foregroundStyle(Color.textSecondary)
+    }
+
+    private func confirmationValue(_ value: String) -> some View {
+        Text(value)
+            .font(Typography.monoLabel())
+            .foregroundStyle(Color.textPrimary)
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     private var confirmButtonTitle: String {

--- a/HealthMd/Shared/Views/ExportPreviewView.swift
+++ b/HealthMd/Shared/Views/ExportPreviewView.swift
@@ -70,7 +70,7 @@ struct ExportPreviewView: View {
     private var emptyStateView: some View {
         VStack(spacing: Spacing.md) {
             Image(systemName: "doc.text.magnifyingglass")
-                .font(.system(size: 40))
+                .font(.largeTitle)
                 .foregroundStyle(Color.textMuted)
             Text("No data to preview")
                 .font(.body.weight(.semibold))
@@ -104,12 +104,12 @@ struct ExportPreviewView: View {
                     }
                 } header: {
                     Text(preview.dateLabel)
-                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .font(Typography.monoCaptionEmphasis())
                         .foregroundStyle(Color.textSecondary)
                 } footer: {
                     if !preview.folderPath.isEmpty {
                         Text(preview.folderPath)
-                            .font(.system(size: 11, design: .monospaced))
+                            .font(Typography.monoCaption())
                             .foregroundStyle(Color.textMuted)
                     }
                 }
@@ -150,7 +150,7 @@ struct ExportPreviewView: View {
                 if totalDateCount > datePreviews.count {
                     HStack(alignment: .top, spacing: 6) {
                         Image(systemName: "info.circle")
-                            .font(.system(size: 11))
+                            .font(.caption2)
                         Text("Previewing the \(datePreviews.count) most recent day\(datePreviews.count == 1 ? "" : "s") with data. The full export will run on every selected date.")
                             .font(.caption)
                     }
@@ -193,16 +193,16 @@ struct ExportPreviewView: View {
     private func fileRow(_ file: FilePreview) -> some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: file.format.iconName)
-                .font(.system(size: 16, weight: .semibold))
+                .font(.body.weight(.semibold))
                 .foregroundStyle(Color.accent)
                 .frame(width: 28, height: 28)
                 .background(Circle().fill(Color.accentSubtle))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(file.filename)
-                    .font(.system(size: 14, weight: .medium, design: .monospaced))
+                    .font(Typography.monoEmphasis())
                     .foregroundStyle(Color.textPrimary)
-                    .lineLimit(1)
+                    .lineLimit(2)
                     .truncationMode(.middle)
                 Text("\(file.format.rawValue) · \(file.sizeLabel)")
                     .font(.caption)
@@ -291,7 +291,7 @@ private struct FileContentView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Text(file.content.isEmpty ? "(empty file)" : file.content)
-                    .font(.system(size: 12, design: .monospaced))
+                    .font(Typography.monoCaption())
                     .foregroundStyle(Color.textPrimary)
                     .textSelection(.disabled)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/HealthMd/iOS/Components/AnimatedButton.swift
+++ b/HealthMd/iOS/Components/AnimatedButton.swift
@@ -38,7 +38,7 @@ struct PrimaryButton: View {
                         .scaleEffect(0.85)
                 } else {
                     Image(systemName: icon)
-                        .font(.system(size: 16, weight: .semibold))
+                        .font(.body.weight(.semibold))
                 }
 
                 Text(LocalizedStringKey(isLoading ? "Exporting..." : title))
@@ -47,7 +47,7 @@ struct PrimaryButton: View {
             }
             .foregroundStyle(.white)
             .frame(maxWidth: .infinity)
-            .frame(height: 52)
+            .frame(minHeight: 52)
             .background(
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
                     .fill(isPressed ? Color.accent.opacity(0.6) : Color.accent.opacity(0.75))
@@ -102,7 +102,7 @@ struct SecondaryButton: View {
             HStack(spacing: Spacing.xs) {
                 if let icon {
                     Image(systemName: icon)
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.footnote.weight(.medium))
                 }
                 Text(LocalizedStringKey(title))
                     .font(.subheadline.weight(.medium))
@@ -163,7 +163,7 @@ struct IconButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: icon)
-                .font(.system(size: 15, weight: .medium))
+                .font(Typography.bodyEmphasis())
                 .foregroundStyle(color)
                 .frame(width: size, height: size)
                 .background(

--- a/HealthMd/iOS/Components/ExportModal.swift
+++ b/HealthMd/iOS/Components/ExportModal.swift
@@ -25,7 +25,7 @@ struct ExportModal: View {
                         // Subfolder input with Liquid Glass styling (tappable)
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("SUBFOLDER")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -34,7 +34,7 @@ struct ExportModal: View {
                             } label: {
                                 HStack(spacing: Spacing.sm) {
                                     Image(systemName: "folder")
-                                        .font(.system(size: 15, weight: .medium))
+                                        .font(Typography.bodyEmphasis())
                                         .foregroundStyle(Color.accent)
 
                                     Text(subfolder.isEmpty ? "Health" : subfolder)
@@ -44,7 +44,7 @@ struct ExportModal: View {
                                     Spacer()
 
                                     Image(systemName: "chevron.right")
-                                        .font(.system(size: 13, weight: .semibold))
+                                        .font(.footnote.weight(.semibold))
                                         .foregroundStyle(Color.textMuted)
                                 }
                                 .padding(.horizontal, Spacing.md)
@@ -63,14 +63,14 @@ struct ExportModal: View {
                             .accessibilityHint("Double tap to change subfolder name")
 
                             Text("Base folder for your health data exports")
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.caption2.weight(.medium))
                                 .foregroundStyle(Color.textMuted)
                         }
 
                         // Folder organization with Liquid Glass styling
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("FOLDER ORGANIZATION")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -79,7 +79,7 @@ struct ExportModal: View {
                             } label: {
                                 HStack(spacing: Spacing.sm) {
                                     Image(systemName: "folder.badge.gearshape")
-                                        .font(.system(size: 15, weight: .medium))
+                                        .font(Typography.bodyEmphasis())
                                         .foregroundStyle(Color.accent)
 
                                     Text(LocalizedStringKey(folderStructureDisplayText))
@@ -89,7 +89,7 @@ struct ExportModal: View {
                                     Spacer()
 
                                     Image(systemName: "chevron.right")
-                                        .font(.system(size: 13, weight: .semibold))
+                                        .font(.footnote.weight(.semibold))
                                         .foregroundStyle(Color.textMuted)
                                 }
                                 .padding(.horizontal, Spacing.md)
@@ -108,7 +108,7 @@ struct ExportModal: View {
                             .accessibilityHint("Double tap to change folder structure")
 
                             Text("Organize exports into subfolders by date")
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.caption2.weight(.medium))
                                 .foregroundStyle(Color.textMuted)
                         }
 
@@ -117,11 +117,11 @@ struct ExportModal: View {
                             if exportSettings.useRollingDateRange {
                                 VStack(alignment: .leading, spacing: Spacing.xs) {
                                     Text("AUTOMATIC RANGE")
-                                        .font(.system(size: 12, weight: .semibold))
+                                        .font(.caption.weight(.semibold))
                                         .foregroundStyle(Color.textMuted)
                                         .tracking(2)
                                     Text("Past \(exportSettings.rollingDateRangeDays) day\(exportSettings.rollingDateRangeDays == 1 ? "" : "s"), including today")
-                                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                        .font(Typography.monoEmphasis())
                                         .foregroundStyle(Color.textPrimary)
                                 }
                             }
@@ -129,7 +129,7 @@ struct ExportModal: View {
                             // Start Date
                             VStack(alignment: .leading, spacing: Spacing.sm) {
                                 Text("START DATE")
-                                    .font(.system(size: 12, weight: .semibold))
+                                    .font(.caption.weight(.semibold))
                                     .foregroundStyle(Color.textMuted)
                                     .tracking(2)
 
@@ -160,7 +160,7 @@ struct ExportModal: View {
                             // End Date
                             VStack(alignment: .leading, spacing: Spacing.sm) {
                                 Text("END DATE")
-                                    .font(.system(size: 12, weight: .semibold))
+                                    .font(.caption.weight(.semibold))
                                     .foregroundStyle(Color.textMuted)
                                     .tracking(2)
 
@@ -192,7 +192,7 @@ struct ExportModal: View {
                         // Export path preview with Liquid Glass styling (tappable)
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("EXPORT TO")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -202,19 +202,19 @@ struct ExportModal: View {
                                 HStack(spacing: Spacing.sm) {
                                     ZStack {
                                         Image(systemName: "arrow.right.circle.fill")
-                                            .font(.system(size: 16, weight: .medium))
+                                            .font(Typography.bodyEmphasis())
                                             .foregroundStyle(Color.accent)
                                             .blur(radius: 4)
                                             .opacity(0.5)
                                             .accessibilityHidden(true)
 
                                         Image(systemName: "arrow.right.circle.fill")
-                                            .font(.system(size: 16, weight: .medium))
+                                            .font(Typography.bodyEmphasis())
                                             .foregroundStyle(Color.accent)
                                     }
 
                                     Text(exportPath)
-                                        .font(.system(size: 14, weight: .medium, design: .monospaced))
+                                        .font(Typography.monoEmphasis())
                                         .foregroundStyle(Color.textPrimary)
                                         .lineLimit(2)
                                         .multilineTextAlignment(.leading)
@@ -222,7 +222,7 @@ struct ExportModal: View {
                                     Spacer()
 
                                     Image(systemName: "pencil.circle.fill")
-                                        .font(.system(size: 18, weight: .medium))
+                                        .font(.title3.weight(.medium))
                                         .foregroundStyle(Color.textMuted)
                                 }
                                 .padding(.horizontal, Spacing.md)
@@ -242,7 +242,7 @@ struct ExportModal: View {
                             .accessibilityHint("Double tap to customize filename format")
 
                             Text("Tap to customize filename format")
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.caption2.weight(.medium))
                                 .foregroundStyle(Color.textMuted)
                         }
                         
@@ -392,13 +392,13 @@ struct FilenameFormatEditor: View {
                         // Format input
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("FILENAME FORMAT")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
                             HStack(spacing: Spacing.sm) {
                                 Image(systemName: "doc.text")
-                                    .font(.system(size: 15, weight: .medium))
+                                    .font(Typography.bodyEmphasis())
                                     .foregroundStyle(Color.accent)
 
                                 TextField("{date}", text: $tempFormat)
@@ -422,7 +422,7 @@ struct FilenameFormatEditor: View {
                         // Preview
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("PREVIEW")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -445,7 +445,7 @@ struct FilenameFormatEditor: View {
                         // Available placeholders
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("AVAILABLE PLACEHOLDERS")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -462,7 +462,7 @@ struct FilenameFormatEditor: View {
                                             Spacer()
 
                                             Text(item.description)
-                                                .font(.system(size: 12, weight: .medium))
+                                                .font(.caption.weight(.medium))
                                                 .foregroundStyle(Color.textMuted)
                                         }
                                         .padding(.horizontal, Spacing.md)
@@ -494,7 +494,7 @@ struct FilenameFormatEditor: View {
                                 Image(systemName: "arrow.counterclockwise")
                                 Text("Reset to Default")
                             }
-                            .font(.system(size: 14, weight: .medium))
+                            .font(.footnote.weight(.medium))
                             .foregroundStyle(Color.textSecondary)
                             .padding(.horizontal, Spacing.md)
                             .padding(.vertical, Spacing.sm)
@@ -609,7 +609,7 @@ struct FolderStructureEditor: View {
                         // Quick presets
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("PRESETS")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -621,11 +621,11 @@ struct FolderStructureEditor: View {
                                         HStack {
                                             VStack(alignment: .leading, spacing: 2) {
                                                 Text(preset.name)
-                                                    .font(.system(size: 15, weight: .medium))
+                                                    .font(Typography.bodyEmphasis())
                                                     .foregroundStyle(Color.textPrimary)
 
                                                 Text(preset.description)
-                                                    .font(.system(size: 12, weight: .regular))
+                                                    .font(.caption)
                                                     .foregroundStyle(Color.textMuted)
                                             }
 
@@ -633,7 +633,7 @@ struct FolderStructureEditor: View {
 
                                             if tempStructure == preset.value {
                                                 Image(systemName: "checkmark.circle.fill")
-                                                    .font(.system(size: 18, weight: .medium))
+                                                    .font(.title3.weight(.medium))
                                                     .foregroundStyle(Color.accent)
                                             }
                                         }
@@ -665,13 +665,13 @@ struct FolderStructureEditor: View {
                         // Custom format input
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("CUSTOM FORMAT")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
                             HStack(spacing: Spacing.sm) {
                                 Image(systemName: "folder.badge.gearshape")
-                                    .font(.system(size: 15, weight: .medium))
+                                    .font(Typography.bodyEmphasis())
                                     .foregroundStyle(Color.accent)
 
                                 TextField("e.g. {year}/{month}", text: $tempStructure)
@@ -692,14 +692,14 @@ struct FolderStructureEditor: View {
                             )
 
                             Text("Leave empty for flat structure, or use placeholders below")
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.caption2.weight(.medium))
                                 .foregroundStyle(Color.textMuted)
                         }
 
                         // Preview
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("PREVIEW")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -722,7 +722,7 @@ struct FolderStructureEditor: View {
                         // Available placeholders
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("AVAILABLE PLACEHOLDERS")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -742,7 +742,7 @@ struct FolderStructureEditor: View {
                                             Spacer()
 
                                             Text(item.description)
-                                                .font(.system(size: 12, weight: .medium))
+                                                .font(.caption.weight(.medium))
                                                 .foregroundStyle(Color.textMuted)
                                         }
                                         .padding(.horizontal, Spacing.md)
@@ -863,7 +863,7 @@ struct SubfolderEditor: View {
                         // Quick presets
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("PRESETS")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -875,11 +875,11 @@ struct SubfolderEditor: View {
                                         HStack {
                                             VStack(alignment: .leading, spacing: 2) {
                                                 Text(preset.name)
-                                                    .font(.system(size: 15, weight: .medium))
+                                                    .font(Typography.bodyEmphasis())
                                                     .foregroundStyle(Color.textPrimary)
 
                                                 Text(preset.description)
-                                                    .font(.system(size: 12, weight: .regular))
+                                                    .font(.caption)
                                                     .foregroundStyle(Color.textMuted)
                                             }
 
@@ -887,7 +887,7 @@ struct SubfolderEditor: View {
 
                                             if tempSubfolder == preset.value {
                                                 Image(systemName: "checkmark.circle.fill")
-                                                    .font(.system(size: 18, weight: .medium))
+                                                    .font(.title3.weight(.medium))
                                                     .foregroundStyle(Color.accent)
                                             }
                                         }
@@ -919,13 +919,13 @@ struct SubfolderEditor: View {
                         // Custom folder name input
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("CUSTOM FOLDER NAME")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
                             HStack(spacing: Spacing.sm) {
                                 Image(systemName: "folder")
-                                    .font(.system(size: 15, weight: .medium))
+                                    .font(Typography.bodyEmphasis())
                                     .foregroundStyle(Color.accent)
 
                                 TextField("Health", text: $tempSubfolder)
@@ -946,14 +946,14 @@ struct SubfolderEditor: View {
                             )
 
                             Text("Enter a custom folder name for your exports")
-                                .font(.system(size: 11, weight: .medium))
+                                .font(.caption2.weight(.medium))
                                 .foregroundStyle(Color.textMuted)
                         }
 
                         // Preview
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("PREVIEW")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
@@ -976,17 +976,17 @@ struct SubfolderEditor: View {
                         // Info section
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             Text("INFO")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.textMuted)
                                 .tracking(2)
 
                             HStack(spacing: Spacing.sm) {
                                 Image(systemName: "info.circle")
-                                    .font(.system(size: 15, weight: .medium))
+                                    .font(Typography.bodyEmphasis())
                                     .foregroundStyle(Color.accent)
 
                                 Text("This folder will be created inside your selected export location. Leave empty to export directly to the root folder.")
-                                    .font(.system(size: 13, weight: .regular))
+                                    .font(.footnote)
                                     .foregroundStyle(Color.textSecondary)
                             }
                             .padding(.horizontal, Spacing.md)
@@ -1057,7 +1057,7 @@ struct IndividualTrackingExportPreview: View {
         VStack(alignment: .leading, spacing: Spacing.sm) {
             HStack {
                 Text("INDIVIDUAL ENTRIES")
-                    .font(.system(size: 12, weight: .semibold))
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(Color.textMuted)
                     .tracking(2)
                 
@@ -1066,7 +1066,7 @@ struct IndividualTrackingExportPreview: View {
                 // Badge showing count or warning
                 if settings.totalEnabledCount > 0 {
                     Text("\(settings.totalEnabledCount) metrics")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.caption2.weight(.semibold))
                         .foregroundStyle(Color.white)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
@@ -1076,7 +1076,7 @@ struct IndividualTrackingExportPreview: View {
                         )
                 } else {
                     Text("No metrics selected")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.caption2.weight(.semibold))
                         .foregroundStyle(Color.white)
                         .padding(.horizontal, 8)
                         .padding(.vertical, 4)
@@ -1093,16 +1093,16 @@ struct IndividualTrackingExportPreview: View {
                 VStack(alignment: .leading, spacing: Spacing.sm) {
                     HStack(spacing: Spacing.sm) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 15, weight: .medium))
+                            .font(Typography.bodyEmphasis())
                             .foregroundStyle(Color.orange)
                         
                         Text("No individual entries will be created")
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.footnote.weight(.medium))
                             .foregroundStyle(Color.textPrimary)
                     }
                     
                     Text("Individual Entry Tracking is enabled, but no metrics are selected. Go to Settings → Individual Entry Tracking and select which metrics to track individually.")
-                        .font(.system(size: 12, weight: .regular))
+                        .font(.caption)
                         .foregroundStyle(Color.textSecondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -1121,11 +1121,11 @@ struct IndividualTrackingExportPreview: View {
                 VStack(alignment: .leading, spacing: Spacing.xs) {
                     HStack(spacing: Spacing.sm) {
                         Image(systemName: "doc.on.doc")
-                            .font(.system(size: 15, weight: .medium))
+                            .font(Typography.bodyEmphasis())
                             .foregroundStyle(Color.accent)
                         
                         Text("Will create individual files for:")
-                            .font(.system(size: 13, weight: .medium))
+                            .font(.footnote.weight(.medium))
                             .foregroundStyle(Color.textPrimary)
                     }
                     
@@ -1134,16 +1134,16 @@ struct IndividualTrackingExportPreview: View {
                         ForEach(enabledCategories, id: \.self) { category in
                             HStack(spacing: 6) {
                                 Image(systemName: category.icon)
-                                    .font(.system(size: 11))
+                                    .font(.caption2)
                                     .foregroundStyle(Color.accent.opacity(0.8))
                                     .frame(width: 16)
                                 
                                 Text(category.rawValue)
-                                    .font(.system(size: 12, weight: .medium))
+                                    .font(.caption.weight(.medium))
                                     .foregroundStyle(Color.textSecondary)
                                 
                                 Text("(\(settings.enabledCount(for: category)))")
-                                    .font(.system(size: 11))
+                                    .font(.caption2)
                                     .foregroundStyle(Color.textMuted)
                             }
                         }
@@ -1153,11 +1153,11 @@ struct IndividualTrackingExportPreview: View {
                     // Folder preview
                     HStack(spacing: 6) {
                         Image(systemName: "folder")
-                            .font(.system(size: 11))
+                            .font(.caption2)
                             .foregroundStyle(Color.textMuted)
                         
                         Text(folderPreview)
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .font(Typography.monoCaption())
                             .foregroundStyle(Color.textMuted)
                     }
                     .padding(.top, 4)
@@ -1174,7 +1174,7 @@ struct IndividualTrackingExportPreview: View {
                 )
                 
                 Text("Individual entries are created in addition to daily summaries")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.caption2.weight(.medium))
                     .foregroundStyle(Color.textMuted)
             }
         }

--- a/HealthMd/iOS/Components/LiquidGlassNavBar.swift
+++ b/HealthMd/iOS/Components/LiquidGlassNavBar.swift
@@ -85,10 +85,10 @@ struct TabButton: View {
         Button(action: action) {
             VStack(spacing: 4) {
                 Image(systemName: isSelected ? tab.selectedIcon : tab.icon)
-                    .font(.system(size: 22, weight: .medium))
+                    .font(.title3.weight(.medium))
 
                 Text(LocalizedStringKey(tab.label))
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.caption2.weight(.medium))
             }
             .foregroundStyle(isSelected ? Color.white : Color.textSecondary)
             .frame(maxWidth: .infinity)

--- a/HealthMd/iOS/Components/SectionCard.swift
+++ b/HealthMd/iOS/Components/SectionCard.swift
@@ -15,11 +15,11 @@ struct CompactStatusBadge: View {
         Button(action: { action?() }) {
             HStack(spacing: Spacing.sm) {
                 Image(systemName: icon)
-                    .font(.system(size: 15, weight: .medium))
+                    .font(Typography.bodyEmphasis())
 
                 Text(LocalizedStringKey(title))
                     .font(.footnote.weight(.medium))
-                    .lineLimit(1)
+                    .lineLimit(2)
 
                 // Status dot with glow
                 ZStack {
@@ -143,13 +143,13 @@ struct VaultSelectionCard: View {
                         if isSelected {
                             HStack(spacing: Spacing.xs) {
                                 Image(systemName: "folder.fill")
-                                    .font(.system(size: 12))
+                                    .font(.caption)
                                     .foregroundStyle(Color.accent)
 
                                 Text(vaultName)
                                     .font(Typography.caption())
                                     .foregroundStyle(Color.textSecondary)
-                                    .lineLimit(1)
+                                    .lineLimit(2)
                             }
                         } else {
                             Text("No vault selected")
@@ -194,7 +194,7 @@ struct ExportSettingsCard: View {
                 // Section header with Liquid Glass icon
                 HStack(spacing: Spacing.sm) {
                     Image(systemName: "gearshape.fill")
-                        .font(.system(size: 18, weight: .medium))
+                        .font(.title3.weight(.medium))
                         .foregroundStyle(Color.accent)
                         .frame(width: 32, height: 32)
                         .background(
@@ -220,7 +220,7 @@ struct ExportSettingsCard: View {
 
                     HStack(spacing: Spacing.sm) {
                         Image(systemName: "folder")
-                            .font(.system(size: 15, weight: .medium))
+                            .font(Typography.bodyEmphasis())
                             .foregroundStyle(Color.accent)
 
                         TextField("Health", text: $subfolder)
@@ -318,12 +318,12 @@ struct ExportSettingsCard: View {
                         Image(systemName: "arrow.right.circle.fill")
                             .foregroundStyle(Color.accent)
                     }
-                    .font(.system(size: 14, weight: .medium))
+                    .font(.footnote.weight(.medium))
 
                     Text(exportPath)
                         .font(.footnote.weight(.medium).monospaced())
                         .foregroundStyle(Color.textPrimary)
-                        .lineLimit(1)
+                        .lineLimit(2)
                 }
                 .padding(.horizontal, Spacing.md)
                 .padding(.vertical, Spacing.sm + 2)

--- a/HealthMd/iOS/Components/StatusIndicator.swift
+++ b/HealthMd/iOS/Components/StatusIndicator.swift
@@ -29,12 +29,13 @@ struct StatusPill: View {
     }
 
     let status: Status
+    @ScaledMetric(relativeTo: .footnote) private var dotSize: CGFloat = 8
 
     var body: some View {
         HStack(spacing: Spacing.xs) {
             Circle()
                 .fill(status.color)
-                .frame(width: 8, height: 8)
+                .frame(width: dotSize, height: dotSize)
                 .shadow(color: status.color.opacity(0.6), radius: 4, x: 0, y: 0)
 
             Text(status.label)
@@ -63,13 +64,14 @@ struct StatusPill: View {
 
 struct PulsingHeartIcon: View {
     let isConnected: Bool
+    @ScaledMetric(relativeTo: .title2) private var iconContainerSize: CGFloat = 48
 
     var body: some View {
         ZStack {
             // Glow layer when connected
             if isConnected {
                 Image(systemName: "heart.fill")
-                    .font(.system(size: 24, weight: .medium))
+                    .font(.title2.weight(.medium))
                     .foregroundStyle(Color.accent)
                     .blur(radius: 8)
                     .opacity(0.6)
@@ -77,10 +79,10 @@ struct PulsingHeartIcon: View {
 
             // Main icon
             Image(systemName: "heart.fill")
-                .font(.system(size: 24, weight: .medium))
+                .font(.title2.weight(.medium))
                 .foregroundStyle(isConnected ? Color.accent : Color.textMuted)
         }
-        .frame(width: 48, height: 48)
+        .frame(width: iconContainerSize, height: iconContainerSize)
         .background(
             Circle()
                 .fill(.ultraThinMaterial)
@@ -101,13 +103,14 @@ struct PulsingHeartIcon: View {
 
 struct VaultIcon: View {
     let isSelected: Bool
+    @ScaledMetric(relativeTo: .title2) private var iconContainerSize: CGFloat = 48
 
     var body: some View {
         ZStack {
             // Glow layer when selected
             if isSelected {
                 Image(systemName: "folder.fill")
-                    .font(.system(size: 24, weight: .medium))
+                    .font(.title2.weight(.medium))
                     .foregroundStyle(Color.accent)
                     .blur(radius: 8)
                     .opacity(0.6)
@@ -116,10 +119,10 @@ struct VaultIcon: View {
 
             // Main icon
             Image(systemName: "folder.fill")
-                .font(.system(size: 24, weight: .medium))
+                .font(.title2.weight(.medium))
                 .foregroundStyle(isSelected ? Color.accent : Color.textMuted)
         }
-        .frame(width: 48, height: 48)
+        .frame(width: iconContainerSize, height: iconContainerSize)
         .background(
             Circle()
                 .fill(.ultraThinMaterial)
@@ -186,7 +189,7 @@ struct ExportStatusBadge: View {
                     }
                 }
             }
-            .font(.system(size: 18, weight: .medium))
+            .font(.title3.weight(.medium))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(message)
@@ -198,7 +201,7 @@ struct ExportStatusBadge: View {
                 if canOpenFolder {
                     HStack(spacing: 3) {
                         Image(systemName: "folder.fill")
-                            .font(.system(size: 10, weight: .medium))
+                            .font(.caption2.weight(.medium))
                         Text("Open in Files")
                             .font(.caption.weight(.medium))
                     }

--- a/HealthMd/iOS/ContentView.swift
+++ b/HealthMd/iOS/ContentView.swift
@@ -610,54 +610,26 @@ struct ContentView: View {
 struct DiscordPromoBanner: View {
     private let discordURL = URL(string: "https://discord.gg/RaQYS4t6gn")!
     let onClose: () -> Void
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     var body: some View {
-        HStack(spacing: Spacing.sm) {
-            Image(systemName: "bubble.left.and.bubble.right.fill")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.accent)
-                .frame(width: 26, height: 26)
-                .background(
-                    Circle()
-                        .fill(Color.accentSubtle)
-                )
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text("Join the community")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundStyle(Color.textPrimary)
-
-                Text("Chat with us on Discord")
-                    .font(.caption)
-                    .foregroundStyle(Color.textSecondary)
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                VStack(alignment: .leading, spacing: Spacing.sm) {
+                    bannerMessage
+                    HStack(spacing: Spacing.sm) {
+                        bannerJoinLink
+                        bannerDismissButton
+                    }
+                }
+            } else {
+                HStack(spacing: Spacing.sm) {
+                    bannerMessage
+                    Spacer(minLength: Spacing.sm)
+                    bannerJoinLink
+                    bannerDismissButton
+                }
             }
-
-            Spacer(minLength: Spacing.sm)
-
-            Link(destination: discordURL) {
-                Text("Join")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Color.accent)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(
-                        Capsule()
-                            .fill(Color.accentSubtle)
-                    )
-            }
-
-            Button(action: onClose) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 10, weight: .bold))
-                    .foregroundStyle(Color.textMuted)
-                    .padding(6)
-                    .background(
-                        Circle()
-                            .fill(Color.white.opacity(0.06))
-                    )
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Dismiss Discord banner")
         }
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, 10)
@@ -671,6 +643,60 @@ struct DiscordPromoBanner: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("Join the Health.md Discord community.")
+    }
+
+    private var bannerMessage: some View {
+        HStack(spacing: Spacing.sm) {
+            Image(systemName: "bubble.left.and.bubble.right.fill")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(Color.accent)
+                .frame(width: 26, height: 26)
+                .background(
+                    Circle()
+                        .fill(Color.accentSubtle)
+                )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Join the community")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Text("Chat with us on Discord")
+                    .font(.caption)
+                    .foregroundStyle(Color.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var bannerJoinLink: some View {
+        Link(destination: discordURL) {
+            Text("Join")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.accent)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule()
+                        .fill(Color.accentSubtle)
+                )
+        }
+    }
+
+    private var bannerDismissButton: some View {
+        Button(action: onClose) {
+            Image(systemName: "xmark")
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(Color.textMuted)
+                .padding(6)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(0.06))
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Dismiss Discord banner")
     }
 }
 
@@ -736,7 +762,7 @@ struct SettingsTabView: View {
                 VStack(spacing: Spacing.lg) {
                     // Settings icon with Liquid Glass container
                     Image(systemName: "gearshape.fill")
-                        .font(.system(size: 48, weight: .medium))
+                        .font(.largeTitle.weight(.medium))
                         .foregroundStyle(Color.textMuted)
                         .frame(width: 84, height: 84)
                         .background(
@@ -893,7 +919,7 @@ struct SettingsRow: View {
                 ZStack {
                     if isActive {
                         Image(systemName: icon)
-                            .font(.system(size: 18, weight: .medium))
+                            .font(.title3.weight(.medium))
                             .foregroundStyle(Color.accent)
                             .blur(radius: 6)
                             .opacity(0.5)
@@ -901,7 +927,7 @@ struct SettingsRow: View {
                     }
 
                     Image(systemName: icon)
-                        .font(.system(size: 18, weight: .medium))
+                        .font(.title3.weight(.medium))
                         .foregroundStyle(isActive ? Color.accent : Color.textMuted)
                 }
                 .frame(width: 36, height: 36)
@@ -927,7 +953,7 @@ struct SettingsRow: View {
                 Spacer()
 
                 Image(systemName: "chevron.right")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.footnote.weight(.semibold))
                     .foregroundStyle(Color.textMuted)
             }
             .padding(.horizontal, Spacing.md + 4)

--- a/HealthMd/iOS/Views/ExportTabView.swift
+++ b/HealthMd/iOS/Views/ExportTabView.swift
@@ -25,6 +25,11 @@ struct ExportTabView: View {
     @State private var showSubfolderEditor = false
     @State private var showPreview = false
     @State private var pearlPulse = false
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var usesAccessibilityLayout: Bool {
+        dynamicTypeSize.isAccessibilitySize
+    }
 
     var body: some View {
         NavigationStack {
@@ -149,7 +154,7 @@ struct ExportTabView: View {
     // MARK: - Status Badges
 
     private var statusBadges: some View {
-        HStack(spacing: Spacing.md) {
+        let badges = Group {
             CompactStatusBadge(
                 icon: "heart.fill",
                 title: "Health",
@@ -172,6 +177,18 @@ struct ExportTabView: View {
                 action: { showFolderPicker = true }
             )
             .accessibilityIdentifier(AccessibilityID.Export.vaultBadge)
+        }
+
+        return Group {
+            if usesAccessibilityLayout {
+                VStack(spacing: Spacing.md) {
+                    badges
+                }
+            } else {
+                HStack(spacing: Spacing.md) {
+                    badges
+                }
+            }
         }
     }
 
@@ -296,7 +313,7 @@ struct ExportTabView: View {
                 if advancedSettings.exportFormats.isEmpty {
                     HStack(spacing: Spacing.xs) {
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .font(.system(size: 12))
+                            .font(.caption)
                         Text("Select at least one export format.")
                             .font(.footnote.weight(.medium))
                     }
@@ -463,10 +480,10 @@ struct ExportTabView: View {
                     Image(systemName: "arrow.right.circle.fill")
                         .foregroundStyle(Color.accent)
                 }
-                .font(.system(size: 16, weight: .medium))
+                .font(Typography.bodyEmphasis())
 
                 Text(exportPath)
-                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .font(Typography.monoEmphasis())
                     .foregroundStyle(Color.textPrimary)
                     .multilineTextAlignment(.leading)
             }
@@ -509,27 +526,43 @@ struct ExportTabView: View {
                     .accessibilityLabel("\(remaining) free export\(remaining == 1 ? "" : "s") remaining before purchase required")
             }
 
-            HStack(spacing: 10) {
-                if !isExporting {
-                    previewPillButton
-                        .transition(.scale.combined(with: .opacity))
-                }
-
-                pearlExportButton
-
-                if isExporting {
-                    pearlStopButton
-                        .transition(.scale.combined(with: .opacity))
+            Group {
+                if usesAccessibilityLayout {
+                    VStack(spacing: 10) {
+                        floatingBarButtons
+                    }
+                } else {
+                    HStack(spacing: 10) {
+                        floatingBarButtons
+                    }
                 }
             }
             .animation(AnimationTimings.standard, value: isExporting)
         }
         .padding(.horizontal, Spacing.lg)
+        .padding(.top, 10)
         .padding(.bottom, 4)
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial)
         .onAppear {
             withAnimation(.easeInOut(duration: 2.4).repeatForever(autoreverses: true)) {
                 pearlPulse = true
             }
+        }
+    }
+
+    @ViewBuilder
+    private var floatingBarButtons: some View {
+        if !isExporting {
+            previewPillButton
+                .transition(.scale.combined(with: .opacity))
+        }
+
+        pearlExportButton
+
+        if isExporting {
+            pearlStopButton
+                .transition(.scale.combined(with: .opacity))
         }
     }
 
@@ -543,7 +576,7 @@ struct ExportTabView: View {
                         .frame(width: 13, height: 13)
                 } else {
                     Image(systemName: "arrow.up")
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.footnote.weight(.semibold))
                 }
                 Text(LocalizedStringKey(isExporting ? "Exporting…" : "Review"))
                     .font(.callout.weight(.semibold))
@@ -566,7 +599,7 @@ struct ExportTabView: View {
         Button { showPreview = true } label: {
             HStack(spacing: 6) {
                 Image(systemName: "eye")
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.footnote.weight(.semibold))
                 Text("Preview")
                     .font(.callout.weight(.semibold))
                     .tracking(0.4)
@@ -660,7 +693,7 @@ struct ExportTabView: View {
                     .scaleEffect(0.6)
             } else {
                 Image(systemName: icon)
-                    .font(.system(size: 12, weight: .heavy))
+                    .font(.caption.weight(.heavy))
                     .foregroundStyle(iconColor)
             }
         }
@@ -717,7 +750,7 @@ struct ExportTabView: View {
 
     private func sectionLabel(_ text: String) -> some View {
         Text(text)
-            .font(.system(size: 12, weight: .semibold))
+            .font(.caption.weight(.semibold))
             .foregroundStyle(Color.textMuted)
             .tracking(2)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -751,7 +784,7 @@ struct ExportTabView: View {
     ) -> some View {
         HStack(spacing: Spacing.md) {
             Image(systemName: icon)
-                .font(.system(size: 17, weight: .medium))
+                .font(.body.weight(.medium))
                 .foregroundStyle(Color.accent)
                 .frame(width: 32, height: 32)
                 .background(Circle().fill(.ultraThinMaterial))
@@ -785,11 +818,11 @@ struct ExportTabView: View {
             if isActive {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(Color.accent)
-                    .font(.system(size: 16))
+                    .font(.body)
             }
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 13, weight: .semibold))
+                .font(.footnote.weight(.semibold))
                 .foregroundStyle(Color.textMuted)
         }
         .padding(.horizontal, Spacing.md)
@@ -808,7 +841,7 @@ struct ExportTabView: View {
     private func editorRowLabel(icon: String, title: String, value: String) -> some View {
         HStack(spacing: Spacing.md) {
             Image(systemName: icon)
-                .font(.system(size: 17, weight: .medium))
+                .font(.body.weight(.medium))
                 .foregroundStyle(Color.accent)
                 .frame(width: 32, height: 32)
                 .background(Circle().fill(.ultraThinMaterial))
@@ -822,14 +855,14 @@ struct ExportTabView: View {
                 Text(value)
                     .font(.footnote.monospaced())
                     .foregroundStyle(Color.textSecondary)
-                    .lineLimit(1)
+                    .lineLimit(2)
                     .truncationMode(.middle)
             }
 
             Spacer()
 
             Image(systemName: "pencil.circle.fill")
-                .font(.system(size: 18, weight: .medium))
+                .font(.title3.weight(.medium))
                 .foregroundStyle(Color.textMuted)
         }
         .padding(.horizontal, Spacing.md)

--- a/HealthMd/iOS/Views/IndividualTrackingView.swift
+++ b/HealthMd/iOS/Views/IndividualTrackingView.swift
@@ -293,7 +293,7 @@ struct CategoryTrackingRow: View {
             Button(action: onToggleExpand) {
                 HStack {
                     Image(systemName: category.icon)
-                        .font(.system(size: 16))
+                        .font(Typography.bodyEmphasis())
                         .foregroundColor(Color.accent)
                         .frame(width: 24)
                     
@@ -317,7 +317,7 @@ struct CategoryTrackingRow: View {
                         .foregroundColor(Color.textSecondary)
                     
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                        .font(.system(size: 12, weight: .semibold))
+                        .font(.caption.weight(.semibold))
                         .foregroundColor(Color.textSecondary)
                 }
                 .contentShape(Rectangle())
@@ -360,7 +360,7 @@ struct MetricTrackingRow: View {
                     
                     if IndividualTrackingSettings.isSuggested(metric.id) {
                         Image(systemName: "sparkles")
-                            .font(.system(size: 10))
+                            .font(.caption2)
                             .foregroundColor(Color.accent)
                     }
                 }

--- a/HealthMd/iOS/Views/OnboardingView.swift
+++ b/HealthMd/iOS/Views/OnboardingView.swift
@@ -44,53 +44,53 @@ struct OnboardingView: View {
                     .padding(.top, Spacing.md)
                     .padding(.horizontal, Spacing.xl)
 
-                Spacer()
-
                 // Step content with directional slide
-                ZStack {
-                    switch currentStep {
-                    case 0:
-                        WelcomeStep(animateIn: animateIn)
-                            .transition(stepTransition)
-                    case 1:
-                        HealthAccessStep(
-                            isAuthorized: healthKitManager.isAuthorized,
-                            animateIn: animateIn,
-                            onRequestAccess: {
-                                Task {
-                                    try? await healthKitManager.requestAuthorization()
+                ScrollView {
+                    ZStack {
+                        switch currentStep {
+                        case 0:
+                            WelcomeStep(animateIn: animateIn)
+                                .transition(stepTransition)
+                        case 1:
+                            HealthAccessStep(
+                                isAuthorized: healthKitManager.isAuthorized,
+                                animateIn: animateIn,
+                                onRequestAccess: {
+                                    Task {
+                                        try? await healthKitManager.requestAuthorization()
+                                    }
                                 }
-                            }
-                        )
-                        .transition(stepTransition)
-                    case 2:
-                        FolderSetupStep(
-                            vaultManager: vaultManager,
-                            animateIn: animateIn,
-                            onPickFolder: { showFolderPicker = true }
-                        )
-                        .transition(stepTransition)
-                    case 3:
-                        UnlockStep(
-                            purchaseManager: purchaseManager,
-                            animateIn: animateIn
-                        )
-                        .transition(stepTransition)
-                    case 4:
-                        ReadyStep(
-                            healthAuthorized: healthKitManager.isAuthorized,
-                            folderSelected: vaultManager.vaultURL != nil,
-                            folderName: vaultManager.vaultName,
-                            animateIn: animateIn
-                        )
-                        .transition(stepTransition)
-                    default:
-                        EmptyView()
+                            )
+                            .transition(stepTransition)
+                        case 2:
+                            FolderSetupStep(
+                                vaultManager: vaultManager,
+                                animateIn: animateIn,
+                                onPickFolder: { showFolderPicker = true }
+                            )
+                            .transition(stepTransition)
+                        case 3:
+                            UnlockStep(
+                                purchaseManager: purchaseManager,
+                                animateIn: animateIn
+                            )
+                            .transition(stepTransition)
+                        case 4:
+                            ReadyStep(
+                                healthAuthorized: healthKitManager.isAuthorized,
+                                folderSelected: vaultManager.vaultURL != nil,
+                                folderName: vaultManager.vaultName,
+                                animateIn: animateIn
+                            )
+                            .transition(stepTransition)
+                        default:
+                            EmptyView()
+                        }
                     }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, Spacing.lg)
                 }
                 .animation(.spring(response: 0.5, dampingFraction: 0.85), value: currentStep)
-
-                Spacer()
 
                 // Navigation buttons
                 VStack(spacing: Spacing.md) {
@@ -218,13 +218,15 @@ private enum TransitionDirection {
 struct OnboardingProgressBar: View {
     let current: Int
     let total: Int
+    @ScaledMetric(relativeTo: .caption) private var selectedSegmentWidth: CGFloat = 32
+    @ScaledMetric(relativeTo: .caption) private var segmentHeight: CGFloat = 3
 
     var body: some View {
         HStack(spacing: 6) {
             ForEach(0..<total, id: \.self) { index in
                 Capsule()
                     .fill(index <= current ? Color.accent : Color.borderDefault)
-                    .frame(width: index == current ? 32 : nil, height: 3)
+                    .frame(width: index == current ? selectedSegmentWidth : nil, height: segmentHeight)
                     .frame(maxWidth: index == current ? nil : .infinity)
                     .animation(.spring(response: 0.4, dampingFraction: 0.75), value: current)
             }
@@ -305,6 +307,7 @@ private extension View {
 
 private struct WelcomeStep: View {
     let animateIn: Bool
+    @ScaledMetric(relativeTo: .largeTitle) private var appIconSize: CGFloat = 100
 
     var body: some View {
         VStack(spacing: Spacing.lg) {
@@ -313,7 +316,7 @@ private struct WelcomeStep: View {
                 Image("AppIconImage")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 100, height: 100)
+                    .frame(width: appIconSize, height: appIconSize)
                     .blur(radius: 30)
                     .breathingGlow()
                     .accessibilityHidden(true)
@@ -321,7 +324,7 @@ private struct WelcomeStep: View {
                 Image("AppIconImage")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 100, height: 100)
+                    .frame(width: appIconSize, height: appIconSize)
                     .clipShape(RoundedRectangle(cornerRadius: 24, style: .continuous))
                     .overlay(
                         RoundedRectangle(cornerRadius: 24, style: .continuous)
@@ -388,6 +391,7 @@ private struct HealthAccessStep: View {
     let isAuthorized: Bool
     let animateIn: Bool
     let onRequestAccess: () -> Void
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconContainerSize: CGFloat = 100
 
     var body: some View {
         VStack(spacing: Spacing.lg) {
@@ -395,7 +399,7 @@ private struct HealthAccessStep: View {
             ZStack {
                 if isAuthorized {
                     Image(systemName: "heart.fill")
-                        .font(.system(size: 52, weight: .medium))
+                        .font(.largeTitle.weight(.medium))
                         .foregroundStyle(Color.accent)
                         .blur(radius: 20)
                         .breathingGlow()
@@ -403,11 +407,11 @@ private struct HealthAccessStep: View {
                 }
 
                 Image(systemName: isAuthorized ? "heart.fill" : "heart")
-                    .font(.system(size: 52, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(isAuthorized ? Color.accent : Color.textMuted)
                     .contentTransition(.symbolEffect(.replace))
             }
-            .frame(width: 100, height: 100)
+            .frame(width: heroIconContainerSize, height: heroIconContainerSize)
             .background(
                 Circle()
                     .fill(.ultraThinMaterial)
@@ -472,7 +476,7 @@ private struct HealthAccessStep: View {
                 Button(action: onRequestAccess) {
                     HStack(spacing: 8) {
                         Image(systemName: "heart.circle.fill")
-                            .font(.system(size: 18))
+                            .font(.title3)
                         Text("Grant Access")
                             .font(Typography.bodyEmphasis())
                     }
@@ -503,6 +507,7 @@ private struct FolderSetupStep: View {
     @ObservedObject var vaultManager: VaultManager
     let animateIn: Bool
     let onPickFolder: () -> Void
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconContainerSize: CGFloat = 100
 
     var body: some View {
         VStack(spacing: Spacing.lg) {
@@ -510,7 +515,7 @@ private struct FolderSetupStep: View {
             ZStack {
                 if vaultManager.vaultURL != nil {
                     Image(systemName: "folder.fill")
-                        .font(.system(size: 52, weight: .medium))
+                        .font(.largeTitle.weight(.medium))
                         .foregroundStyle(Color.accent)
                         .blur(radius: 20)
                         .breathingGlow()
@@ -518,11 +523,11 @@ private struct FolderSetupStep: View {
                 }
 
                 Image(systemName: vaultManager.vaultURL != nil ? "folder.fill" : "folder")
-                    .font(.system(size: 52, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(vaultManager.vaultURL != nil ? Color.accent : Color.textMuted)
                     .contentTransition(.symbolEffect(.replace))
             }
-            .frame(width: 100, height: 100)
+            .frame(width: heroIconContainerSize, height: heroIconContainerSize)
             .background(
                 Circle()
                     .fill(.ultraThinMaterial)
@@ -555,7 +560,7 @@ private struct FolderSetupStep: View {
                 if vaultManager.vaultURL != nil {
                     HStack(spacing: Spacing.sm) {
                         Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 20))
+                            .font(.title3)
                             .foregroundStyle(Color.success)
 
                         VStack(alignment: .leading, spacing: 2) {
@@ -610,7 +615,7 @@ private struct FolderSetupStep: View {
                     Button(action: onPickFolder) {
                         HStack(spacing: 8) {
                             Image(systemName: "folder.badge.plus")
-                                .font(.system(size: 18))
+                                .font(.title3)
                             Text("Select Folder")
                                 .font(Typography.bodyEmphasis())
                         }
@@ -642,6 +647,7 @@ private struct FolderSetupStep: View {
 private struct UnlockStep: View {
     @ObservedObject var purchaseManager: PurchaseManager
     let animateIn: Bool
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconContainerSize: CGFloat = 100
 
     private var priceLabel: String {
         purchaseManager.product?.displayPrice ?? "$9.99"
@@ -652,17 +658,17 @@ private struct UnlockStep: View {
             // Hero icon
             ZStack {
                 Image(systemName: "lock.open.fill")
-                    .font(.system(size: 52, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(Color.accent)
                     .blur(radius: 20)
                     .breathingGlow()
                     .accessibilityHidden(true)
 
                 Image(systemName: "lock.open.fill")
-                    .font(.system(size: 52, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(Color.accent)
             }
-            .frame(width: 100, height: 100)
+            .frame(width: heroIconContainerSize, height: heroIconContainerSize)
             .background(
                 Circle()
                     .fill(.ultraThinMaterial)
@@ -730,17 +736,19 @@ private struct UnlockStep: View {
 private struct UnlockFeatureRow: View {
     let icon: String
     let text: String
+    @ScaledMetric(relativeTo: .body) private var iconWidth: CGFloat = 28
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: icon)
-                .font(.system(size: 14, weight: .medium))
+                .font(.footnote.weight(.medium))
                 .foregroundStyle(Color.accent)
-                .frame(width: 28)
+                .frame(width: iconWidth)
 
             Text(text)
                 .font(Typography.body())
                 .foregroundStyle(Color.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
 
             Spacer()
         }
@@ -757,23 +765,24 @@ private struct ReadyStep: View {
     let animateIn: Bool
 
     @State private var celebrationBounce = false
+    @ScaledMetric(relativeTo: .largeTitle) private var heroIconContainerSize: CGFloat = 100
 
     var body: some View {
         VStack(spacing: Spacing.lg) {
             // Checkmark icon with celebration bounce
             ZStack {
                 Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 56, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(Color.success)
                     .blur(radius: 20)
                     .breathingGlow()
                     .accessibilityHidden(true)
 
                 Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 56, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(Color.success)
             }
-            .frame(width: 100, height: 100)
+            .frame(width: heroIconContainerSize, height: heroIconContainerSize)
             .background(
                 Circle()
                     .fill(.ultraThinMaterial)
@@ -860,13 +869,14 @@ private struct FeatureRow: View {
     let icon: String
     let title: String
     let description: String
+    @ScaledMetric(relativeTo: .body) private var iconContainerSize: CGFloat = 40
 
     var body: some View {
         HStack(spacing: Spacing.md) {
             Image(systemName: icon)
-                .font(.system(size: 20, weight: .medium))
+                .font(.title3.weight(.medium))
                 .foregroundStyle(Color.accent)
-                .frame(width: 40, height: 40)
+                .frame(width: iconContainerSize, height: iconContainerSize)
                 .background(
                     Circle()
                         .fill(Color.accentSubtle)
@@ -876,10 +886,12 @@ private struct FeatureRow: View {
                 Text(title)
                     .font(Typography.bodyEmphasis())
                     .foregroundStyle(Color.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Text(description)
                     .font(Typography.caption())
                     .foregroundStyle(Color.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Spacer()
@@ -891,13 +903,14 @@ private struct DataCategoryRow: View {
     let icon: String
     let label: String
     let detail: String
+    @ScaledMetric(relativeTo: .body) private var iconWidth: CGFloat = 28
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: icon)
-                .font(.system(size: 14, weight: .medium))
+                .font(.footnote.weight(.medium))
                 .foregroundStyle(Color.accent)
-                .frame(width: 28)
+                .frame(width: iconWidth)
 
             Text(label)
                 .font(Typography.bodyEmphasis())
@@ -917,13 +930,14 @@ private struct SuggestionRow: View {
     let icon: String
     let label: String
     let recommended: Bool
+    @ScaledMetric(relativeTo: .body) private var iconWidth: CGFloat = 28
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: icon)
-                .font(.system(size: 16, weight: .medium))
+                .font(Typography.bodyEmphasis())
                 .foregroundStyle(recommended ? Color.accent : Color.textSecondary)
-                .frame(width: 28)
+                .frame(width: iconWidth)
 
             Text(label)
                 .font(Typography.body())
@@ -952,13 +966,14 @@ private struct SetupSummaryRow: View {
     let label: String
     let status: String
     let isComplete: Bool
+    @ScaledMetric(relativeTo: .body) private var iconWidth: CGFloat = 28
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: icon)
-                .font(.system(size: 16, weight: .medium))
+                .font(Typography.bodyEmphasis())
                 .foregroundStyle(isComplete ? Color.accent : Color.textMuted)
-                .frame(width: 28)
+                .frame(width: iconWidth)
 
             Text(label)
                 .font(Typography.bodyEmphasis())
@@ -972,7 +987,7 @@ private struct SetupSummaryRow: View {
                     .foregroundStyle(isComplete ? Color.success : Color.textMuted)
 
                 Image(systemName: isComplete ? "checkmark.circle.fill" : "circle")
-                    .font(.system(size: 14))
+                    .font(.footnote)
                     .foregroundStyle(isComplete ? Color.success : Color.textMuted)
                     .contentTransition(.symbolEffect(.replace))
             }

--- a/HealthMd/iOS/Views/PaywallView.swift
+++ b/HealthMd/iOS/Views/PaywallView.swift
@@ -5,120 +5,124 @@ import StoreKit
 struct PaywallView: View {
     @ObservedObject private var purchaseManager = PurchaseManager.shared
     @Environment(\.dismiss) private var dismiss
+    @ScaledMetric(relativeTo: .largeTitle) private var appIconSize: CGFloat = 72
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
             Color.bgPrimary.ignoresSafeArea()
 
-            VStack(spacing: 0) {
-                // MARK: - Header
-                VStack(spacing: Spacing.lg) {
-                    ZStack {
-                        Image("AppIconImage")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 72, height: 72)
-                            .blur(radius: 28)
-                            .opacity(0.4)
-                            .accessibilityHidden(true)
+            ScrollView {
+                VStack(spacing: 0) {
+                    // MARK: - Header
+                    VStack(spacing: Spacing.lg) {
+                        ZStack {
+                            Image("AppIconImage")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: appIconSize, height: appIconSize)
+                                .blur(radius: 28)
+                                .opacity(0.4)
+                                .accessibilityHidden(true)
 
-                        Image("AppIconImage")
-                            .resizable()
-                            .aspectRatio(contentMode: .fit)
-                            .frame(width: 72, height: 72)
-                            .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 18, style: .continuous)
-                                    .strokeBorder(
-                                        LinearGradient(
-                                            colors: [Color.white.opacity(0.25), Color.clear],
-                                            startPoint: .topLeading,
-                                            endPoint: .bottomTrailing
-                                        ),
-                                        lineWidth: 1
-                                    )
-                            )
-                            .shadow(color: Color.accent.opacity(0.35), radius: 20, x: 0, y: 10)
-                    }
-                    .padding(.top, Spacing.xl + Spacing.sm)
-
-                    VStack(spacing: Spacing.xs) {
-                        Text("Unlock Health.md")
-                            .font(Typography.displayMedium())
-                            .foregroundStyle(Color.textPrimary)
-                            .accessibilityIdentifier(AccessibilityID.Paywall.title)
-
-                        Text("You've used your 3 free exports")
-                            .font(Typography.body())
-                            .foregroundStyle(Color.textSecondary)
-                            .multilineTextAlignment(.center)
-                            .accessibilityIdentifier(AccessibilityID.Paywall.subtitle)
-                    }
-                }
-                .padding(.horizontal, Spacing.lg)
-
-                // MARK: - Features
-                VStack(spacing: Spacing.sm) {
-                    PaywallFeatureRow(icon: "arrow.up.doc.fill",  text: "Unlimited exports, forever")
-                    PaywallFeatureRow(icon: "clock.fill",         text: "Automated scheduled exports")
-                    PaywallFeatureRow(icon: "checkmark.shield",   text: "All future features included")
-                    PaywallFeatureRow(icon: "lock.open.fill",     text: "One-time payment — no subscription")
-                }
-                .padding(.horizontal, Spacing.lg)
-                .padding(.top, Spacing.xl)
-
-                Spacer()
-
-                // MARK: - CTA
-                VStack(spacing: Spacing.md) {
-                    if let error = purchaseManager.purchaseError {
-                        Text(error)
-                            .font(.caption)
-                            // Restore "not found" messages are informational — use a
-                            // softer muted colour. True errors (network, verification)
-                            // stay red so the user knows something went wrong.
-                            .foregroundStyle(
-                                error.contains("cody@isolated.tech")
-                                    ? Color.textMuted
-                                    : Color.error
-                            )
-                            .multilineTextAlignment(.center)
-                            .padding(.horizontal, Spacing.md)
-                            .accessibilityIdentifier(AccessibilityID.Paywall.errorMessage)
-                    }
-
-                    PrimaryButton(
-                        priceButtonLabel(purchaseManager.product),
-                        icon: "lock.open.fill",
-                        isLoading: purchaseManager.isPurchasing,
-                        isDisabled: purchaseManager.isPurchasing || purchaseManager.isRestoring,
-                        action: {
-                            Task { await purchaseManager.purchase() }
+                            Image("AppIconImage")
+                                .resizable()
+                                .aspectRatio(contentMode: .fit)
+                                .frame(width: appIconSize, height: appIconSize)
+                                .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                        .strokeBorder(
+                                            LinearGradient(
+                                                colors: [Color.white.opacity(0.25), Color.clear],
+                                                startPoint: .topLeading,
+                                                endPoint: .bottomTrailing
+                                            ),
+                                            lineWidth: 1
+                                        )
+                                )
+                                .shadow(color: Color.accent.opacity(0.35), radius: 20, x: 0, y: 10)
                         }
-                    )
-                    .accessibilityIdentifier(AccessibilityID.Paywall.unlockButton)
+                        .padding(.top, Spacing.xl + Spacing.sm)
 
-                    Button {
-                        Task { await purchaseManager.restore() }
-                    } label: {
-                        HStack(spacing: 6) {
-                            if purchaseManager.isRestoring {
-                                ProgressView()
-                                    .controlSize(.mini)
-                                    .tint(Color.textMuted)
+                        VStack(spacing: Spacing.xs) {
+                            Text("Unlock Health.md")
+                                .font(Typography.displayMedium())
+                                .foregroundStyle(Color.textPrimary)
+                                .accessibilityIdentifier(AccessibilityID.Paywall.title)
+
+                            Text("You've used your 3 free exports")
+                                .font(Typography.body())
+                                .foregroundStyle(Color.textSecondary)
+                                .multilineTextAlignment(.center)
+                                .accessibilityIdentifier(AccessibilityID.Paywall.subtitle)
+                        }
+                    }
+                    .padding(.horizontal, Spacing.lg)
+
+                    // MARK: - Features
+                    VStack(spacing: Spacing.sm) {
+                        PaywallFeatureRow(icon: "arrow.up.doc.fill",  text: "Unlimited exports, forever")
+                        PaywallFeatureRow(icon: "clock.fill",         text: "Automated scheduled exports")
+                        PaywallFeatureRow(icon: "checkmark.shield",   text: "All future features included")
+                        PaywallFeatureRow(icon: "lock.open.fill",     text: "One-time payment — no subscription")
+                    }
+                    .padding(.horizontal, Spacing.lg)
+                    .padding(.top, Spacing.xl)
+
+                    Spacer(minLength: Spacing.xl)
+
+                    // MARK: - CTA
+                    VStack(spacing: Spacing.md) {
+                        if let error = purchaseManager.purchaseError {
+                            Text(error)
+                                .font(.caption)
+                                // Restore "not found" messages are informational — use a
+                                // softer muted colour. True errors (network, verification)
+                                // stay red so the user knows something went wrong.
+                                .foregroundStyle(
+                                    error.contains("cody@isolated.tech")
+                                        ? Color.textMuted
+                                        : Color.error
+                                )
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, Spacing.md)
+                                .accessibilityIdentifier(AccessibilityID.Paywall.errorMessage)
+                        }
+
+                        PrimaryButton(
+                            priceButtonLabel(purchaseManager.product),
+                            icon: "lock.open.fill",
+                            isLoading: purchaseManager.isPurchasing,
+                            isDisabled: purchaseManager.isPurchasing || purchaseManager.isRestoring,
+                            action: {
+                                Task { await purchaseManager.purchase() }
                             }
-                            Text("Restore Purchase")
-                                .font(.subheadline)
-                                .foregroundStyle(Color.textMuted)
+                        )
+                        .accessibilityIdentifier(AccessibilityID.Paywall.unlockButton)
+
+                        Button {
+                            Task { await purchaseManager.restore() }
+                        } label: {
+                            HStack(spacing: 6) {
+                                if purchaseManager.isRestoring {
+                                    ProgressView()
+                                        .controlSize(.mini)
+                                        .tint(Color.textMuted)
+                                }
+                                Text("Restore Purchase")
+                                    .font(.subheadline)
+                                    .foregroundStyle(Color.textMuted)
+                            }
                         }
+                        .buttonStyle(.plain)
+                        .disabled(purchaseManager.isPurchasing || purchaseManager.isRestoring)
+                        .accessibilityIdentifier(AccessibilityID.Paywall.restoreButton)
+                        .accessibilityLabel("Restore previous purchase")
                     }
-                    .buttonStyle(.plain)
-                    .disabled(purchaseManager.isPurchasing || purchaseManager.isRestoring)
-                    .accessibilityIdentifier(AccessibilityID.Paywall.restoreButton)
-                    .accessibilityLabel("Restore previous purchase")
+                    .padding(.horizontal, Spacing.lg)
+                    .padding(.bottom, Spacing.xl)
                 }
-                .padding(.horizontal, Spacing.lg)
-                .padding(.bottom, Spacing.xl)
+                .frame(maxWidth: .infinity)
             }
 
             // MARK: - Dismiss Button
@@ -126,7 +130,7 @@ struct PaywallView: View {
                 dismiss()
             } label: {
                 Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.caption2.weight(.bold))
                     .foregroundStyle(Color.textMuted)
                     .padding(8)
                     .background(
@@ -166,18 +170,20 @@ struct PaywallView: View {
 private struct PaywallFeatureRow: View {
     let icon: String
     let text: String
+    @ScaledMetric(relativeTo: .body) private var iconWidth: CGFloat = 28
 
     var body: some View {
         HStack(spacing: Spacing.sm) {
             Image(systemName: icon)
-                .font(.system(size: 15, weight: .medium))
+                .font(Typography.bodyEmphasis())
                 .foregroundStyle(Color.accent)
-                .frame(width: 28)
+                .frame(width: iconWidth)
                 .accessibilityHidden(true)
 
             Text(text)
                 .font(Typography.body())
                 .foregroundStyle(Color.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
 
             Spacer()
         }

--- a/HealthMd/iOS/Views/ScheduleSettingsView.swift
+++ b/HealthMd/iOS/Views/ScheduleSettingsView.swift
@@ -276,7 +276,7 @@ struct ScheduleSettingsView: View {
                 .font(.body.weight(.medium).monospaced())
                 .foregroundStyle(Color.textPrimary)
             Image(systemName: "chevron.up.chevron.down")
-                .font(.system(size: 10, weight: .semibold))
+                .font(.caption2.weight(.semibold))
                 .foregroundStyle(Color.accent)
                 .accessibilityHidden(true)
         }
@@ -499,7 +499,7 @@ struct RetryProgressOverlay: View {
                         .animation(.spring(response: 0.3), value: progress)
 
                     Image(systemName: "arrow.clockwise")
-                        .font(.system(size: 20, weight: .medium))
+                        .font(.title3.weight(.medium))
                         .foregroundStyle(Color.accent)
                 }
                 .accessibilityHidden(true)
@@ -571,7 +571,7 @@ struct ExportHistoryRow: View {
             // Status icon
             Image(systemName: statusIcon)
                 .foregroundStyle(statusColor)
-                .font(.system(size: 16))
+                .font(Typography.bodyEmphasis())
                 .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
@@ -583,7 +583,7 @@ struct ExportHistoryRow: View {
                 // Timestamp and source
                 HStack(spacing: Spacing.xs) {
                     Image(systemName: entry.source.icon)
-                        .font(.system(size: 10))
+                        .font(.caption2)
                     Text(formatTimestamp(entry.timestamp))
                         .font(Typography.caption())
                 }
@@ -593,7 +593,7 @@ struct ExportHistoryRow: View {
             Spacer()
 
             Image(systemName: "chevron.right")
-                .font(.system(size: 12, weight: .semibold))
+                .font(.caption.weight(.semibold))
                 .foregroundStyle(Color.textMuted)
                 .accessibilityHidden(true)
         }
@@ -728,7 +728,7 @@ struct ExportHistoryDetailView: View {
                             HStack {
                                 Text(detail.dateString)
                                     .foregroundStyle(Color.textPrimary)
-                                    .font(.system(.body, design: .monospaced))
+                                    .font(Typography.bodyMono())
                                 Spacer()
                                 Text(detail.reason.shortDescription)
                                     .font(Typography.caption())

--- a/HealthMd/iOS/Views/SyncSettingsView.swift
+++ b/HealthMd/iOS/Views/SyncSettingsView.swift
@@ -41,7 +41,7 @@ struct SyncSettingsView: View {
                     Link(destination: macAppURL) {
                         HStack(spacing: 14) {
                             Image(systemName: "desktopcomputer")
-                                .font(.system(size: 20, weight: .semibold))
+                                .font(.title3.weight(.semibold))
                                 .foregroundStyle(Color.accent)
                                 .frame(width: 34, height: 34)
                                 .accessibilityHidden(true)
@@ -60,7 +60,7 @@ struct SyncSettingsView: View {
                             Spacer()
 
                             Image(systemName: "arrow.up.right")
-                                .font(.system(size: 12, weight: .semibold))
+                                .font(.caption.weight(.semibold))
                                 .foregroundStyle(Color.accent)
                                 .accessibilityHidden(true)
                         }

--- a/HealthMd/iPad/iPadContentView.swift
+++ b/HealthMd/iPad/iPadContentView.swift
@@ -160,13 +160,13 @@ struct iPadContentView: View {
     private var brandPlaceholder: some View {
         VStack(spacing: 16) {
             Image(systemName: "heart.text.square")
-                .font(.system(size: 48))
+                .font(.largeTitle)
                 .foregroundStyle(Color.accent)
             Text("health.md")
-                .font(.system(size: 22, weight: .semibold, design: .monospaced))
+                .font(.title2.weight(.semibold).monospaced())
                 .foregroundStyle(Color.textPrimary)
             Text("Select a section from the sidebar")
-                .font(.system(size: 13, weight: .regular, design: .monospaced))
+                .font(Typography.mono())
                 .foregroundStyle(Color.textMuted)
         }
     }

--- a/HealthMd/iPad/iPadExportView.swift
+++ b/HealthMd/iPad/iPadExportView.swift
@@ -24,6 +24,11 @@ struct iPadExportView: View {
     @State private var showHealthPermissionsGuide = false
     @State private var showMetricSelection = false
     @State private var showPreview = false
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var stacksControlsVertically: Bool {
+        dynamicTypeSize.isAccessibilitySize
+    }
 
     var body: some View {
         ScrollView {
@@ -33,48 +38,24 @@ struct iPadExportView: View {
                 VStack(alignment: .leading, spacing: 14) {
                     iPadBrandLabel("Health Data")
 
-                    HStack(spacing: 12) {
-                        Circle()
-                            .fill(healthKitManager.isAuthorized ? Color.success : Color.textMuted)
-                            .frame(width: 10, height: 10)
-
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(healthKitManager.isAuthorized
-                                 ? "Apple Health Connected"
-                                 : "Not Connected")
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
-                                .foregroundStyle(Color.textPrimary)
-                            Text(healthKitManager.isAuthorized
-                                 ? "Ready to export health data"
-                                 : "Grant access to export health data")
-                                .font(.system(size: 12, weight: .regular, design: .monospaced))
-                                .foregroundStyle(Color.textMuted)
+                    if stacksControlsVertically {
+                        VStack(alignment: .leading, spacing: 12) {
+                            healthStatusText
+                            healthStatusButton
                         }
-
-                        Spacer()
-
-                        if !healthKitManager.isAuthorized {
-                            Button("Connect") {
-                                Task { try? await healthKitManager.requestAuthorization() }
+                    } else {
+                        ViewThatFits(in: .horizontal) {
+                            healthStatusRow
+                            VStack(alignment: .leading, spacing: 12) {
+                                healthStatusText
+                                healthStatusButton
                             }
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
-                            .buttonStyle(.bordered)
-                            .tint(Color.accent)
-                            .controlSize(.small)
-                        } else {
-                            Button("Permissions") {
-                                showHealthPermissionsGuide = true
-                            }
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
-                            .buttonStyle(.bordered)
-                            .tint(Color.accent)
-                            .controlSize(.small)
                         }
                     }
 
                     if !healthKitManager.isAuthorized {
                         Text("Connect Apple Health to start exporting your wellness data.")
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .font(Typography.monoCaption())
                             .foregroundStyle(Color.textMuted)
                     }
                 }
@@ -86,47 +67,29 @@ struct iPadExportView: View {
                 VStack(alignment: .leading, spacing: 14) {
                     iPadBrandLabel("Export Folder")
 
-                    HStack(spacing: 10) {
-                        if let url = vaultManager.vaultURL {
-                            Image(systemName: "folder.fill")
-                                .foregroundStyle(Color.accent)
-                                .font(.system(size: 16))
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(vaultManager.vaultName)
-                                    .font(.system(size: 13, weight: .medium, design: .monospaced))
-                                    .foregroundStyle(Color.textPrimary)
-                                Text(url.path(percentEncoded: false))
-                                    .font(.system(size: 11, weight: .regular, design: .monospaced))
-                                    .foregroundStyle(Color.textMuted)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
+                    if stacksControlsVertically {
+                        VStack(alignment: .leading, spacing: 12) {
+                            folderStatusText
+                            folderPickerButton
+                        }
+                    } else {
+                        ViewThatFits(in: .horizontal) {
+                            folderStatusRow
+                            VStack(alignment: .leading, spacing: 12) {
+                                folderStatusText
+                                folderPickerButton
                             }
-                        } else {
-                            Image(systemName: "folder")
-                                .foregroundStyle(Color.textMuted)
-                                .font(.system(size: 16))
-                            Text("No folder selected")
-                                .font(.system(size: 13, weight: .regular, design: .monospaced))
-                                .foregroundStyle(Color.textMuted)
                         }
-                        Spacer()
-                        Button(vaultManager.vaultURL != nil ? "Change…" : "Choose…") {
-                            showFolderPicker = true
-                        }
-                        .font(.system(size: 13, weight: .medium, design: .monospaced))
-                        .buttonStyle(.bordered)
-                        .tint(Color.accent)
-                        .controlSize(.small)
                     }
 
                     if vaultManager.vaultURL != nil {
                         HStack {
                             Text("Subfolder")
-                                .font(.system(size: 13, weight: .regular, design: .monospaced))
+                                .font(Typography.mono())
                                 .foregroundStyle(Color.textSecondary)
                             Spacer()
                             Text(vaultManager.healthSubfolder.isEmpty ? "Health" : vaultManager.healthSubfolder)
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .foregroundStyle(Color.textPrimary)
                         }
                     }
@@ -140,7 +103,7 @@ struct iPadExportView: View {
                     iPadBrandLabel("Date Range")
 
                     Toggle("Automatically use past days", isOn: $advancedSettings.useRollingDateRange)
-                        .font(.system(size: 13, weight: .regular, design: .monospaced))
+                        .font(Typography.mono())
                         .foregroundStyle(Color.textSecondary)
                         .tint(Color.accent)
                         .onChange(of: advancedSettings.useRollingDateRange) { _, isEnabled in
@@ -156,10 +119,10 @@ struct iPadExportView: View {
                         ) {
                             VStack(alignment: .leading, spacing: 2) {
                                 Text("Past \(advancedSettings.rollingDateRangeDays) day\(advancedSettings.rollingDateRangeDays == 1 ? "" : "s")")
-                                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                    .font(Typography.monoEmphasis())
                                     .foregroundStyle(Color.textPrimary)
                                 Text("Includes today and updates before export.")
-                                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                    .font(Typography.monoCaption())
                                     .foregroundStyle(Color.textMuted)
                             }
                         }
@@ -170,7 +133,7 @@ struct iPadExportView: View {
 
                     HStack {
                         Text("From")
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                            .font(Typography.mono())
                             .foregroundStyle(Color.textSecondary)
                         Spacer()
                         DatePicker("", selection: $startDate, displayedComponents: .date)
@@ -181,7 +144,7 @@ struct iPadExportView: View {
 
                     HStack {
                         Text("To")
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                            .font(Typography.mono())
                             .foregroundStyle(Color.textSecondary)
                         Spacer()
                         DatePicker("", selection: $endDate, displayedComponents: .date)
@@ -218,7 +181,7 @@ struct iPadExportView: View {
 
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Formats")
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                            .font(Typography.mono())
                             .foregroundStyle(Color.textSecondary)
                         ForEach(ExportFormat.allCases, id: \.self) { format in
                             Toggle(format.rawValue, isOn: Binding(
@@ -232,43 +195,43 @@ struct iPadExportView: View {
                         }
                         if advancedSettings.exportFormats.isEmpty {
                             Text("Select at least one export format.")
-                                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                .font(Typography.monoCaption())
                                 .foregroundStyle(Color.red)
                         }
                     }
 
-                    HStack {
-                        Text("Write Mode")
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
-                            .foregroundStyle(Color.textSecondary)
-                        Spacer()
-                        Picker("", selection: $advancedSettings.writeMode) {
-                            ForEach(WriteMode.allCases, id: \.self) { mode in
-                                Text(mode.rawValue).tag(mode)
+                    if stacksControlsVertically {
+                        VStack(alignment: .leading, spacing: 8) {
+                            writeModeLabel
+                            writeModePicker
+                        }
+                    } else {
+                        ViewThatFits(in: .horizontal) {
+                            HStack {
+                                writeModeLabel
+                                Spacer()
+                                writeModePicker
+                            }
+                            VStack(alignment: .leading, spacing: 8) {
+                                writeModeLabel
+                                writeModePicker
                             }
                         }
-                        .pickerStyle(.menu)
-                        .tint(Color.accent)
-                        .frame(width: 180)
                     }
 
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Health Metrics")
-                                .font(.system(size: 13, weight: .regular, design: .monospaced))
-                                .foregroundStyle(Color.textSecondary)
-                            Text("\(advancedSettings.metricSelection.totalEnabledCount) of \(advancedSettings.metricSelection.totalMetricCount) enabled")
-                                .font(.system(size: 11, weight: .regular, design: .monospaced))
-                                .foregroundStyle(Color.textMuted)
+                    if stacksControlsVertically {
+                        VStack(alignment: .leading, spacing: 12) {
+                            metricsSummary
+                            metricsConfigureButton
                         }
-                        Spacer()
-                        Button("Configure…") {
-                            showMetricSelection = true
+                    } else {
+                        ViewThatFits(in: .horizontal) {
+                            metricsConfigurationRow
+                            VStack(alignment: .leading, spacing: 12) {
+                                metricsSummary
+                                metricsConfigureButton
+                            }
                         }
-                        .font(.system(size: 13, weight: .medium, design: .monospaced))
-                        .buttonStyle(.bordered)
-                        .tint(Color.accent)
-                        .controlSize(.small)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -286,9 +249,9 @@ struct iPadExportView: View {
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: "stop.fill")
-                                        .font(.system(size: 10, weight: .semibold))
+                                        .font(.caption2.weight(.semibold))
                                     Text("Stop")
-                                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                                        .font(Typography.monoLabel())
                                 }
                                 .foregroundStyle(Color.red)
                                 .padding(.horizontal, 10)
@@ -309,7 +272,7 @@ struct iPadExportView: View {
                             ProgressView()
                                 .controlSize(.small)
                             Text(exportStatusMessage)
-                                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                                .font(Typography.monoCaption())
                                 .foregroundStyle(Color.textSecondary)
                         }
                         ProgressView(value: exportProgress)
@@ -326,7 +289,7 @@ struct iPadExportView: View {
                         Image(systemName: "info.circle")
                             .foregroundStyle(Color.textMuted)
                         Text(readinessMessage)
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                            .font(Typography.mono())
                             .foregroundStyle(Color.textMuted)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -342,10 +305,11 @@ struct iPadExportView: View {
                 Button {
                     showPreview = true
                 } label: {
-                    HStack(spacing: 6) {
+                    if stacksControlsVertically {
                         Image(systemName: "eye")
-                        Text("Preview")
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    } else {
+                        Label("Preview", systemImage: "eye")
+                            .font(Typography.monoLabel())
                     }
                 }
                 .disabled(!canPreview || isExporting)
@@ -357,10 +321,11 @@ struct iPadExportView: View {
                 Button {
                     onExportTapped?()
                 } label: {
-                    HStack(spacing: 6) {
+                    if stacksControlsVertically {
                         Image(systemName: purchaseManager.canExport ? "arrow.up.doc.fill" : "lock.fill")
-                        Text(purchaseManager.canExport ? "Review Export" : "Unlock to Export")
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    } else {
+                        Label(purchaseManager.canExport ? "Review Export" : "Unlock to Export", systemImage: purchaseManager.canExport ? "arrow.up.doc.fill" : "lock.fill")
+                            .font(Typography.monoLabel())
                     }
                 }
                 .disabled(!canExport || isExporting)
@@ -398,6 +363,143 @@ struct iPadExportView: View {
         }
     }
 
+    private var healthStatusRow: some View {
+        HStack(spacing: 12) {
+            healthStatusText
+            Spacer()
+            healthStatusButton
+        }
+    }
+
+    private var healthStatusText: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(healthKitManager.isAuthorized ? Color.success : Color.textMuted)
+                .frame(width: 10, height: 10)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(healthKitManager.isAuthorized ? "Apple Health Connected" : "Not Connected")
+                    .font(Typography.monoEmphasis())
+                    .foregroundStyle(Color.textPrimary)
+                Text(healthKitManager.isAuthorized ? "Ready to export health data" : "Grant access to export health data")
+                    .font(Typography.monoCaption())
+                    .foregroundStyle(Color.textMuted)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var healthStatusButton: some View {
+        if !healthKitManager.isAuthorized {
+            Button("Connect") {
+                Task { try? await healthKitManager.requestAuthorization() }
+            }
+            .font(Typography.monoEmphasis())
+            .buttonStyle(.bordered)
+            .tint(Color.accent)
+            .controlSize(.small)
+        } else {
+            Button("Permissions") {
+                showHealthPermissionsGuide = true
+            }
+            .font(Typography.monoEmphasis())
+            .buttonStyle(.bordered)
+            .tint(Color.accent)
+            .controlSize(.small)
+        }
+    }
+
+    private var folderStatusRow: some View {
+        HStack(spacing: 10) {
+            folderStatusText
+            Spacer()
+            folderPickerButton
+        }
+    }
+
+    private var folderStatusText: some View {
+        HStack(spacing: 10) {
+            if let url = vaultManager.vaultURL {
+                Image(systemName: "folder.fill")
+                    .foregroundStyle(Color.accent)
+                    .font(.body)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(vaultManager.vaultName)
+                        .font(Typography.monoEmphasis())
+                        .foregroundStyle(Color.textPrimary)
+                    Text(url.path(percentEncoded: false))
+                        .font(Typography.monoCaption())
+                        .foregroundStyle(Color.textMuted)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+            } else {
+                Image(systemName: "folder")
+                    .foregroundStyle(Color.textMuted)
+                    .font(.body)
+                Text("No folder selected")
+                    .font(Typography.mono())
+                    .foregroundStyle(Color.textMuted)
+            }
+        }
+    }
+
+    private var folderPickerButton: some View {
+        Button(vaultManager.vaultURL != nil ? "Change…" : "Choose…") {
+            showFolderPicker = true
+        }
+        .font(Typography.monoEmphasis())
+        .buttonStyle(.bordered)
+        .tint(Color.accent)
+        .controlSize(.small)
+    }
+
+    private var writeModeLabel: some View {
+        Text("Write Mode")
+            .font(Typography.mono())
+            .foregroundStyle(Color.textSecondary)
+    }
+
+    private var writeModePicker: some View {
+        Picker("", selection: $advancedSettings.writeMode) {
+            ForEach(WriteMode.allCases, id: \.self) { mode in
+                Text(mode.rawValue).tag(mode)
+            }
+        }
+        .pickerStyle(.menu)
+        .tint(Color.accent)
+        .frame(minWidth: 180, maxWidth: 260, alignment: .trailing)
+    }
+
+    private var metricsConfigurationRow: some View {
+        HStack {
+            metricsSummary
+            Spacer()
+            metricsConfigureButton
+        }
+    }
+
+    private var metricsSummary: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Health Metrics")
+                .font(Typography.mono())
+                .foregroundStyle(Color.textSecondary)
+            Text("\(advancedSettings.metricSelection.totalEnabledCount) of \(advancedSettings.metricSelection.totalMetricCount) enabled")
+                .font(Typography.monoCaption())
+                .foregroundStyle(Color.textMuted)
+        }
+    }
+
+    private var metricsConfigureButton: some View {
+        Button("Configure…") {
+            showMetricSelection = true
+        }
+        .font(Typography.monoEmphasis())
+        .buttonStyle(.bordered)
+        .tint(Color.accent)
+        .controlSize(.small)
+    }
+
     // MARK: - Helpers
 
     private var readinessMessage: String {
@@ -430,7 +532,7 @@ struct iPadExportView: View {
     private func quickDateButton(_ label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             Text(label)
-                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                .font(Typography.monoCaption())
                 .padding(.horizontal, 12)
                 .padding(.vertical, 5)
         }
@@ -453,9 +555,12 @@ struct iPadExportView: View {
 struct iPadMetricSelectionView: View {
     @ObservedObject var selectionState: MetricSelectionState
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ScaledMetric(relativeTo: .body) private var headerProgressWidth: CGFloat = 100
     @State private var searchText = ""
     @State private var expandedCategories: Set<HealthMetricCategory> = []
     @State private var showPendingApprovalAlert = false
+    private var usesVerticalHeader: Bool { dynamicTypeSize.isAccessibilitySize }
 
     private var enabledCategoryCount: Int {
         HealthMetricCategory.allCases.filter { selectionState.isCategoryFullyEnabled($0) }.count
@@ -484,17 +589,30 @@ struct iPadMetricSelectionView: View {
         NavigationStack {
             VStack(spacing: 0) {
                 // Header
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        iPadBrandLabel("Health Metrics")
-                        Text("\(selectionState.totalEnabledCount) of \(selectionState.totalMetricCount) metrics enabled · \(enabledCategoryCount) of \(availableCategoryCount) categories")
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
-                            .foregroundStyle(Color.textMuted)
+                Group {
+                    if usesVerticalHeader {
+                        VStack(alignment: .leading, spacing: 8) {
+                            metricSelectionHeaderText
+                            ProgressView(value: Double(selectionState.totalEnabledCount), total: Double(selectionState.totalMetricCount))
+                                .tint(Color.accent)
+                        }
+                    } else {
+                        ViewThatFits(in: .horizontal) {
+                            HStack {
+                                metricSelectionHeaderText
+                                Spacer()
+                                ProgressView(value: Double(selectionState.totalEnabledCount), total: Double(selectionState.totalMetricCount))
+                                    .frame(width: headerProgressWidth)
+                                    .tint(Color.accent)
+                            }
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                metricSelectionHeaderText
+                                ProgressView(value: Double(selectionState.totalEnabledCount), total: Double(selectionState.totalMetricCount))
+                                    .tint(Color.accent)
+                            }
+                        }
                     }
-                    Spacer()
-                    ProgressView(value: Double(selectionState.totalEnabledCount), total: Double(selectionState.totalMetricCount))
-                        .frame(width: 100)
-                        .tint(Color.accent)
                 }
                 .padding()
 
@@ -537,6 +655,16 @@ struct iPadMetricSelectionView: View {
         }
     }
 
+    private var metricSelectionHeaderText: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            iPadBrandLabel("Health Metrics")
+            Text("\(selectionState.totalEnabledCount) of \(selectionState.totalMetricCount) metrics enabled · \(enabledCategoryCount) of \(availableCategoryCount) categories")
+                .font(Typography.monoCaption())
+                .foregroundStyle(Color.textMuted)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
     @ViewBuilder
     private func categorySection(for category: HealthMetricCategory) -> some View {
         if category.isPendingAppleApproval {
@@ -558,10 +686,10 @@ struct iPadMetricSelectionView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(category.rawValue)
-                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                        .font(Typography.monoEmphasis())
                         .foregroundStyle(Color.textPrimary)
                     Text("Pending Apple permission")
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .font(Typography.monoCaption())
                         .foregroundStyle(Color.textMuted)
                 }
 
@@ -594,10 +722,10 @@ struct iPadMetricSelectionView: View {
                 )) {
                     HStack {
                         Text(metric.name)
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                            .font(Typography.mono())
                         if !metric.unit.isEmpty {
                             Text("(\(metric.unit))")
-                                .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                .font(Typography.monoCaption())
                                 .foregroundStyle(Color.textMuted)
                         }
                     }
@@ -612,12 +740,12 @@ struct iPadMetricSelectionView: View {
                     .frame(width: 20)
 
                 Text(category.rawValue)
-                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .font(Typography.monoEmphasis())
 
                 Spacer()
 
                 Text("\(selectionState.enabledMetricCount(for: category))/\(selectionState.totalMetricCount(for: category))")
-                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .font(Typography.monoEmphasis())
                     .foregroundStyle(Color.textMuted)
 
                 Button {

--- a/HealthMd/iPad/iPadHistoryView.swift
+++ b/HealthMd/iPad/iPadHistoryView.swift
@@ -35,13 +35,13 @@ struct iPadHistoryView: View {
             if historyManager.history.isEmpty {
                 VStack(spacing: 16) {
                     Image(systemName: "list.bullet.clipboard")
-                        .font(.system(size: 40))
+                        .font(.largeTitle)
                         .foregroundStyle(Color.textMuted)
                     Text("No Export History")
-                        .font(.system(size: 15, weight: .medium, design: .monospaced))
+                        .font(Typography.monoEmphasis())
                         .foregroundStyle(Color.textPrimary)
                     Text("Export history will appear here after your first export.")
-                        .font(.system(size: 13, weight: .regular, design: .monospaced))
+                        .font(Typography.mono())
                         .foregroundStyle(Color.textMuted)
                 }
             } else {
@@ -81,13 +81,13 @@ struct iPadHistoryView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(entry.summaryDescription)
-                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                        .font(Typography.monoEmphasis())
                         .foregroundStyle(Color.textPrimary)
-                        .lineLimit(1)
+                        .lineLimit(2)
 
                     HStack(spacing: 8) {
                         Text(Self.dateFormatter.string(from: entry.timestamp))
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .font(Typography.monoCaption())
                             .foregroundStyle(Color.textMuted)
 
                         sourceBadge(for: entry)
@@ -97,7 +97,7 @@ struct iPadHistoryView: View {
                 Spacer()
 
                 Text("\(entry.successCount)/\(entry.totalCount)")
-                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .font(Typography.monoEmphasis())
                     .foregroundStyle(Color.textMuted)
             }
             .padding(.vertical, 2)
@@ -116,7 +116,7 @@ struct iPadHistoryView: View {
                     HStack(spacing: 8) {
                         statusIcon(for: entry)
                         Text(entry.isFullSuccess ? "Success" : entry.success ? "Partial" : "Failed")
-                            .font(.system(size: 22, weight: .semibold, design: .monospaced))
+                            .font(.title2.weight(.semibold).monospaced())
                             .foregroundStyle(Color.textPrimary)
                     }
                     .padding(16)
@@ -140,7 +140,7 @@ struct iPadHistoryView: View {
                         VStack(alignment: .leading, spacing: 8) {
                             iPadBrandLabel("Failure Reason")
                             Text(reason.detailedDescription)
-                                .font(.system(size: 13, weight: .regular, design: .monospaced))
+                                .font(Typography.mono())
                                 .foregroundStyle(Color.textSecondary)
                         }
                         .padding(16)
@@ -157,10 +157,10 @@ struct iPadHistoryView: View {
                                         .foregroundStyle(Color.error)
                                         .font(.caption)
                                     Text(detail.dateString)
-                                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                        .font(Typography.monoEmphasis())
                                         .foregroundStyle(Color.textPrimary)
                                     Text("— \(detail.reason.shortDescription)")
-                                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                        .font(Typography.monoCaption())
                                         .foregroundStyle(Color.textMuted)
                                 }
                             }
@@ -177,10 +177,10 @@ struct iPadHistoryView: View {
         } else {
             VStack(spacing: 12) {
                 Image(systemName: "doc.text.magnifyingglass")
-                    .font(.system(size: 32))
+                    .font(.largeTitle)
                     .foregroundStyle(Color.textMuted)
                 Text("Select an export to see details")
-                    .font(.system(size: 13, weight: .regular, design: .monospaced))
+                    .font(Typography.mono())
                     .foregroundStyle(Color.textMuted)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -200,7 +200,7 @@ struct iPadHistoryView: View {
     @ViewBuilder
     private func sourceBadge(for entry: ExportHistoryEntry) -> some View {
         Text(entry.source.rawValue)
-            .font(.system(size: 11, weight: .regular, design: .monospaced))
+            .font(Typography.monoCaption())
             .foregroundStyle(Color.textMuted)
             .padding(.horizontal, 8)
             .padding(.vertical, 2)

--- a/HealthMd/iPad/iPadScheduleView.swift
+++ b/HealthMd/iPad/iPadScheduleView.swift
@@ -23,7 +23,7 @@ struct iPadScheduleView: View {
                 iPadBrandLabel("Automation")
             } footer: {
                 Text("Health.md will automatically export your health data on the schedule below.")
-                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .font(Typography.monoCaption())
                     .foregroundStyle(Color.textMuted)
             }
 
@@ -70,7 +70,7 @@ struct iPadScheduleView: View {
                 // MARK: Background
                 Section {
                     Text("iOS determines the optimal background task timing. Make sure background refresh is enabled for Health.md in Settings.")
-                        .font(.system(size: 13, weight: .regular, design: .monospaced))
+                        .font(Typography.mono())
                         .foregroundStyle(Color.textSecondary)
                 } header: {
                     iPadBrandLabel("Background")
@@ -85,14 +85,14 @@ struct iPadScheduleView: View {
                                     .foregroundStyle(Color.success)
                                     .font(.caption)
                                 Text(lastExport, style: .relative)
-                                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                    .font(Typography.monoEmphasis())
                                     .foregroundStyle(Color.textSecondary)
                             }
                         }
                     } else {
                         LabeledContent("Last Export") {
                             Text("Never")
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .foregroundStyle(Color.textMuted)
                         }
                     }
@@ -100,7 +100,7 @@ struct iPadScheduleView: View {
                     if let next = schedulingManager.getNextExportDescription() {
                         LabeledContent("Next Export") {
                             Text(next)
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .foregroundStyle(Color.textSecondary)
                         }
                     }

--- a/HealthMd/iPad/iPadSettingsView.swift
+++ b/HealthMd/iPad/iPadSettingsView.swift
@@ -7,46 +7,42 @@ struct iPadSettingsView: View {
     @ObservedObject var vaultManager: VaultManager
     @ObservedObject var advancedSettings: AdvancedExportSettings
     @Binding var showFolderPicker: Bool
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ScaledMetric(relativeTo: .body) private var metricProgressWidth: CGFloat = 100
     @State private var showMetricSelection = false
     @State private var showMailCompose = false
     private let discordURL = URL(string: "https://discord.gg/RaQYS4t6gn")!
+    private var usesVerticalControlRows: Bool { dynamicTypeSize.isAccessibilitySize }
 
     var body: some View {
         Form {
             // MARK: Export Folder
             Section {
-                HStack {
-                    if let url = vaultManager.vaultURL {
-                        Image(systemName: "folder.fill")
-                            .foregroundStyle(Color.accent)
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(vaultManager.vaultName)
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
-                            Text(url.path(percentEncoded: false))
-                                .font(.system(size: 11, weight: .regular, design: .monospaced))
-                                .foregroundStyle(Color.textMuted)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
+                if usesVerticalControlRows {
+                    VStack(alignment: .leading, spacing: 12) {
+                        folderStatus
+                        folderPickerButton
+                    }
+                } else {
+                    ViewThatFits(in: .horizontal) {
+                        HStack {
+                            folderStatus
+                            Spacer()
+                            folderPickerButton
                         }
-                    } else {
-                        Image(systemName: "folder")
-                            .foregroundStyle(Color.textMuted)
-                        Text("No folder selected")
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
-                            .foregroundStyle(Color.textMuted)
+
+                        VStack(alignment: .leading, spacing: 12) {
+                            folderStatus
+                            folderPickerButton
+                        }
                     }
-                    Spacer()
-                    Button(vaultManager.vaultURL != nil ? "Change…" : "Choose…") {
-                        showFolderPicker = true
-                    }
-                    .tint(Color.accent)
                 }
 
                 if vaultManager.vaultURL != nil {
                     LabeledContent("Subfolder") {
                         TextField("Health", text: $vaultManager.healthSubfolder)
-                            .font(.system(size: 13, design: .monospaced))
-                            .frame(width: 200)
+                            .font(Typography.mono())
+                            .frame(minWidth: 160, maxWidth: 280, alignment: .trailing)
                             .multilineTextAlignment(.trailing)
                             .onChange(of: vaultManager.healthSubfolder) {
                                 vaultManager.saveSubfolderSetting()
@@ -101,20 +97,20 @@ struct iPadSettingsView: View {
             Section {
                 LabeledContent("Filename Pattern") {
                     TextField("{date}", text: $advancedSettings.filenameFormat)
-                        .font(.system(size: 13, design: .monospaced))
-                        .frame(width: 200)
+                        .font(Typography.mono())
+                        .frame(minWidth: 160, maxWidth: 280, alignment: .trailing)
                         .multilineTextAlignment(.trailing)
                 }
 
                 LabeledContent("Folder Structure") {
                     TextField("e.g. {year}/{month}", text: $advancedSettings.folderStructure)
-                        .font(.system(size: 13, design: .monospaced))
-                        .frame(width: 200)
+                        .font(Typography.mono())
+                        .frame(minWidth: 160, maxWidth: 280, alignment: .trailing)
                         .multilineTextAlignment(.trailing)
                 }
 
                 Text("Placeholders: {date}, {year}, {month}, {day}, {weekday}, {monthName}, {quarter}")
-                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .font(Typography.monoCaption())
                     .foregroundStyle(Color.textMuted)
 
                 LabeledContent("Preview") {
@@ -122,11 +118,11 @@ struct iPadSettingsView: View {
                     let ext = advancedSettings.primaryFormat.fileExtension
                     if let folder = advancedSettings.formatFolderPath(for: Date()) {
                         Text("\(folder)/\(filename).\(ext)")
-                            .font(.system(size: 12, weight: .regular, design: .monospaced))
+                            .font(Typography.monoCaption())
                             .foregroundStyle(Color.accent)
                     } else {
                         Text("\(filename).\(ext)")
-                            .font(.system(size: 12, weight: .regular, design: .monospaced))
+                            .font(Typography.monoCaption())
                             .foregroundStyle(Color.accent)
                     }
                 }
@@ -200,31 +196,41 @@ struct iPadSettingsView: View {
                 iPadBrandLabel("Placeholder Fields")
             } footer: {
                 Text("Add fields that export with empty values for manual entry (e.g., omron_systolic, omron_diastolic)")
-                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .font(Typography.monoCaption())
                     .foregroundStyle(Color.textMuted)
             }
 
             // MARK: Health Metrics
             Section {
-                HStack {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Selected Metrics")
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
-                        Text("\(advancedSettings.metricSelection.totalEnabledCount) of \(advancedSettings.metricSelection.totalMetricCount) enabled")
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
-                            .foregroundStyle(Color.textMuted)
+                if usesVerticalControlRows {
+                    VStack(alignment: .leading, spacing: 12) {
+                        metricsSummary
+                        ProgressView(
+                            value: Double(advancedSettings.metricSelection.totalEnabledCount),
+                            total: Double(advancedSettings.metricSelection.totalMetricCount)
+                        )
+                        .tint(Color.accent)
+                        metricsConfigureButton
                     }
-                    Spacer()
-                    ProgressView(
-                        value: Double(advancedSettings.metricSelection.totalEnabledCount),
-                        total: Double(advancedSettings.metricSelection.totalMetricCount)
-                    )
-                    .frame(width: 100)
-                    .tint(Color.accent)
-                    Button("Configure…") {
-                        showMetricSelection = true
+                } else {
+                    ViewThatFits(in: .horizontal) {
+                        HStack {
+                            metricsSummary
+                            Spacer()
+                            ProgressView(
+                                value: Double(advancedSettings.metricSelection.totalEnabledCount),
+                                total: Double(advancedSettings.metricSelection.totalMetricCount)
+                            )
+                            .frame(width: metricProgressWidth)
+                            .tint(Color.accent)
+                            metricsConfigureButton
+                        }
+
+                        VStack(alignment: .leading, spacing: 12) {
+                            metricsSummary
+                            metricsConfigureButton
+                        }
                     }
-                    .tint(Color.accent)
                 }
 
                 ForEach(HealthMetricCategory.allCases, id: \.self) { category in
@@ -236,16 +242,16 @@ struct iPadSettingsView: View {
                         Spacer()
                         if category.isPendingAppleApproval {
                             Image(systemName: "lock.fill")
-                                .font(.system(size: 11))
+                                .font(.caption2)
                                 .foregroundStyle(Color.textMuted)
                             Text("Pending")
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .foregroundStyle(Color.textMuted)
                         } else {
                             let enabled = advancedSettings.metricSelection.enabledMetricCount(for: category)
                             let total = advancedSettings.metricSelection.totalMetricCount(for: category)
                             Text("\(enabled)/\(total)")
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .foregroundStyle(Color.textMuted)
                         }
                     }
@@ -262,8 +268,8 @@ struct iPadSettingsView: View {
                 if advancedSettings.individualTracking.globalEnabled {
                     LabeledContent("Entries Folder") {
                         TextField("entries", text: $advancedSettings.individualTracking.entriesFolder)
-                            .font(.system(size: 13, design: .monospaced))
-                            .frame(width: 200)
+                            .font(Typography.mono())
+                            .frame(minWidth: 160, maxWidth: 280, alignment: .trailing)
                             .multilineTextAlignment(.trailing)
                     }
 
@@ -272,7 +278,7 @@ struct iPadSettingsView: View {
 
                     LabeledContent("Tracked Metrics") {
                         Text("\(advancedSettings.individualTracking.totalEnabledCount)")
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
+                            .font(Typography.monoEmphasis())
                             .foregroundStyle(Color.accent)
                     }
                 }
@@ -281,11 +287,11 @@ struct iPadSettingsView: View {
             } footer: {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Create individual timestamped files for selected metrics in addition to daily summaries.")
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .font(Typography.monoCaption())
                         .foregroundStyle(Color.textMuted)
                     if advancedSettings.individualTracking.globalEnabled && advancedSettings.individualTracking.totalEnabledCount == 0 {
                         Text("⚠️ No metrics selected — individual entries won't be created until you select metrics to track.")
-                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .font(Typography.monoCaptionEmphasis())
                             .foregroundStyle(Color.orange)
                     }
                 }
@@ -312,7 +318,7 @@ struct iPadSettingsView: View {
                 iPadBrandLabel("Community")
             } footer: {
                 Text("Chat with other Health.md users, share feedback, and get help.")
-                    .font(.system(size: 11, weight: .regular, design: .monospaced))
+                    .font(Typography.monoCaption())
                     .foregroundStyle(Color.textMuted)
             }
 
@@ -374,6 +380,54 @@ struct iPadSettingsView: View {
             MailComposeView()
         }
     }
+
+    private var folderStatus: some View {
+        HStack(spacing: 8) {
+            if let url = vaultManager.vaultURL {
+                Image(systemName: "folder.fill")
+                    .foregroundStyle(Color.accent)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(vaultManager.vaultName)
+                        .font(Typography.monoEmphasis())
+                    Text(url.path(percentEncoded: false))
+                        .font(Typography.monoCaption())
+                        .foregroundStyle(Color.textMuted)
+                        .lineLimit(2)
+                        .truncationMode(.middle)
+                }
+            } else {
+                Image(systemName: "folder")
+                    .foregroundStyle(Color.textMuted)
+                Text("No folder selected")
+                    .font(Typography.mono())
+                    .foregroundStyle(Color.textMuted)
+            }
+        }
+    }
+
+    private var folderPickerButton: some View {
+        Button(vaultManager.vaultURL != nil ? "Change…" : "Choose…") {
+            showFolderPicker = true
+        }
+        .tint(Color.accent)
+    }
+
+    private var metricsSummary: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text("Selected Metrics")
+                .font(Typography.monoEmphasis())
+            Text("\(advancedSettings.metricSelection.totalEnabledCount) of \(advancedSettings.metricSelection.totalMetricCount) enabled")
+                .font(Typography.monoCaption())
+                .foregroundStyle(Color.textMuted)
+        }
+    }
+
+    private var metricsConfigureButton: some View {
+        Button("Configure…") {
+            showMetricSelection = true
+        }
+        .tint(Color.accent)
+    }
 }
 
 // MARK: - Placeholder Fields View for iPad
@@ -388,10 +442,10 @@ struct iPadPlaceholderFieldsView: View {
             ForEach(config.placeholderFields.sorted(), id: \.self) { key in
                 HStack {
                     Text(key)
-                        .font(.system(size: 13, weight: .regular, design: .monospaced))
+                        .font(Typography.mono())
                     Spacer()
                     Text("(empty)")
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .font(Typography.monoCaption())
                         .foregroundStyle(Color.textMuted)
                     Button {
                         config.placeholderFields.removeAll { $0 == key }
@@ -406,7 +460,7 @@ struct iPadPlaceholderFieldsView: View {
             // Add new placeholder field
             HStack {
                 TextField("Field name (e.g., omron_systolic)", text: $newPlaceholderKey)
-                    .font(.system(size: 13, design: .monospaced))
+                    .font(Typography.mono())
                     .textFieldStyle(.roundedBorder)
                 
                 Button("Add") {

--- a/HealthMd/iPad/iPadSidebar.swift
+++ b/HealthMd/iPad/iPadSidebar.swift
@@ -27,6 +27,11 @@ enum iPadNavItem: String, CaseIterable, Identifiable {
 struct iPadSidebar: View {
     @Binding var selectedTab: iPadNavItem?
     @EnvironmentObject var syncService: SyncService
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private var usesCompactLabels: Bool {
+        dynamicTypeSize.isAccessibilitySize
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -37,9 +42,11 @@ struct iPadSidebar: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 24, height: 24)
                     .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
-                Text("health.md")
-                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(Color.textPrimary)
+                if !usesCompactLabels {
+                    Text("health.md")
+                        .font(.headline.weight(.semibold).monospaced())
+                        .foregroundStyle(Color.textPrimary)
+                }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 16)
@@ -49,14 +56,23 @@ struct iPadSidebar: View {
             // Sidebar navigation
             List(selection: $selectedTab) {
                 ForEach(iPadNavItem.allCases) { item in
-                    Label {
-                        Text(item.rawValue)
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
-                    } icon: {
+                    if usesCompactLabels {
                         Image(systemName: item.icon)
                             .foregroundStyle(Color.accent)
+                            .font(.title2)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .accessibilityLabel(item.rawValue)
+                            .tag(item)
+                    } else {
+                        Label {
+                            Text(item.rawValue)
+                                .font(Typography.monoEmphasis())
+                        } icon: {
+                            Image(systemName: item.icon)
+                                .foregroundStyle(Color.accent)
+                        }
+                        .tag(item)
                     }
-                    .tag(item)
                 }
             }
             .listStyle(.sidebar)
@@ -69,9 +85,11 @@ struct iPadSidebar: View {
                 Circle()
                     .fill(syncService.connectionState == .connected ? Color.success : Color.textMuted)
                     .frame(width: 6, height: 6)
-                Text(sidebarStatusLabel)
-                    .font(.system(size: 11, weight: .regular, design: .monospaced))
-                    .foregroundStyle(Color.textMuted)
+                if !usesCompactLabels {
+                    Text(sidebarStatusLabel)
+                        .font(Typography.monoCaption())
+                        .foregroundStyle(Color.textMuted)
+                }
                 Spacer()
             }
             .padding(.horizontal, 16)

--- a/HealthMd/iPad/iPadSyncView.swift
+++ b/HealthMd/iPad/iPadSyncView.swift
@@ -29,12 +29,12 @@ struct iPadSyncView: View {
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(healthKitManager.isAuthorized ? "Connected" : "Not Connected")
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .foregroundStyle(Color.textPrimary)
                             Text(healthKitManager.isAuthorized
                                  ? "Health data is accessible"
                                  : "Grant access to export health data")
-                                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                                .font(Typography.monoCaption())
                                 .foregroundStyle(Color.textMuted)
                         }
 
@@ -44,14 +44,14 @@ struct iPadSyncView: View {
                             Button("Permissions") {
                                 showHealthPermissionsGuide = true
                             }
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
+                            .font(Typography.monoEmphasis())
                             .tint(Color.accent)
                             .controlSize(.small)
                         } else {
                             Button("Connect") {
                                 Task { try? await healthKitManager.requestAuthorization() }
                             }
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
+                            .font(Typography.monoEmphasis())
                             .buttonStyle(.bordered)
                             .tint(Color.accent)
                             .controlSize(.small)
@@ -59,7 +59,7 @@ struct iPadSyncView: View {
                     }
 
                     Text("Health.md reads your Apple Health data locally on this device.")
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .font(Typography.monoCaption())
                         .foregroundStyle(Color.textMuted)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -77,12 +77,12 @@ struct iPadSyncView: View {
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(syncEnabled ? "Enabled" : "Disabled")
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .foregroundStyle(Color.textPrimary)
                             Text(syncEnabled
                                  ? "This iPad is discoverable by Health.md on Mac"
                                  : "Enable to let your Mac sync health data from this iPad")
-                                .font(.system(size: 12, weight: .regular, design: .monospaced))
+                                .font(Typography.monoCaption())
                                 .foregroundStyle(Color.textMuted)
                         }
 
@@ -102,7 +102,7 @@ struct iPadSyncView: View {
                     }
 
                     Text("When enabled, your Mac can discover this iPad and request health data over your local network.")
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .font(Typography.monoCaption())
                         .foregroundStyle(Color.textMuted)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -118,21 +118,21 @@ struct iPadSyncView: View {
                             HStack(spacing: 12) {
                                 Image(systemName: "desktopcomputer")
                                     .foregroundStyle(Color.accent)
-                                    .font(.system(size: 20, weight: .semibold))
+                                    .font(.title3.weight(.semibold))
 
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text("macOS on App Store")
-                                        .font(.system(size: 18, weight: .semibold, design: .monospaced))
+                                        .font(.headline.weight(.semibold).monospaced())
                                         .foregroundStyle(Color.textPrimary)
                                     Text("Use Health.md on your desktop")
-                                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                        .font(Typography.monoCaption())
                                         .foregroundStyle(Color.textMuted)
                                 }
 
                                 Spacer()
 
                                 Image(systemName: "arrow.up.right")
-                                    .font(.system(size: 12, weight: .semibold))
+                                    .font(.caption.weight(.semibold))
                                     .foregroundStyle(Color.accent)
                             }
                         }
@@ -160,10 +160,10 @@ struct iPadSyncView: View {
 
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(connectionTitle)
-                                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                    .font(Typography.monoEmphasis())
                                     .foregroundStyle(Color.textPrimary)
                                 Text(connectionSubtitle)
-                                    .font(.system(size: 12, weight: .regular, design: .monospaced))
+                                    .font(Typography.monoCaption())
                                     .foregroundStyle(Color.textMuted)
                             }
 
@@ -173,7 +173,7 @@ struct iPadSyncView: View {
                                 Button("Disconnect") {
                                     syncService.disconnect()
                                 }
-                                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                .font(Typography.monoEmphasis())
                                 .buttonStyle(.bordered)
                                 .tint(Color.accent)
                                 .controlSize(.small)
@@ -187,10 +187,10 @@ struct iPadSyncView: View {
                             Toggle(isOn: $autoSyncAfterExport) {
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text("Auto-sync after export")
-                                        .font(.system(size: 13, weight: .medium, design: .monospaced))
+                                        .font(Typography.monoEmphasis())
                                         .foregroundStyle(Color.textPrimary)
                                     Text("Automatically send data to Mac when you export")
-                                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                        .font(Typography.monoCaption())
                                         .foregroundStyle(Color.textMuted)
                                 }
                             }
@@ -205,7 +205,7 @@ struct iPadSyncView: View {
                                 ProgressView()
                                     .controlSize(.small)
                                 Text("Syncing health data to Mac…")
-                                    .font(.system(size: 12, weight: .regular, design: .monospaced))
+                                    .font(Typography.monoCaption())
                                     .foregroundStyle(Color.textSecondary)
                             }
                         }
@@ -227,7 +227,7 @@ struct iPadSyncView: View {
                                 Image(systemName: "arrow.triangle.2.circlepath")
                                 Text("Sync Last 7 Days Now")
                             }
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
+                            .font(Typography.monoEmphasis())
                             .padding(.horizontal, 20)
                             .padding(.vertical, 8)
                         }
@@ -235,7 +235,7 @@ struct iPadSyncView: View {
                         .tint(Color.accent)
 
                         Text("Sends the last 7 days of health data to your connected Mac.")
-                            .font(.system(size: 11, weight: .regular, design: .monospaced))
+                            .font(Typography.monoCaption())
                             .foregroundStyle(Color.textMuted)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -249,7 +249,7 @@ struct iPadSyncView: View {
                         Image(systemName: "exclamationmark.triangle")
                             .foregroundStyle(Color.warning)
                         Text(error)
-                            .font(.system(size: 13, weight: .regular, design: .monospaced))
+                            .font(Typography.mono())
                             .foregroundStyle(Color.warning)
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -336,7 +336,7 @@ struct iPadBrandLabel: View {
 
     var body: some View {
         Text(text.uppercased())
-            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .font(Typography.monoCaptionEmphasis())
             .foregroundStyle(Color.accent)
             .kerning(2.2)
     }
@@ -351,11 +351,11 @@ struct iPadBrandDataRow: View {
     var body: some View {
         HStack {
             Text(label)
-                .font(.system(size: 13, weight: .regular, design: .monospaced))
+                .font(Typography.mono())
                 .foregroundStyle(Color.textSecondary)
             Spacer()
             Text(value)
-                .font(.system(size: 13, weight: .medium, design: .monospaced))
+                .font(Typography.monoEmphasis())
                 .foregroundStyle(Color.textPrimary)
         }
     }

--- a/HealthMd/macOS/Views/MacContentView.swift
+++ b/HealthMd/macOS/Views/MacContentView.swift
@@ -75,7 +75,7 @@ struct MacContentView: View {
                         .font(.title3)
                         .foregroundStyle(Color.accent)
                     Text("health.md")
-                        .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                        .font(BrandTypography.subheading())
                         .foregroundStyle(Color.textPrimary)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -87,7 +87,7 @@ struct MacContentView: View {
                 List(SidebarItem.allCases, selection: $selectedItem) { item in
                     Label {
                         Text(item.rawValue)
-                            .font(.system(size: 13, weight: .medium, design: .monospaced))
+                            .font(BrandTypography.detail())
                     } icon: {
                         Image(systemName: item.icon)
                             .foregroundStyle(Color.accent)
@@ -154,7 +154,7 @@ struct MacContentView: View {
     private var brandPlaceholder: some View {
         VStack(spacing: 16) {
             Image(systemName: "heart.text.square")
-                .font(.system(size: 48))
+                .font(.largeTitle)
                 .foregroundStyle(Color.accent)
             Text("health.md")
                 .font(BrandTypography.heading())

--- a/HealthMd/macOS/Views/MacExportView.swift
+++ b/HealthMd/macOS/Views/MacExportView.swift
@@ -87,7 +87,7 @@ struct MacExportView: View {
                         if let url = vaultManager.vaultURL {
                             Image(systemName: "folder.fill")
                                 .foregroundStyle(Color.accent)
-                                .font(.system(size: 16))
+                                .font(.body)
                                 .accessibilityHidden(true)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(vaultManager.vaultName)
@@ -105,7 +105,7 @@ struct MacExportView: View {
                         } else {
                             Image(systemName: "folder")
                                 .foregroundStyle(Color.textMuted)
-                                .font(.system(size: 16))
+                                .font(.body)
                                 .accessibilityHidden(true)
                             Text("No folder selected")
                                 .font(BrandTypography.body())
@@ -131,7 +131,7 @@ struct MacExportView: View {
                                 .foregroundStyle(Color.textSecondary)
                             Spacer()
                             TextField("Health", text: $vaultManager.healthSubfolder)
-                                .font(.system(size: 13, design: .monospaced))
+                                .font(BrandTypography.detail())
                                 .frame(width: 200)
                                 .textFieldStyle(.roundedBorder)
                                 .onChange(of: vaultManager.healthSubfolder) {
@@ -274,9 +274,9 @@ struct MacExportView: View {
                             } label: {
                                 HStack(spacing: 4) {
                                     Image(systemName: "stop.fill")
-                                        .font(.system(size: 10, weight: .semibold))
+                                        .font(.caption2.weight(.semibold))
                                     Text("Stop")
-                                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                                        .font(BrandTypography.caption())
                                 }
                                 .foregroundStyle(Color.red)
                                 .padding(.horizontal, 10)
@@ -365,7 +365,7 @@ struct MacExportView: View {
                     HStack(spacing: 6) {
                         Image(systemName: "eye")
                         Text("Preview")
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .font(BrandTypography.caption())
                     }
                 }
                 .disabled(!canPreview || isExporting)
@@ -385,7 +385,7 @@ struct MacExportView: View {
                     HStack(spacing: 6) {
                         Image(systemName: purchaseManager.canExport ? "arrow.up.doc.fill" : "lock.fill")
                         Text(purchaseManager.canExport ? "Review Export" : "Unlock to Export")
-                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .font(BrandTypography.caption())
                     }
                 }
                 .disabled(!canExport || isExporting)

--- a/HealthMd/macOS/Views/MacHistoryView.swift
+++ b/HealthMd/macOS/Views/MacHistoryView.swift
@@ -25,7 +25,7 @@ struct MacHistoryView: View {
             if historyManager.history.isEmpty {
                 VStack(spacing: 16) {
                     Image(systemName: "list.bullet.clipboard")
-                        .font(.system(size: 40))
+                        .font(.largeTitle)
                         .foregroundStyle(Color.textMuted)
                     Text("No Export History")
                         .font(BrandTypography.subheading())
@@ -198,7 +198,7 @@ struct MacHistoryView: View {
         } else {
             VStack(spacing: 12) {
                 Image(systemName: "doc.text.magnifyingglass")
-                    .font(.system(size: 32))
+                    .font(.title)
                     .foregroundStyle(Color.textMuted)
                 Text("Select an export to see details")
                     .font(BrandTypography.body())

--- a/HealthMd/macOS/Views/MacMenuBarView.swift
+++ b/HealthMd/macOS/Views/MacMenuBarView.swift
@@ -30,7 +30,7 @@ struct MacMenuBarView: View {
                     .foregroundStyle(Color.accent)
                     .font(.title3)
                 Text("health.md")
-                    .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                    .font(BrandTypography.bodyMedium())
                     .foregroundStyle(primaryTextColor)
                 Spacer()
             }

--- a/HealthMd/macOS/Views/MacOnboardingView.swift
+++ b/HealthMd/macOS/Views/MacOnboardingView.swift
@@ -71,7 +71,7 @@ struct MacOnboardingView: View {
                 .font(.title3)
                 .foregroundStyle(Color.accent)
             Text("health.md")
-                .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                .font(BrandTypography.subheading())
                 .foregroundStyle(Color.textPrimary)
 
             Spacer()
@@ -245,7 +245,7 @@ private struct HowItWorksStep: View {
                     .animation(.spring(response: 0.6, dampingFraction: 0.7).delay(0.05), value: animateIn)
 
                 Image(systemName: "chevron.right.2")
-                    .font(.system(size: 22, weight: .medium))
+                    .font(.title2.weight(.medium))
                     .foregroundStyle(Color.accent)
                     .opacity(animateIn ? 0.9 : 0)
                     .offset(x: animateIn ? 0 : -8)
@@ -309,7 +309,7 @@ private struct HowItWorksStep: View {
     private func deviceIcon(_ symbol: String, label: String) -> some View {
         VStack(spacing: 8) {
             Image(systemName: symbol)
-                .font(.system(size: 38, weight: .medium))
+                .font(.largeTitle.weight(.medium))
                 .foregroundStyle(Color.accent)
                 .frame(width: 88, height: 88)
                 .background(Circle().fill(Color.accentSubtle))
@@ -337,14 +337,14 @@ private struct GetIPhoneAppStep: View {
         VStack(spacing: 24) {
             ZStack {
                 Image(systemName: "iphone.gen3")
-                    .font(.system(size: 48, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(Color.accent)
                     .blur(radius: 22)
                     .opacity(0.6)
                     .accessibilityHidden(true)
 
                 Image(systemName: "iphone.gen3")
-                    .font(.system(size: 48, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(Color.accent)
             }
             .frame(width: 96, height: 96)
@@ -434,14 +434,14 @@ private struct ConnectStep: View {
         VStack(spacing: 24) {
             ZStack {
                 Image(systemName: heroIcon)
-                    .font(.system(size: 48, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(heroColor)
                     .blur(radius: 22)
                     .opacity(0.55)
                     .accessibilityHidden(true)
 
                 Image(systemName: heroIcon)
-                    .font(.system(size: 48, weight: .medium))
+                    .font(.largeTitle.weight(.medium))
                     .foregroundStyle(heroColor)
                     .contentTransition(.symbolEffect(.replace))
             }
@@ -493,7 +493,7 @@ private struct ConnectStep: View {
                             syncService.startBrowsing()
                         } label: {
                             Image(systemName: "arrow.clockwise")
-                                .font(.system(size: 13, weight: .medium))
+                                .font(.footnote.weight(.medium))
                         }
                         .buttonStyle(.plain)
                         .foregroundStyle(Color.textMuted)
@@ -586,7 +586,7 @@ private struct MacFeatureRow: View {
     var body: some View {
         HStack(spacing: 14) {
             Image(systemName: icon)
-                .font(.system(size: 16, weight: .medium))
+                .font(.body.weight(.medium))
                 .foregroundStyle(Color.accent)
                 .frame(width: 32, height: 32)
                 .background(Circle().fill(Color.accentSubtle))
@@ -608,7 +608,7 @@ private struct MacStepRow: View {
     var body: some View {
         HStack(spacing: 14) {
             Text(number)
-                .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                .font(BrandTypography.caption())
                 .foregroundStyle(Color.accent)
                 .frame(width: 26, height: 26)
                 .background(Circle().fill(Color.accentSubtle))

--- a/HealthMd/macOS/Views/MacPaywallView.swift
+++ b/HealthMd/macOS/Views/MacPaywallView.swift
@@ -61,7 +61,7 @@ struct MacPaywallView: View {
                             ProgressView().controlSize(.small).tint(.white)
                         } else {
                             Image(systemName: "lock.open.fill")
-                                .font(.system(size: 13, weight: .medium))
+                                .font(.footnote.weight(.medium))
                         }
                         Text(priceButtonLabel(purchaseManager.product))
                             .font(BrandTypography.bodyMedium())
@@ -126,7 +126,7 @@ private struct MacPaywallFeatureRow: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: icon)
-                .font(.system(size: 13, weight: .medium))
+                .font(.footnote.weight(.medium))
                 .foregroundStyle(Color.accent)
                 .frame(width: 20)
                 .accessibilityHidden(true)

--- a/HealthMd/macOS/Views/MacSettingsView.swift
+++ b/HealthMd/macOS/Views/MacSettingsView.swift
@@ -87,14 +87,14 @@ struct MacDetailSettingsView: View {
             Section {
                 LabeledContent("Filename Pattern") {
                     TextField("{date}", text: $advancedSettings.filenameFormat)
-                        .font(.system(size: 13, design: .monospaced))
+                        .font(BrandTypography.detail())
                         .frame(width: 200)
                         .textFieldStyle(.roundedBorder)
                 }
 
                 LabeledContent("Folder Structure") {
                     TextField("e.g. {year}/{month}", text: $advancedSettings.folderStructure)
-                        .font(.system(size: 13, design: .monospaced))
+                        .font(BrandTypography.detail())
                         .frame(width: 200)
                         .textFieldStyle(.roundedBorder)
                 }
@@ -190,7 +190,7 @@ struct MacDetailSettingsView: View {
                 if advancedSettings.individualTracking.globalEnabled {
                     LabeledContent("Entries Folder") {
                         TextField("entries", text: $advancedSettings.individualTracking.entriesFolder)
-                            .font(.system(size: 13, design: .monospaced))
+                            .font(BrandTypography.detail())
                             .frame(width: 200)
                             .textFieldStyle(.roundedBorder)
                             .accessibilityLabel("Entries folder name")
@@ -394,7 +394,7 @@ struct MacFormatSettingsTab: View {
             Section {
                 LabeledContent("Filename") {
                     TextField("{date}", text: $advancedSettings.filenameFormat)
-                        .font(.system(size: 13, design: .monospaced))
+                        .font(BrandTypography.detail())
                         .frame(width: 200)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel("Filename pattern")
@@ -403,7 +403,7 @@ struct MacFormatSettingsTab: View {
 
                 LabeledContent("Subfolder Pattern") {
                     TextField("e.g. {year}/{month}", text: $advancedSettings.folderStructure)
-                        .font(.system(size: 13, design: .monospaced))
+                        .font(BrandTypography.detail())
                         .frame(width: 200)
                         .textFieldStyle(.roundedBorder)
                         .accessibilityLabel("Subfolder pattern")
@@ -603,7 +603,7 @@ struct MacDataSettingsTab: View {
                 if advancedSettings.individualTracking.globalEnabled {
                     LabeledContent("Entries Folder") {
                         TextField("entries", text: $advancedSettings.individualTracking.entriesFolder)
-                            .font(.system(size: 13, design: .monospaced))
+                            .font(BrandTypography.detail())
                             .frame(width: 200)
                             .textFieldStyle(.roundedBorder)
                     }
@@ -655,7 +655,7 @@ struct MacDataSettingsTab: View {
                 if advancedSettings.dailyNoteInjection.enabled {
                     LabeledContent("Notes Folder") {
                         TextField("Daily", text: $advancedSettings.dailyNoteInjection.folderPath)
-                            .font(.system(size: 13, design: .monospaced))
+                            .font(BrandTypography.detail())
                             .frame(width: 200)
                             .textFieldStyle(.roundedBorder)
                             .accessibilityLabel("Daily notes folder path")
@@ -663,7 +663,7 @@ struct MacDataSettingsTab: View {
 
                     LabeledContent("Filename Pattern") {
                         TextField("{date}", text: $advancedSettings.dailyNoteInjection.filenamePattern)
-                            .font(.system(size: 13, design: .monospaced))
+                            .font(BrandTypography.detail())
                             .frame(width: 200)
                             .textFieldStyle(.roundedBorder)
                             .accessibilityLabel("Daily note filename pattern")
@@ -788,7 +788,7 @@ struct MacFeedbackTab: View {
                         .foregroundStyle(Color.textMuted)
 
                     Text(FeedbackHelper.diagnosticsBlock)
-                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                        .font(BrandTypography.caption())
                         .foregroundStyle(Color.textSecondary)
                         .padding(10)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/HealthMd/macOS/Views/MacSyncView.swift
+++ b/HealthMd/macOS/Views/MacSyncView.swift
@@ -60,7 +60,7 @@ struct MacSyncView: View {
                             HStack(spacing: 10) {
                                 Image(systemName: "iphone")
                                     .foregroundStyle(Color.accent)
-                                    .font(.system(size: 14))
+                                    .font(.callout)
                                     .accessibilityHidden(true)
                                 Text(peer.displayName)
                                     .font(BrandTypography.bodyMedium())

--- a/HealthMd/macOS/Views/MacVaultFolderSection.swift
+++ b/HealthMd/macOS/Views/MacVaultFolderSection.swift
@@ -48,7 +48,7 @@ struct MacVaultFolderSection: View {
             if showSubfolder, vaultManager.vaultURL != nil {
                 LabeledContent("Subfolder") {
                     TextField("Health", text: $vaultManager.healthSubfolder)
-                        .font(.system(size: 13, design: .monospaced))
+                        .font(BrandTypography.detail())
                         .frame(width: 200)
                         .textFieldStyle(.roundedBorder)
                         .onChange(of: vaultManager.healthSubfolder) {


### PR DESCRIPTION
Closes CodyBontecou/health-md#36

Implemented by Symphony agent automation.

## Issue

https://github.com/CodyBontecou/health-md/issues/36

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 79
Videos: 9
Other artifacts: 6

### .symphony/qa-artifacts/01_ipad_launch_accessibility_xxxl.png

![.symphony/qa-artifacts/01_ipad_launch_accessibility_xxxl.png](https://imghost.isolated.tech/ad5d2a65.png)

### .symphony/qa-artifacts/01_launch_accessibility_xxxl.png

![.symphony/qa-artifacts/01_launch_accessibility_xxxl.png](https://imghost.isolated.tech/b29daa45.png)

### .symphony/qa-artifacts/02_system_apple_account_alert.png

![.symphony/qa-artifacts/02_system_apple_account_alert.png](https://imghost.isolated.tech/f821c531.png)

### .symphony/qa-artifacts/03_after_alert_dismiss.png

![.symphony/qa-artifacts/03_after_alert_dismiss.png](https://imghost.isolated.tech/0ca0cbbf.png)

### .symphony/qa-artifacts/03_permission_prompt.png

![.symphony/qa-artifacts/03_permission_prompt.png](https://imghost.isolated.tech/458c24ba.png)

### .symphony/qa-artifacts/04_ipad_export_accessibility_xxxl.png

![.symphony/qa-artifacts/04_ipad_export_accessibility_xxxl.png](https://imghost.isolated.tech/18aca424.png)

### .symphony/qa-artifacts/05_after_idb_cancel.png

![.symphony/qa-artifacts/05_after_idb_cancel.png](https://imghost.isolated.tech/64c7c587.png)

### .symphony/qa-artifacts/05_ipad_export_scrolled_accessibility_xxxl.png

![.symphony/qa-artifacts/05_ipad_export_scrolled_accessibility_xxxl.png](https://imghost.isolated.tech/da01d114.png)

### .symphony/qa-artifacts/06_system_notification_prompt.png

![.symphony/qa-artifacts/06_system_notification_prompt.png](https://imghost.isolated.tech/abb7a7bc.png)

### .symphony/qa-artifacts/07_ipad_export_after_prompts_accessibility_xxxl.png

![.symphony/qa-artifacts/07_ipad_export_after_prompts_accessibility_xxxl.png](https://imghost.isolated.tech/dda227bf.png)

### .symphony/qa-artifacts/07_ipad_settings_accessibility_xxxl.png

![.symphony/qa-artifacts/07_ipad_settings_accessibility_xxxl.png](https://imghost.isolated.tech/90334825.png)

### .symphony/qa-artifacts/08_ipad_settings_accessibility_xxxl.png

![.symphony/qa-artifacts/08_ipad_settings_accessibility_xxxl.png](https://imghost.isolated.tech/c77aa23a.png)

### .symphony/qa-artifacts/08_iphone_first_launch_accessibility_xxxl.png

![.symphony/qa-artifacts/08_iphone_first_launch_accessibility_xxxl.png](https://imghost.isolated.tech/bb9a1c87.png)

### .symphony/qa-artifacts/09_ipad_settings_scrolled_accessibility_xxxl.png

![.symphony/qa-artifacts/09_ipad_settings_scrolled_accessibility_xxxl.png](https://imghost.isolated.tech/86190a0e.png)

### .symphony/qa-artifacts/09_iphone_onboarding_or_main_accessibility_xxxl.png

![.symphony/qa-artifacts/09_iphone_onboarding_or_main_accessibility_xxxl.png](https://imghost.isolated.tech/8f0b88a2.png)

### .symphony/qa-artifacts/10_iphone_after_alert_dismiss_attempt_accessibility_xxxl.png

![.symphony/qa-artifacts/10_iphone_after_alert_dismiss_attempt_accessibility_xxxl.png](https://imghost.isolated.tech/2614a04a.png)

### .symphony/qa-artifacts/10_return_to_healthmd.png

![.symphony/qa-artifacts/10_return_to_healthmd.png](https://imghost.isolated.tech/41001633.png)

### .symphony/qa-artifacts/11_iphone_onboarding_accessibility_xxxl.png

![.symphony/qa-artifacts/11_iphone_onboarding_accessibility_xxxl.png](https://imghost.isolated.tech/96e2afb2.png)

### .symphony/qa-artifacts/11_relaunch_healthmd.png

![.symphony/qa-artifacts/11_relaunch_healthmd.png](https://imghost.isolated.tech/358d9fac.png)

### .symphony/qa-artifacts/12_clean_ipad_export_accessibility_xxxl.png

![.symphony/qa-artifacts/12_clean_ipad_export_accessibility_xxxl.png](https://imghost.isolated.tech/af68f5f5.png)

- ...and 74 more artifact(s)

<details>
<summary>QA report</summary>

# QA Report: CodyBontecou/health-md#36

## Result
PASS WITH LIMITATIONS

The implementation builds and the primary iPad export/settings Dynamic Type surfaces are usable at `accessibility-extra-extra-extra-large`. Static scan found no remaining fixed `.system(size:)` calls under `HealthMd/Shared`, `HealthMd/iPad`, or `HealthMd/iOS`.

Validation of iPhone onboarding/paywall was limited by a persistent Apple Account sign-in system prompt. I captured the prompt and did not enter real credentials or invoke purchase/sign-in flows.

## Simulator / Device Used
- iPad Pro 13-inch (M5), iOS 26.3 simulator, build target.
- iPad Pro 11-inch (M5), iOS 26.3 simulator, clean visual QA target.
- iPhone 17 Pro, iOS 26.3 simulator, attempted onboarding/paywall validation.

## Mocked Data Setup
- Used app UI-test mode only: `--uitesting`.
- Environment used for iPad app run: `UITEST_HEALTH_AUTHORIZED=true`, `UITEST_VAULT_SELECTED=true`, `UITEST_PURCHASE_UNLOCKED=true`, `UITEST_FREE_EXPORTS_USED=0`, `UITEST_SYNC_STATE=connected`.
- Dynamic Type set with `simctl ui ... content_size accessibility-extra-extra-extra-large`.
- No production APIs, real Apple Account credentials, real StoreKit purchase, or real user data were used.

## Steps Performed
1. Inspected git diff for the issue areas and confirmed typography changes in iPad settings/export, shared export preview/confirmation, onboarding, paywall, and custom components.
2. Ran `rg "system\\(size:" HealthMd/Shared HealthMd/iPad HealthMd/iOS -n`; no matches remained.
3. Built the app with `xcodebuild -project HealthMd.xcodeproj -scheme HealthMd -destination 'platform=iOS Simulator,id=C3A1CAD9-9497-4A22-842A-4A35F0CD84E0' -derivedDataPath .symphony/DerivedData build`.
4. Installed and launched Health.md in simulator-only UI-test mode.
5. Set Accessibility XXXL content size and captured iPad export/settings screens.
6. Recorded a short iPad video navigating the Dynamic Type UI.
7. Attempted iPhone onboarding/paywall validation; captured Apple Account prompt and stopped without credentials.

## Evidence
- `build.log`
- `12_clean_ipad_export_accessibility_xxxl.png`
- `13_clean_ipad_settings_accessibility_xxxl.png`
- `clean_ipad_dynamic_type_export_settings.mp4`
- `14_iphone_onboarding_accessibility_xxxl.png`
- `15_iphone_after_apple_account_cancel_accessibility_xxxl.png`
- `17_iphone_uitest_export_accessibility_xxxl.png`
- `qa-notes.json`

## Observations
- iPad export and settings no longer show fixed-size typography behavior; text scales substantially and key controls remain reachable by scrolling.
- The iPad layout is very large at Accessibility XXXL, but major controls such as Permissions, Choose, format toggles, and write mode remain visible/reachable.
- The clean iPad run did not call production services or real purchase flows.

## Limitations / Follow-up
- iPhone onboarding/paywall visual validation remains incomplete because the simulator presented a persistent Apple Account sign-in prompt. Re-run that slice with a simulator/account state that suppresses StoreKit account prompts or a StoreKit test configuration that does not require sign-in.
- An already-booted iPad simulator initially had another app in split-screen; clean evidence was recaptured on a separate iPad simulator and should be used instead.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
