### PR TITLE
Fix #39: Report partial export failures instead of silent try? drops

### DIFF
--- a/HealthMd/Shared/Managers/ExportOrchestrator.swift
+++ b/HealthMd/Shared/Managers/ExportOrchestrator.swift
@@ -12,20 +12,41 @@ struct ExportOrchestrator {
         let successCount: Int
         let totalCount: Int
         let failedDateDetails: [FailedDateDetail]
+        let partialFailures: [ExportPartialFailure]
         let wasCancelled: Bool
         /// Number of files written per successful date (= count of selected formats at export time).
         let formatsPerDate: Int
 
-        init(successCount: Int, totalCount: Int, failedDateDetails: [FailedDateDetail], formatsPerDate: Int = 1, wasCancelled: Bool = false) {
+        init(
+            successCount: Int,
+            totalCount: Int,
+            failedDateDetails: [FailedDateDetail],
+            partialFailures: [ExportPartialFailure] = [],
+            formatsPerDate: Int = 1,
+            wasCancelled: Bool = false
+        ) {
             self.successCount = successCount
             self.totalCount = totalCount
             self.failedDateDetails = failedDateDetails
+            self.partialFailures = partialFailures
             self.formatsPerDate = formatsPerDate
             self.wasCancelled = wasCancelled
         }
 
-        var isFullSuccess: Bool { successCount == totalCount && totalCount > 0 && !wasCancelled }
-        var isPartialSuccess: Bool { (successCount > 0 && successCount < totalCount) || (successCount > 0 && wasCancelled) }
+        var hasPartialFailures: Bool { !partialFailures.isEmpty }
+        var partialFailureSummary: String {
+            guard let first = partialFailures.first else { return "" }
+            if partialFailures.count == 1 {
+                return "Warning: \(first.summary)"
+            }
+            return "Warning: \(partialFailures.count) metric fetches failed, including \(first.summary)"
+        }
+        var isFullSuccess: Bool { successCount == totalCount && totalCount > 0 && !wasCancelled && !hasPartialFailures }
+        var isPartialSuccess: Bool {
+            (successCount > 0 && successCount < totalCount) ||
+            (successCount > 0 && wasCancelled) ||
+            (successCount > 0 && hasPartialFailures)
+        }
         var isFailure: Bool { successCount == 0 && totalCount > 0 }
         var primaryFailureReason: ExportFailureReason? { failedDateDetails.first?.reason }
         /// Total file count = days that succeeded × formats per day.
@@ -65,6 +86,7 @@ struct ExportOrchestrator {
         let formatsPerDate = settings.exportFormats.count
         var successCount = 0
         var failedDateDetails: [FailedDateDetail] = []
+        var partialFailures: [ExportPartialFailure] = []
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
 
@@ -75,6 +97,7 @@ struct ExportOrchestrator {
                     successCount: successCount,
                     totalCount: totalDays,
                     failedDateDetails: failedDateDetails,
+                    partialFailures: partialFailures,
                     formatsPerDate: formatsPerDate,
                     wasCancelled: true
                 )
@@ -85,6 +108,7 @@ struct ExportOrchestrator {
 
             do {
                 let healthData = try await healthKitManager.fetchHealthData(for: date, includeGranularData: settings.includeGranularData)
+                partialFailures.append(contentsOf: healthData.partialFailures)
                 try await vaultManager.exportHealthData(healthData, settings: settings)
                 successCount += 1
             } catch let error as ExportError {
@@ -107,6 +131,7 @@ struct ExportOrchestrator {
             successCount: successCount,
             totalCount: totalDays,
             failedDateDetails: failedDateDetails,
+            partialFailures: partialFailures,
             formatsPerDate: formatsPerDate
         )
     }
@@ -125,6 +150,7 @@ struct ExportOrchestrator {
         let formatsPerDate = settings.exportFormats.count
         var successCount = 0
         var failedDateDetails: [FailedDateDetail] = []
+        var partialFailures: [ExportPartialFailure] = []
 
         for date in dates {
             // Check for cancellation before each date
@@ -133,6 +159,7 @@ struct ExportOrchestrator {
                     successCount: successCount,
                     totalCount: dates.count,
                     failedDateDetails: failedDateDetails,
+                    partialFailures: partialFailures,
                     formatsPerDate: formatsPerDate,
                     wasCancelled: true
                 )
@@ -140,6 +167,7 @@ struct ExportOrchestrator {
 
             do {
                 let healthData = try await healthKitManager.fetchHealthData(for: date, includeGranularData: settings.includeGranularData)
+                partialFailures.append(contentsOf: healthData.partialFailures)
 
                 if !healthData.hasAnyData {
                     failedDateDetails.append(FailedDateDetail(date: date, reason: .noHealthData))
@@ -173,6 +201,7 @@ struct ExportOrchestrator {
             successCount: successCount,
             totalCount: dates.count,
             failedDateDetails: failedDateDetails,
+            partialFailures: partialFailures,
             formatsPerDate: formatsPerDate
         )
     }
@@ -195,7 +224,8 @@ struct ExportOrchestrator {
                 dateRangeEnd: dateRangeEnd,
                 successCount: result.successCount,
                 totalCount: result.totalCount,
-                failedDateDetails: result.failedDateDetails
+                failedDateDetails: result.failedDateDetails,
+                partialFailures: result.partialFailures
             )
         } else {
             history.recordFailure(
@@ -205,7 +235,8 @@ struct ExportOrchestrator {
                 reason: result.primaryFailureReason ?? .unknown,
                 successCount: 0,
                 totalCount: result.totalCount,
-                failedDateDetails: result.failedDateDetails
+                failedDateDetails: result.failedDateDetails,
+                partialFailures: result.partialFailures
             )
         }
     }

--- a/HealthMd/Shared/Managers/HealthKitManager.swift
+++ b/HealthMd/Shared/Managers/HealthKitManager.swift
@@ -573,72 +573,94 @@ final class HealthKitManager: ObservableObject {
             return msg.contains("protected") || msg.contains("authorization") || msg.contains("not authorized")
         }
 
+        let dayRangeDescription = Self.dayRangeDescription(for: date)
+
+        func recordPartialFailure(_ dataType: String, error: Error) {
+            let failure = ExportPartialFailure(
+                date: date,
+                dataType: dataType,
+                dateRangeDescription: dayRangeDescription,
+                errorDescription: error.localizedDescription
+            )
+            healthData.partialFailures.append(failure)
+            logger.warning("HealthKit export fetch failed for \(dataType, privacy: .public) dateRange=\(dayRangeDescription, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
+
         do { healthData.sleep       = try await sleepTask     } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("sleep fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("sleep", error: error)
         }
         do { healthData.activity    = try await activityTask  } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("activity fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("activity", error: error)
         }
         do { healthData.heart       = try await heartTask     } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("heart fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("heart", error: error)
         }
         do { healthData.vitals      = try await vitalsTask    } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("vitals fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("vitals", error: error)
         }
         do { healthData.body        = try await bodyTask      } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("body fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("body", error: error)
         }
         do { healthData.nutrition   = try await nutritionTask } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("nutrition fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("nutrition", error: error)
         }
         do { healthData.mindfulness = try await mindfulTask   } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("mindfulness fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("mindfulness", error: error)
         }
         do { healthData.mobility    = try await mobilityTask  } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("mobility fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("mobility", error: error)
         }
         do { healthData.hearing     = try await hearingTask   } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("hearing fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("hearing", error: error)
         }
         do { healthData.reproductiveHealth = try await reproductiveTask } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("reproductive health fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("reproductive health", error: error)
         }
         do { healthData.cyclingPerformance = try await cyclingPerfTask } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("cycling performance fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("cycling performance", error: error)
         }
         do { healthData.vitamins   = try await vitaminsTask  } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("vitamins fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("vitamins", error: error)
         }
         do { healthData.minerals   = try await mineralsTask  } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("minerals fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("minerals", error: error)
         }
         do { healthData.symptoms   = try await symptomsTask  } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("symptoms fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("symptoms", error: error)
         }
         do { healthData.other      = try await otherTask     } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("other health data fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("other health data", error: error)
         }
         do { healthData.workouts    = try await workoutsTask  } catch {
             guard !isDeviceLocked(error) else { throw HealthKitError.dataProtectedWhileLocked }
-            logger.warning("workouts fetch failed: \(error.localizedDescription)")
+            recordPartialFailure("workouts", error: error)
         }
 
         return healthData
+    }
+
+    private static func dayRangeDescription(for date: Date) -> String {
+        let calendar = Calendar.current
+        let start = calendar.startOfDay(for: date)
+        let end = calendar.date(byAdding: DateComponents(day: 1, second: -1), to: start) ?? date
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return "\(formatter.string(from: start)) - \(formatter.string(from: end))"
     }
 
     // MARK: - Earliest Data Date

--- a/HealthMd/Shared/Models/ExportHistory.swift
+++ b/HealthMd/Shared/Models/ExportHistory.swift
@@ -13,6 +13,12 @@ struct ExportHistoryEntry: Codable, Identifiable {
     let totalCount: Int
     let failureReason: ExportFailureReason?
     let failedDateDetails: [FailedDateDetail]
+    let partialFailures: [ExportPartialFailure]
+
+    enum CodingKeys: String, CodingKey {
+        case id, timestamp, source, success, dateRangeStart, dateRangeEnd
+        case successCount, totalCount, failureReason, failedDateDetails, partialFailures
+    }
 
     init(
         id: UUID = UUID(),
@@ -24,7 +30,8 @@ struct ExportHistoryEntry: Codable, Identifiable {
         successCount: Int,
         totalCount: Int,
         failureReason: ExportFailureReason? = nil,
-        failedDateDetails: [FailedDateDetail] = []
+        failedDateDetails: [FailedDateDetail] = [],
+        partialFailures: [ExportPartialFailure] = []
     ) {
         self.id = id
         self.timestamp = timestamp
@@ -36,16 +43,40 @@ struct ExportHistoryEntry: Codable, Identifiable {
         self.totalCount = totalCount
         self.failureReason = failureReason
         self.failedDateDetails = failedDateDetails
+        self.partialFailures = partialFailures
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        timestamp = try container.decode(Date.self, forKey: .timestamp)
+        source = try container.decode(ExportSource.self, forKey: .source)
+        success = try container.decode(Bool.self, forKey: .success)
+        dateRangeStart = try container.decode(Date.self, forKey: .dateRangeStart)
+        dateRangeEnd = try container.decode(Date.self, forKey: .dateRangeEnd)
+        successCount = try container.decode(Int.self, forKey: .successCount)
+        totalCount = try container.decode(Int.self, forKey: .totalCount)
+        failureReason = try container.decodeIfPresent(ExportFailureReason.self, forKey: .failureReason)
+        failedDateDetails = try container.decodeIfPresent([FailedDateDetail].self, forKey: .failedDateDetails) ?? []
+        partialFailures = try container.decodeIfPresent([ExportPartialFailure].self, forKey: .partialFailures) ?? []
     }
 
     /// Returns true if all exports succeeded
     var isFullSuccess: Bool {
-        success && successCount == totalCount && totalCount > 0
+        success && successCount == totalCount && totalCount > 0 && partialFailures.isEmpty
     }
 
     /// Returns true if some but not all exports succeeded
     var isPartialSuccess: Bool {
-        success && successCount > 0 && successCount < totalCount
+        success && successCount > 0 && (successCount < totalCount || !partialFailures.isEmpty)
+    }
+
+    var partialFailureSummary: String? {
+        guard let first = partialFailures.first else { return nil }
+        if partialFailures.count == 1 {
+            return "Warning: \(first.summary)"
+        }
+        return "Warning: \(partialFailures.count) metric fetches failed, including \(first.summary)"
     }
 
     /// Summary description for display
@@ -53,6 +84,9 @@ struct ExportHistoryEntry: Codable, Identifiable {
         if isFullSuccess {
             return String(localized: "Exported \(successCount) file(s)", comment: "Export success summary")
         } else if isPartialSuccess {
+            if !partialFailures.isEmpty {
+                return String(localized: "Partial: \(partialFailures.count) metric warning(s)", comment: "Partial export metric warning summary")
+            }
             return String(localized: "Partial: \(successCount)/\(totalCount) files", comment: "Partial export summary")
         } else if let reason = failureReason {
             return reason.shortDescription
@@ -180,7 +214,8 @@ class ExportHistoryManager: ObservableObject {
         dateRangeEnd: Date,
         successCount: Int,
         totalCount: Int,
-        failedDateDetails: [FailedDateDetail] = []
+        failedDateDetails: [FailedDateDetail] = [],
+        partialFailures: [ExportPartialFailure] = []
     ) {
         let entry = ExportHistoryEntry(
             source: source,
@@ -189,7 +224,8 @@ class ExportHistoryManager: ObservableObject {
             dateRangeEnd: dateRangeEnd,
             successCount: successCount,
             totalCount: totalCount,
-            failedDateDetails: failedDateDetails
+            failedDateDetails: failedDateDetails,
+            partialFailures: partialFailures
         )
         addEntry(entry)
     }
@@ -202,7 +238,8 @@ class ExportHistoryManager: ObservableObject {
         reason: ExportFailureReason,
         successCount: Int = 0,
         totalCount: Int = 0,
-        failedDateDetails: [FailedDateDetail] = []
+        failedDateDetails: [FailedDateDetail] = [],
+        partialFailures: [ExportPartialFailure] = []
     ) {
         let entry = ExportHistoryEntry(
             source: source,
@@ -212,7 +249,8 @@ class ExportHistoryManager: ObservableObject {
             successCount: successCount,
             totalCount: totalCount,
             failureReason: reason,
-            failedDateDetails: failedDateDetails
+            failedDateDetails: failedDateDetails,
+            partialFailures: partialFailures
         )
         addEntry(entry)
     }

--- a/HealthMd/Shared/Models/HealthData.swift
+++ b/HealthMd/Shared/Models/HealthData.swift
@@ -868,6 +868,17 @@ struct WorkoutData: Identifiable, Codable {
 
 // MARK: - Complete Health Data
 
+struct ExportPartialFailure: Codable, Equatable {
+    let date: Date
+    let dataType: String
+    let dateRangeDescription: String
+    let errorDescription: String
+
+    var summary: String {
+        "\(dataType) for \(dateRangeDescription): \(errorDescription)"
+    }
+}
+
 struct HealthData: Codable {
     let date: Date
     var sleep: SleepData = SleepData()
@@ -886,6 +897,75 @@ struct HealthData: Codable {
     var symptoms: SymptomsData = SymptomsData()
     var other: OtherHealthData = OtherHealthData()
     var workouts: [WorkoutData] = []
+    var partialFailures: [ExportPartialFailure] = []
+
+    enum CodingKeys: String, CodingKey {
+        case date, sleep, activity, heart, vitals, body, nutrition, mindfulness, mobility, hearing
+        case reproductiveHealth, cyclingPerformance, vitamins, minerals, symptoms, other, workouts
+        case partialFailures
+    }
+
+    init(
+        date: Date,
+        sleep: SleepData = SleepData(),
+        activity: ActivityData = ActivityData(),
+        heart: HeartData = HeartData(),
+        vitals: VitalsData = VitalsData(),
+        body: BodyData = BodyData(),
+        nutrition: NutritionData = NutritionData(),
+        mindfulness: MindfulnessData = MindfulnessData(),
+        mobility: MobilityData = MobilityData(),
+        hearing: HearingData = HearingData(),
+        reproductiveHealth: ReproductiveHealthData = ReproductiveHealthData(),
+        cyclingPerformance: CyclingPerformanceData = CyclingPerformanceData(),
+        vitamins: VitaminsData = VitaminsData(),
+        minerals: MineralsData = MineralsData(),
+        symptoms: SymptomsData = SymptomsData(),
+        other: OtherHealthData = OtherHealthData(),
+        workouts: [WorkoutData] = [],
+        partialFailures: [ExportPartialFailure] = []
+    ) {
+        self.date = date
+        self.sleep = sleep
+        self.activity = activity
+        self.heart = heart
+        self.vitals = vitals
+        self.body = body
+        self.nutrition = nutrition
+        self.mindfulness = mindfulness
+        self.mobility = mobility
+        self.hearing = hearing
+        self.reproductiveHealth = reproductiveHealth
+        self.cyclingPerformance = cyclingPerformance
+        self.vitamins = vitamins
+        self.minerals = minerals
+        self.symptoms = symptoms
+        self.other = other
+        self.workouts = workouts
+        self.partialFailures = partialFailures
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        date = try container.decode(Date.self, forKey: .date)
+        sleep = try container.decodeIfPresent(SleepData.self, forKey: .sleep) ?? SleepData()
+        activity = try container.decodeIfPresent(ActivityData.self, forKey: .activity) ?? ActivityData()
+        heart = try container.decodeIfPresent(HeartData.self, forKey: .heart) ?? HeartData()
+        vitals = try container.decodeIfPresent(VitalsData.self, forKey: .vitals) ?? VitalsData()
+        body = try container.decodeIfPresent(BodyData.self, forKey: .body) ?? BodyData()
+        nutrition = try container.decodeIfPresent(NutritionData.self, forKey: .nutrition) ?? NutritionData()
+        mindfulness = try container.decodeIfPresent(MindfulnessData.self, forKey: .mindfulness) ?? MindfulnessData()
+        mobility = try container.decodeIfPresent(MobilityData.self, forKey: .mobility) ?? MobilityData()
+        hearing = try container.decodeIfPresent(HearingData.self, forKey: .hearing) ?? HearingData()
+        reproductiveHealth = try container.decodeIfPresent(ReproductiveHealthData.self, forKey: .reproductiveHealth) ?? ReproductiveHealthData()
+        cyclingPerformance = try container.decodeIfPresent(CyclingPerformanceData.self, forKey: .cyclingPerformance) ?? CyclingPerformanceData()
+        vitamins = try container.decodeIfPresent(VitaminsData.self, forKey: .vitamins) ?? VitaminsData()
+        minerals = try container.decodeIfPresent(MineralsData.self, forKey: .minerals) ?? MineralsData()
+        symptoms = try container.decodeIfPresent(SymptomsData.self, forKey: .symptoms) ?? SymptomsData()
+        other = try container.decodeIfPresent(OtherHealthData.self, forKey: .other) ?? OtherHealthData()
+        workouts = try container.decodeIfPresent([WorkoutData].self, forKey: .workouts) ?? []
+        partialFailures = try container.decodeIfPresent([ExportPartialFailure].self, forKey: .partialFailures) ?? []
+    }
 
     var hasAnyData: Bool {
         sleep.hasData || activity.hasData || heart.hasData || vitals.hasData ||

--- a/HealthMd/Shared/Protocols/SystemHealthStoreAdapter.swift
+++ b/HealthMd/Shared/Protocols/SystemHealthStoreAdapter.swift
@@ -9,8 +9,10 @@
 @preconcurrency import Foundation
 @preconcurrency import HealthKit
 @preconcurrency import CoreLocation
+import os.log
 
 final class SystemHealthStoreAdapter: HealthStoreProviding, @unchecked Sendable {
+    private static let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "HealthKitExport")
     private let store: HKHealthStore
 
     /// Canonical unit for each quantity type used by this app.
@@ -245,8 +247,30 @@ final class SystemHealthStoreAdapter: HealthStoreProviding, @unchecked Sendable 
         var results: [WorkoutValue] = []
         results.reserveCapacity(workouts.count)
         for w in workouts {
-            let hrStats = try? await fetchHeartRateStats(for: w)
             let workoutPredicate = HKQuery.predicateForObjects(from: w)
+            let workoutRange = Self.rangeDescription(start: w.startDate, end: w.endDate)
+
+            func fetchOptional<T>(_ context: String, operation: () async throws -> T?) async -> T? {
+                do {
+                    return try await operation()
+                } catch {
+                    Self.logger.warning("HealthKit workout detail fetch failed for \(context, privacy: .public) workoutRange=\(workoutRange, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    return nil
+                }
+            }
+
+            func fetchArray<T>(_ context: String, operation: () async throws -> [T]) async -> [T] {
+                do {
+                    return try await operation()
+                } catch {
+                    Self.logger.warning("HealthKit workout detail fetch failed for \(context, privacy: .public) workoutRange=\(workoutRange, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    return []
+                }
+            }
+
+            let hrStats = await fetchOptional("heart rate stats") {
+                try await fetchHeartRateStats(for: w)
+            }
 
             var avgRunningCadence: Double?
             var avgStrideLength: Double?
@@ -258,19 +282,37 @@ final class SystemHealthStoreAdapter: HealthStoreProviding, @unchecked Sendable 
 
             switch w.workoutActivityType {
             case .running:
-                avgStrideLength = try? await queryAverage(identifier: .runningStrideLength, predicate: workoutPredicate)
-                avgGroundContactTime = try? await queryAverage(identifier: .runningGroundContactTime, predicate: workoutPredicate)
-                avgVerticalOscillation = try? await queryAverage(identifier: .runningVerticalOscillation, predicate: workoutPredicate)
-                avgPower = try? await queryAverage(identifier: .runningPower, predicate: workoutPredicate)
-                maxPower = try? await queryMax(identifier: .runningPower, predicate: workoutPredicate)
-                if let steps = try? await querySum(identifier: .stepCount, predicate: workoutPredicate),
-                   steps > 0, w.duration > 0 {
+                avgStrideLength = await fetchOptional("running stride length") {
+                    try await queryAverage(identifier: .runningStrideLength, predicate: workoutPredicate)
+                }
+                avgGroundContactTime = await fetchOptional("running ground contact time") {
+                    try await queryAverage(identifier: .runningGroundContactTime, predicate: workoutPredicate)
+                }
+                avgVerticalOscillation = await fetchOptional("running vertical oscillation") {
+                    try await queryAverage(identifier: .runningVerticalOscillation, predicate: workoutPredicate)
+                }
+                avgPower = await fetchOptional("running power average") {
+                    try await queryAverage(identifier: .runningPower, predicate: workoutPredicate)
+                }
+                maxPower = await fetchOptional("running power max") {
+                    try await queryMax(identifier: .runningPower, predicate: workoutPredicate)
+                }
+                let steps = await fetchOptional("running step count") {
+                    try await querySum(identifier: .stepCount, predicate: workoutPredicate)
+                }
+                if let steps, steps > 0, w.duration > 0 {
                     avgRunningCadence = steps / (w.duration / 60.0)
                 }
             case .cycling:
-                avgCyclingCadence = try? await queryAverage(identifier: .cyclingCadence, predicate: workoutPredicate)
-                avgPower = try? await queryAverage(identifier: .cyclingPower, predicate: workoutPredicate)
-                maxPower = try? await queryMax(identifier: .cyclingPower, predicate: workoutPredicate)
+                avgCyclingCadence = await fetchOptional("cycling cadence average") {
+                    try await queryAverage(identifier: .cyclingCadence, predicate: workoutPredicate)
+                }
+                avgPower = await fetchOptional("cycling power average") {
+                    try await queryAverage(identifier: .cyclingPower, predicate: workoutPredicate)
+                }
+                maxPower = await fetchOptional("cycling power max") {
+                    try await queryMax(identifier: .cyclingPower, predicate: workoutPredicate)
+                }
             default:
                 break
             }
@@ -282,26 +324,34 @@ final class SystemHealthStoreAdapter: HealthStoreProviding, @unchecked Sendable 
             // numbers match Health and indoor workouts work too.
             let distanceSamples: [QuantitySampleValue]
             if let distId = distanceIdentifier(for: w.workoutActivityType) {
-                distanceSamples = (try? await queryQuantitySamples(
-                    identifier: distId,
-                    predicate: workoutPredicate,
-                    ascending: true,
-                    limit: nil
-                )) ?? []
+                distanceSamples = await fetchArray("lap distance samples") {
+                    try await queryQuantitySamples(
+                        identifier: distId,
+                        predicate: workoutPredicate,
+                        ascending: true,
+                        limit: nil
+                    )
+                }
             } else {
                 distanceSamples = []
             }
             let laps = extractLaps(from: w, distanceSamples: distanceSamples)
-            let route = (try? await fetchRoute(for: w)) ?? []
+            let route = await fetchArray("route") {
+                try await fetchRoute(for: w)
+            }
             let elevationGain = computeElevationGain(from: route) ?? metadataElevation(w, key: HKMetadataKeyElevationAscended)
             let elevationLoss = metadataElevation(w, key: HKMetadataKeyElevationDescended)
 
             // Wave 2: per-second time-series samples
-            let timeSeries = (try? await fetchTimeSeries(for: w)) ?? .empty
+            let timeSeries = await fetchOptional("time series") {
+                try await fetchTimeSeries(for: w)
+            } ?? .empty
 
             // Wave 1: derive auto-distance splits from the route (1 km / 1 mi).
             // Adapter renders metric splits by default; renderers handle unit display.
-            let splits = (try? await deriveSplits(workout: w, route: route)) ?? []
+            let splits = await fetchArray("splits") {
+                try await deriveSplits(workout: w, route: route)
+            }
 
             results.append(WorkoutValue(
                 activityType: w.workoutActivityType.rawValue,
@@ -487,7 +537,14 @@ final class SystemHealthStoreAdapter: HealthStoreProviding, @unchecked Sendable 
             cumMeters += currLoc.distance(from: prevLoc)
             while cumMeters - lastSplitMeters >= splitDistance {
                 let splitEnd = curr.timestamp
-                let avgHR = try? await fetchAverageHeartRate(workout: workout, start: lastSplitTime, end: splitEnd)
+                let avgHR: Double?
+                do {
+                    avgHR = try await fetchAverageHeartRate(workout: workout, start: lastSplitTime, end: splitEnd)
+                } catch {
+                    let range = Self.rangeDescription(start: lastSplitTime, end: splitEnd)
+                    Self.logger.warning("HealthKit workout split heart-rate fetch failed for splitRange=\(range, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                    avgHR = nil
+                }
                 splits.append(WorkoutSplit(
                     index: splitIndex,
                     startDate: lastSplitTime,
@@ -501,6 +558,12 @@ final class SystemHealthStoreAdapter: HealthStoreProviding, @unchecked Sendable 
             }
         }
         return splits
+    }
+
+    private static func rangeDescription(start: Date, end: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        return "\(formatter.string(from: start)) - \(formatter.string(from: end))"
     }
 
     private func fetchAverageHeartRate(workout: HKWorkout, start: Date, end: Date) async throws -> Double? {

--- a/HealthMd/Shared/Views/ExportPreviewView.swift
+++ b/HealthMd/Shared/Views/ExportPreviewView.swift
@@ -18,6 +18,7 @@ struct ExportPreviewView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var datePreviews: [DatePreview] = []
+    @State private var partialFailures: [ExportPartialFailure] = []
     @State private var isLoading = true
     @State private var totalDateCount = 0
 
@@ -87,6 +88,7 @@ struct ExportPreviewView: View {
     private var contentList: some View {
         List {
             summarySection
+            partialFailuresSection
             sideEffectsSection
             ForEach(datePreviews) { preview in
                 Section {
@@ -163,6 +165,24 @@ struct ExportPreviewView: View {
     }
 
     @ViewBuilder
+    private var partialFailuresSection: some View {
+        if !partialFailures.isEmpty {
+            Section("Warnings") {
+                ForEach(Array(partialFailures.enumerated()), id: \.offset) { _, failure in
+                    Label {
+                        Text(failure.summary)
+                            .font(.footnote)
+                            .foregroundStyle(Color.textSecondary)
+                    } icon: {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(Color.orange)
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
     private var sideEffectsSection: some View {
         let injection = settings.dailyNoteInjection.enabled && settings.exportFormats.contains(.markdown)
         let individual = settings.individualTracking.globalEnabled && settings.exportFormats.contains(.markdown)
@@ -227,6 +247,7 @@ struct ExportPreviewView: View {
         // collecting up to maxRenderedDates previews. Newest-first matches
         // what users want to see and avoids paying for empty leading days.
         var built: [DatePreview] = []
+        var warnings: [ExportPartialFailure] = []
         var attempts = 0
 
         for date in dates.reversed() {
@@ -234,7 +255,9 @@ struct ExportPreviewView: View {
             if attempts >= Self.maxFetchAttempts { break }
             attempts += 1
 
-            guard let healthData = await fetchHealthData(date), healthData.hasAnyData else { continue }
+            guard let healthData = await fetchHealthData(date) else { continue }
+            warnings.append(contentsOf: healthData.partialFailures)
+            guard healthData.hasAnyData else { continue }
 
             let folderPath = previewFolderPath(for: date)
             let files = settings.exportFormats
@@ -261,6 +284,7 @@ struct ExportPreviewView: View {
         }
 
         datePreviews = built
+        partialFailures = warnings
         isLoading = false
     }
 

--- a/HealthMd/iOS/AppIntents/ExportIntentRunner.swift
+++ b/HealthMd/iOS/AppIntents/ExportIntentRunner.swift
@@ -73,11 +73,13 @@ enum ExportIntentRunner {
             SchedulingManager.shared.schedule = schedule
         }
 
-        if result.successCount == result.totalCount {
+        if result.isFullSuccess {
             return .success(daysExported: result.successCount, formatsPerDate: result.formatsPerDate)
         }
 
-        let reason = result.primaryFailureReason?.shortDescription ?? "Some days had no data"
+        let reason = result.hasPartialFailures
+            ? result.partialFailureSummary
+            : (result.primaryFailureReason?.shortDescription ?? "Some days had no data")
         return .partial(
             exported: result.successCount,
             total: result.totalCount,

--- a/HealthMd/iOS/ContentView.swift
+++ b/HealthMd/iOS/ContentView.swift
@@ -1,8 +1,11 @@
 import SwiftUI
 import UIKit
 import StoreKit
+import os.log
 
 struct ContentView: View {
+    private static let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "Export")
+
     @EnvironmentObject var healthKitManager: HealthKitManager
     @EnvironmentObject var syncService: SyncService
     @StateObject private var vaultManager = VaultManager()
@@ -431,8 +434,13 @@ struct ContentView: View {
     private func autoSyncDates(_ dates: [Date]) async {
         var records: [HealthData] = []
         for date in dates {
-            if let data = try? await healthKitManager.fetchHealthData(for: date), data.hasAnyData {
-                records.append(data)
+            do {
+                let data = try await healthKitManager.fetchHealthData(for: date)
+                if data.hasAnyData {
+                    records.append(data)
+                }
+            } catch {
+                Self.logger.warning("Auto-sync HealthKit fetch failed for date=\(date, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
         guard !records.isEmpty else { return }
@@ -539,12 +547,14 @@ struct ContentView: View {
                     requestReview()
                 }
             } else if result.isPartialSuccess {
+                let warning = result.hasPartialFailures ? result.partialFailureSummary : nil
                 let failedDatesStr = result.failedDateDetails.map { $0.dateString }.joined(separator: ", ")
+                let suffix = warning ?? "Failed: \(failedDatesStr)"
                 if result.formatsPerDate > 1 {
-                    exportStatusMessage = "Exported \(result.totalFilesWritten) files (\(result.successCount)/\(result.totalCount) days × \(result.formatsPerDate) formats). Failed: \(failedDatesStr)"
+                    exportStatusMessage = "Exported \(result.totalFilesWritten) files (\(result.successCount)/\(result.totalCount) days × \(result.formatsPerDate) formats). \(suffix)"
                     vaultManager.lastExportStatus = "Partial export: \(result.successCount)/\(result.totalCount) days succeeded (\(result.totalFilesWritten) files)"
                 } else {
-                    exportStatusMessage = "Exported \(result.successCount)/\(result.totalCount) files. Failed: \(failedDatesStr)"
+                    exportStatusMessage = "Exported \(result.successCount)/\(result.totalCount) files. \(suffix)"
                     vaultManager.lastExportStatus = "Partial export: \(result.successCount)/\(result.totalCount) succeeded"
                 }
                 startStatusDismissTimer()

--- a/HealthMd/iOS/Views/ExportTabView.swift
+++ b/HealthMd/iOS/Views/ExportTabView.swift
@@ -1,10 +1,13 @@
 import SwiftUI
 import UIKit
+import os.log
 
 // MARK: - Export Tab View
 // Single scrollable home for all iOS export configuration plus the export action.
 
 struct ExportTabView: View {
+    private static let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "ExportPreview")
+
     @ObservedObject var healthKitManager: HealthKitManager
     @ObservedObject var vaultManager: VaultManager
     @ObservedObject var advancedSettings: AdvancedExportSettings
@@ -92,10 +95,15 @@ struct ExportTabView: View {
                 vaultManager: vaultManager,
                 settings: advancedSettings,
                 fetchHealthData: { date in
-                    try? await healthKitManager.fetchHealthData(
-                        for: date,
-                        includeGranularData: advancedSettings.includeGranularData
-                    )
+                    do {
+                        return try await healthKitManager.fetchHealthData(
+                            for: date,
+                            includeGranularData: advancedSettings.includeGranularData
+                        )
+                    } catch {
+                        Self.logger.warning("Export preview HealthKit fetch failed for date=\(date, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        return nil
+                    }
                 }
             )
         }

--- a/HealthMd/iOS/Views/ScheduleSettingsView.swift
+++ b/HealthMd/iOS/Views/ScheduleSettingsView.swift
@@ -394,6 +394,7 @@ struct ScheduleSettingsView: View {
         let totalDays = datesToExport.count
         var successCount = 0
         var failedDateDetails: [FailedDateDetail] = []
+        var partialFailures: [ExportPartialFailure] = []
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"
 
@@ -414,6 +415,7 @@ struct ScheduleSettingsView: View {
                 let success = vaultManager.exportHealthData(healthData, for: date, settings: advancedSettings)
 
                 if success {
+                    partialFailures.append(contentsOf: healthData.partialFailures)
                     successCount += 1
                 } else {
                     failedDateDetails.append(FailedDateDetail(date: date, reason: .fileWriteError))
@@ -432,7 +434,7 @@ struct ScheduleSettingsView: View {
             let startDate = datesToExport.min() ?? entry.dateRangeStart
             let endDate = datesToExport.max() ?? entry.dateRangeEnd
 
-            if failedDateDetails.isEmpty && successCount > 0 {
+            if failedDateDetails.isEmpty && partialFailures.isEmpty && successCount > 0 {
                 retryStatusMessage = String(localized: "Successfully exported \(successCount) files", comment: "Export success message")
                 exportHistory.recordSuccess(
                     source: .manual,
@@ -442,14 +444,17 @@ struct ScheduleSettingsView: View {
                     totalCount: totalDays
                 )
             } else if successCount > 0 {
-                retryStatusMessage = "Exported \(successCount)/\(totalDays) files"
+                retryStatusMessage = partialFailures.isEmpty
+                    ? "Exported \(successCount)/\(totalDays) files"
+                    : "Exported \(successCount)/\(totalDays) files with \(partialFailures.count) warning(s)"
                 exportHistory.recordSuccess(
                     source: .manual,
                     dateRangeStart: startDate,
                     dateRangeEnd: endDate,
                     successCount: successCount,
                     totalCount: totalDays,
-                    failedDateDetails: failedDateDetails
+                    failedDateDetails: failedDateDetails,
+                    partialFailures: partialFailures
                 )
             } else {
                 let primaryReason = failedDateDetails.first?.reason ?? .unknown
@@ -463,7 +468,8 @@ struct ScheduleSettingsView: View {
                     reason: primaryReason,
                     successCount: 0,
                     totalCount: totalDays,
-                    failedDateDetails: failedDateDetails
+                    failedDateDetails: failedDateDetails,
+                    partialFailures: partialFailures
                 )
             }
         }
@@ -716,6 +722,24 @@ struct ExportHistoryDetailView: View {
                         .padding(.vertical, 4)
                     } header: {
                         Text("Failure Reason")
+                            .font(Typography.caption())
+                            .foregroundStyle(Color.textSecondary)
+                    }
+                }
+
+                if !entry.partialFailures.isEmpty {
+                    Section {
+                        ForEach(Array(entry.partialFailures.enumerated()), id: \.offset) { _, failure in
+                            HStack(alignment: .top) {
+                                Image(systemName: "exclamationmark.triangle.fill")
+                                    .foregroundStyle(Color.orange)
+                                Text(failure.summary)
+                                    .font(Typography.caption())
+                                    .foregroundStyle(Color.textSecondary)
+                            }
+                        }
+                    } header: {
+                        Text("Partial Export Warnings")
                             .font(Typography.caption())
                             .foregroundStyle(Color.textSecondary)
                     }

--- a/HealthMd/iPad/iPadContentView.swift
+++ b/HealthMd/iPad/iPadContentView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 import UIKit
+import os.log
 
 // MARK: - iPad Root View (matching macOS NavigationSplitView layout)
 
 struct iPadContentView: View {
+    private static let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "Export")
+
     @EnvironmentObject var healthKitManager: HealthKitManager
     @EnvironmentObject var syncService: SyncService
     @EnvironmentObject var schedulingManager: SchedulingManager
@@ -184,8 +187,13 @@ struct iPadContentView: View {
     private func autoSyncDates(_ dates: [Date]) async {
         var records: [HealthData] = []
         for date in dates {
-            if let data = try? await healthKitManager.fetchHealthData(for: date), data.hasAnyData {
-                records.append(data)
+            do {
+                let data = try await healthKitManager.fetchHealthData(for: date)
+                if data.hasAnyData {
+                    records.append(data)
+                }
+            } catch {
+                Self.logger.warning("Auto-sync HealthKit fetch failed for date=\(date, privacy: .public): \(error.localizedDescription, privacy: .public)")
             }
         }
         guard !records.isEmpty else { return }
@@ -270,7 +278,8 @@ struct iPadContentView: View {
                 exportStatusMessage = String(localized: "Successfully exported \(result.successCount) files", comment: "Export success message")
             } else if result.isPartialSuccess {
                 let failedDatesStr = result.failedDateDetails.map { $0.dateString }.joined(separator: ", ")
-                exportStatusMessage = String(localized: "Exported \(result.successCount)/\(result.totalCount) files. Failed: \(failedDatesStr)", comment: "Partial export with failures")
+                let suffix = result.hasPartialFailures ? result.partialFailureSummary : "Failed: \(failedDatesStr)"
+                exportStatusMessage = String(localized: "Exported \(result.successCount)/\(result.totalCount) files. \(suffix)", comment: "Partial export with failures")
             } else {
                 let primaryReason = result.primaryFailureReason ?? .unknown
                 exportStatusMessage = String(localized: "Export failed: \(primaryReason.shortDescription)", comment: "Export failure message")

--- a/HealthMd/iPad/iPadExportView.swift
+++ b/HealthMd/iPad/iPadExportView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
 import UIKit
+import os.log
 
 // MARK: - iPad Export View (matching macOS MacExportView glass card layout)
 
 struct iPadExportView: View {
+    private static let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "ExportPreview")
+
     @ObservedObject var healthKitManager: HealthKitManager
     @ObservedObject var vaultManager: VaultManager
     @ObservedObject var advancedSettings: AdvancedExportSettings
@@ -379,10 +382,15 @@ struct iPadExportView: View {
                 vaultManager: vaultManager,
                 settings: advancedSettings,
                 fetchHealthData: { date in
-                    try? await healthKitManager.fetchHealthData(
-                        for: date,
-                        includeGranularData: advancedSettings.includeGranularData
-                    )
+                    do {
+                        return try await healthKitManager.fetchHealthData(
+                            for: date,
+                            includeGranularData: advancedSettings.includeGranularData
+                        )
+                    } catch {
+                        Self.logger.warning("Export preview HealthKit fetch failed for date=\(date, privacy: .public): \(error.localizedDescription, privacy: .public)")
+                        return nil
+                    }
                 }
             )
         }

--- a/HealthMd/iPad/iPadHistoryView.swift
+++ b/HealthMd/iPad/iPadHistoryView.swift
@@ -148,6 +148,25 @@ struct iPadHistoryView: View {
                         .iPadLiquidGlass()
                     }
 
+                    if !entry.partialFailures.isEmpty {
+                        VStack(alignment: .leading, spacing: 10) {
+                            iPadBrandLabel("Partial Export Warnings")
+                            ForEach(Array(entry.partialFailures.enumerated()), id: \.offset) { _, failure in
+                                HStack(alignment: .top, spacing: 6) {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .foregroundStyle(Color.orange)
+                                        .font(.caption)
+                                    Text(failure.summary)
+                                        .font(.system(size: 11, weight: .regular, design: .monospaced))
+                                        .foregroundStyle(Color.textMuted)
+                                }
+                            }
+                        }
+                        .padding(16)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .iPadLiquidGlass()
+                    }
+
                     if !entry.failedDateDetails.isEmpty {
                         VStack(alignment: .leading, spacing: 10) {
                             iPadBrandLabel("Failed Dates")

--- a/HealthMd/macOS/Views/MacExportView.swift
+++ b/HealthMd/macOS/Views/MacExportView.swift
@@ -572,10 +572,13 @@ struct MacExportView: View {
                 }
             } else if result.isPartialSuccess {
                 resultIsError = false
+                let suffix = result.hasPartialFailures
+                    ? result.partialFailureSummary
+                    : String(localized: "Some dates had no synced data.", comment: "Partial export no synced data suffix")
                 if result.formatsPerDate > 1 {
-                    resultMessage = String(localized: "Exported \(result.totalFilesWritten) files (\(result.successCount) of \(result.totalCount) days × \(result.formatsPerDate) formats). Some dates had no synced data.", comment: "Multi-format partial export message")
+                    resultMessage = String(localized: "Exported \(result.totalFilesWritten) files (\(result.successCount) of \(result.totalCount) days × \(result.formatsPerDate) formats). \(suffix)", comment: "Multi-format partial export message")
                 } else {
-                    resultMessage = String(localized: "Exported \(result.successCount) of \(result.totalCount) files. Some dates had no synced data.", comment: "Partial export message")
+                    resultMessage = String(localized: "Exported \(result.successCount) of \(result.totalCount) files. \(suffix)", comment: "Partial export message")
                 }
             } else {
                 resultIsError = true

--- a/HealthMd/macOS/Views/MacHistoryView.swift
+++ b/HealthMd/macOS/Views/MacHistoryView.swift
@@ -169,6 +169,25 @@ struct MacHistoryView: View {
                         .brandGlassCard(tintOpacity: 0.02)
                     }
 
+                    if !entry.partialFailures.isEmpty {
+                        VStack(alignment: .leading, spacing: 10) {
+                            BrandLabel("Partial Export Warnings")
+                            ForEach(Array(entry.partialFailures.enumerated()), id: \.offset) { _, failure in
+                                HStack(alignment: .top, spacing: 6) {
+                                    Image(systemName: "exclamationmark.triangle.fill")
+                                        .foregroundStyle(Color.orange)
+                                        .font(.caption)
+                                    Text(failure.summary)
+                                        .font(BrandTypography.caption())
+                                        .foregroundStyle(Color.textMuted)
+                                }
+                            }
+                        }
+                        .padding(16)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .brandGlassCard(tintOpacity: 0.02)
+                    }
+
                     if !entry.failedDateDetails.isEmpty {
                         VStack(alignment: .leading, spacing: 10) {
                             BrandLabel("Failed Dates")

--- a/HealthMdTests/Managers/ExportOrchestratorTests.swift
+++ b/HealthMdTests/Managers/ExportOrchestratorTests.swift
@@ -90,6 +90,28 @@ final class ExportOrchestratorTests: XCTestCase {
         XCTAssertEqual(result.primaryFailureReason, .noHealthData)
     }
 
+    func testExportResult_partialMetricFailures_warnWithoutFailedDates() {
+        let result = ExportOrchestrator.ExportResult(
+            successCount: 1,
+            totalCount: 1,
+            failedDateDetails: [],
+            partialFailures: [
+                ExportPartialFailure(
+                    date: makeDate(2026, 3, 15),
+                    dataType: "workouts",
+                    dateRangeDescription: "2026-03-15 00:00:00 - 2026-03-15 23:59:59",
+                    errorDescription: "HealthKit query failed"
+                )
+            ]
+        )
+
+        XCTAssertFalse(result.isFullSuccess)
+        XCTAssertTrue(result.isPartialSuccess)
+        XCTAssertFalse(result.isFailure)
+        XCTAssertTrue(result.partialFailureSummary.contains("workouts"))
+        XCTAssertTrue(result.partialFailureSummary.contains("2026-03-15"))
+    }
+
     func testExportResult_totalFailure() {
         let result = ExportOrchestrator.ExportResult(
             successCount: 0,

--- a/HealthMdTests/Managers/HealthKitManagerTests.swift
+++ b/HealthMdTests/Managers/HealthKitManagerTests.swift
@@ -145,6 +145,10 @@ final class HealthKitManagerFetchTests: XCTestCase {
         // Other categories should still have data
         XCTAssertEqual(data.activity.steps, 12500)
         XCTAssertEqual(data.heart.averageHeartRate, 72)
+        XCTAssertEqual(data.partialFailures.count, 1)
+        XCTAssertEqual(data.partialFailures.first?.dataType, "sleep")
+        XCTAssertTrue(data.partialFailures.first?.dateRangeDescription.contains("2026-03-15") ?? false)
+        XCTAssertTrue(data.partialFailures.first?.errorDescription.isEmpty == false)
     }
 
     @MainActor
@@ -192,6 +196,9 @@ final class HealthKitManagerFetchTests: XCTestCase {
         XCTAssertNil(data.mobility.walkingSpeed)
         XCTAssertNil(data.hearing.headphoneAudioLevel)
         XCTAssertTrue(data.workouts.isEmpty)
+        XCTAssertFalse(data.partialFailures.isEmpty)
+        XCTAssertTrue(data.partialFailures.contains { $0.dataType == "sleep" })
+        XCTAssertTrue(data.partialFailures.contains { $0.dataType == "workouts" })
     }
 
     @MainActor

--- a/HealthMdTests/Models/ExportHistoryTests.swift
+++ b/HealthMdTests/Models/ExportHistoryTests.swift
@@ -41,6 +41,30 @@ final class ExportHistoryTests: XCTestCase {
         XCTAssertTrue(entry.summaryDescription.contains("5"))
     }
 
+    func testEntry_partialMetricFailure_isPartialAndSummarizesWarning() {
+        let entry = ExportHistoryEntry(
+            source: .manual,
+            success: true,
+            dateRangeStart: Date(),
+            dateRangeEnd: Date(),
+            successCount: 1,
+            totalCount: 1,
+            partialFailures: [
+                ExportPartialFailure(
+                    date: Date(),
+                    dataType: "workouts",
+                    dateRangeDescription: "2026-03-15 00:00:00 - 2026-03-15 23:59:59",
+                    errorDescription: "HealthKit query failed"
+                )
+            ]
+        )
+
+        XCTAssertFalse(entry.isFullSuccess)
+        XCTAssertTrue(entry.isPartialSuccess)
+        XCTAssertTrue(entry.summaryDescription.contains("warning"))
+        XCTAssertTrue(entry.partialFailureSummary?.contains("workouts") ?? false)
+    }
+
     func testEntry_failure() {
         let entry = ExportHistoryEntry(
             source: .manual,
@@ -85,6 +109,31 @@ final class ExportHistoryTests: XCTestCase {
         XCTAssertEqual(decoded.success, entry.success)
         XCTAssertEqual(decoded.successCount, entry.successCount)
         XCTAssertEqual(decoded.totalCount, entry.totalCount)
+    }
+
+    func testEntry_codablePreservesPartialFailures() throws {
+        let entry = ExportHistoryEntry(
+            source: .manual,
+            success: true,
+            dateRangeStart: Date(),
+            dateRangeEnd: Date(),
+            successCount: 1,
+            totalCount: 1,
+            partialFailures: [
+                ExportPartialFailure(
+                    date: Date(),
+                    dataType: "sleep",
+                    dateRangeDescription: "2026-03-15 00:00:00 - 2026-03-15 23:59:59",
+                    errorDescription: "Protected data unavailable"
+                )
+            ]
+        )
+
+        let data = try JSONEncoder().encode(entry)
+        let decoded = try JSONDecoder().decode(ExportHistoryEntry.self, from: data)
+
+        XCTAssertEqual(decoded.partialFailures, entry.partialFailures)
+        XCTAssertTrue(decoded.isPartialSuccess)
     }
 
     // MARK: - ExportSource


### PR DESCRIPTION
Closes CodyBontecou/health-md#39

Implemented by Symphony agent automation.

## Issue

https://github.com/CodyBontecou/health-md/issues/39

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 44
Videos: 6
Other artifacts: 6

### .symphony/qa-artifacts/01-export-tab-initial.png

![.symphony/qa-artifacts/01-export-tab-initial.png](https://imghost.isolated.tech/c1ea8cc9.png)

### .symphony/qa-artifacts/01-system-alert-not-now.png

![.symphony/qa-artifacts/01-system-alert-not-now.png](https://imghost.isolated.tech/d56d0cc8.png)

### .symphony/qa-artifacts/02-export-ready.png

![.symphony/qa-artifacts/02-export-ready.png](https://imghost.isolated.tech/3f28b09a.png)

### .symphony/qa-artifacts/02-export-tab-ready.png

![.symphony/qa-artifacts/02-export-tab-ready.png](https://imghost.isolated.tech/09dac628.png)

### .symphony/qa-artifacts/03-after-permission-prompts.png

![.symphony/qa-artifacts/03-after-permission-prompts.png](https://imghost.isolated.tech/64f338da.png)

### .symphony/qa-artifacts/03-preview-no-warnings.png

![.symphony/qa-artifacts/03-preview-no-warnings.png](https://imghost.isolated.tech/b4f65b5a.png)

### .symphony/qa-artifacts/04-export-tab-returned.png

![.symphony/qa-artifacts/04-export-tab-returned.png](https://imghost.isolated.tech/d60758a3.png)

### .symphony/qa-artifacts/04-preview-reopened.png

![.symphony/qa-artifacts/04-preview-reopened.png](https://imghost.isolated.tech/1c0341c7.png)

### .symphony/qa-artifacts/05-confirmation.png

![.symphony/qa-artifacts/05-confirmation.png](https://imghost.isolated.tech/96d11316.png)

### .symphony/qa-artifacts/05-export-confirmation-or-status.png

![.symphony/qa-artifacts/05-export-confirmation-or-status.png](https://imghost.isolated.tech/8b43224e.png)

### .symphony/qa-artifacts/06-export-tab-after-map.png

![.symphony/qa-artifacts/06-export-tab-after-map.png](https://imghost.isolated.tech/9c213f53.png)

### .symphony/qa-artifacts/06-partial-export-shows-success.png

![.symphony/qa-artifacts/06-partial-export-shows-success.png](https://imghost.isolated.tech/e0c21ad5.png)

### .symphony/qa-artifacts/07-after-back-from-map.png

![.symphony/qa-artifacts/07-after-back-from-map.png](https://imghost.isolated.tech/8e4a56fb.png)

### .symphony/qa-artifacts/07-seeded-export-tab.png

![.symphony/qa-artifacts/07-seeded-export-tab.png](https://imghost.isolated.tech/857bc50a.png)

### .symphony/qa-artifacts/08-relaunch-healthmd.png

![.symphony/qa-artifacts/08-relaunch-healthmd.png](https://imghost.isolated.tech/7965e62f.png)

### .symphony/qa-artifacts/08-seeded-history-row.png

![.symphony/qa-artifacts/08-seeded-history-row.png](https://imghost.isolated.tech/f578cc83.png)

### .symphony/qa-artifacts/09-export-confirmation.png

![.symphony/qa-artifacts/09-export-confirmation.png](https://imghost.isolated.tech/d5149b75.png)

### .symphony/qa-artifacts/09-seeded-warning-detail.png

![.symphony/qa-artifacts/09-seeded-warning-detail.png](https://imghost.isolated.tech/490f954f.png)

### .symphony/qa-artifacts/10-export-confirmation-sheet.png

![.symphony/qa-artifacts/10-export-confirmation-sheet.png](https://imghost.isolated.tech/c0ed8e0d.png)

### .symphony/qa-artifacts/10-seeded-warning-detail-warning.png

![.symphony/qa-artifacts/10-seeded-warning-detail-warning.png](https://imghost.isolated.tech/f4bab07c.png)

- ...and 36 more artifact(s)

<details>
<summary>QA report</summary>

# QA Report: GitHub Issue #39

## Result

Pass with limitations.

The implementation records partial HealthKit/export failures, logs affected data type plus date range, preserves successful data when unrelated fetches fail, and surfaces partial warnings in export history. Focused tests passed, and the iOS simulator displayed the seeded partial-warning history row and detail view.

## Simulator / Device

- iPhone 17 Pro simulator, iOS 26.3.1
- Bundle: `com.codybontecou.obsidianhealth`
- Build products: `.symphony/DerivedData`

## Mocked Data Setup

- Used app UI-test mode only with local simulator state:
  - `--uitesting`
  - `UITEST_HEALTH_AUTHORIZED=true`
  - `UITEST_VAULT_SELECTED=true`
  - `UITEST_PURCHASE_UNLOCKED=true`
- Seeded `UserDefaults` key `exportHistory` with local JSON fixture `seed-export-history.json`.
- Fixture represented one successful manual export with one partial failure:
  - data type: `workouts`
  - date range: `2026-03-15 00:00:00 - 2026-03-15 23:59:59`
  - error: `QA fixture HealthKit query failed`
- No production APIs, production auth, real user data, StoreKit purchase, Apple Account sign-in, or Settings flows were used.

## Steps Performed

1. Inspected changed files and confirmed new/changed feature scope:
   - `ExportPartialFailure` added to `HealthData`.
   - `HealthKitManager.fetchHealthData` records non-lock category/workout fetch failures into `partialFailures` and logs data type/date range/error.
   - `ExportOrchestrator.ExportResult` carries partial failures and treats otherwise successful exports as partial.
   - Export history, preview, iOS/iPad/macOS export status, and App Intent result text now consume partial warnings.
2. Ran focused tests on iPhone 17 Pro simulator:
   - `HealthKitManagerFetchTests`
   - `ExportOrchestratorTests`
   - `ExportHistoryTests`
3. Built and launched the iOS app on the simulator.
4. Dismissed the Apple Account system sign-in alert with `Cancel`.
5. Opened Export tab to verify mocked Health and vault ready state.
6. Opened Schedule tab and verified the seeded export-history row showed `Partial: 1 metric warning(s)`.
7. Opened export details and verified `Partial Export Warnings` listed the `workouts` failure with date range and error text.
8. Captured screenshots and a screen recording of the warning flow.

## Verification

- Focused tests: passed, 36 tests, 0 failures.
- `git diff --check`: passed.
- Test log showed warning context, including `HealthKit export fetch failed for sleep dateRange=2026-03-15 00:00:00 - 2026-03-15 23:59:59`.
- Simulator UI showed:
  - history row: `Partial: 1 metric warning(s)`
  - detail status: `Partial`
  - detail warning: `workouts for 2026-03-15 00:00:00 - 2026-03-15 23:59:59: QA fixture HealthKit query failed`

## Artifacts

- `seed-export-history.json`
- `export-tab-seeded.png`
- `schedule-history-partial-row.png`
- `history-detail-partial-warning.png`
- `history-detail-partial-warning-recorded.png`
- `partial-warning-history-flow.mp4` (10.68 seconds)

## Limitations / Follow-up

- A simulator Apple Account sign-in alert appeared on launch and was dismissed with `Cancel`.
- The current `simulateTestExport()` UI-test path documents `UITEST_EXPORT_RESULT=partial` but still treats non-`fail` values as success. I validated the warning surface with seeded local history and validated fetch/orchestrator behavior through focused tests, but a direct mocked manual-export partial toast cannot be exercised without extending the test harness.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
