### PR TITLE
Fix #38: Label remaining icons and hide decorative blur/glow copies

### DIFF
--- a/HealthMd/Shared/Views/ExportPreviewView.swift
+++ b/HealthMd/Shared/Views/ExportPreviewView.swift
@@ -72,6 +72,7 @@ struct ExportPreviewView: View {
             Image(systemName: "doc.text.magnifyingglass")
                 .font(.system(size: 40))
                 .foregroundStyle(Color.textMuted)
+                .accessibilityHidden(true)
             Text("No data to preview")
                 .font(.body.weight(.semibold))
                 .foregroundStyle(Color.textPrimary)
@@ -151,6 +152,7 @@ struct ExportPreviewView: View {
                     HStack(alignment: .top, spacing: 6) {
                         Image(systemName: "info.circle")
                             .font(.system(size: 11))
+                            .accessibilityHidden(true)
                         Text("Previewing the \(datePreviews.count) most recent day\(datePreviews.count == 1 ? "" : "s") with data. The full export will run on every selected date.")
                             .font(.caption)
                     }
@@ -173,7 +175,9 @@ struct ExportPreviewView: View {
                         Text("Daily-note injection updates one note per day")
                             .font(.footnote)
                     } icon: {
-                        Image(systemName: "note.text.badge.plus").foregroundStyle(Color.accent)
+                        Image(systemName: "note.text.badge.plus")
+                            .foregroundStyle(Color.accent)
+                            .accessibilityHidden(true)
                     }
                 }
                 if individual {
@@ -181,7 +185,9 @@ struct ExportPreviewView: View {
                         Text("Individual entry files for tracked metrics")
                             .font(.footnote)
                     } icon: {
-                        Image(systemName: "doc.on.doc").foregroundStyle(Color.accent)
+                        Image(systemName: "doc.on.doc")
+                            .foregroundStyle(Color.accent)
+                            .accessibilityHidden(true)
                     }
                 }
             }
@@ -197,6 +203,7 @@ struct ExportPreviewView: View {
                 .foregroundStyle(Color.accent)
                 .frame(width: 28, height: 28)
                 .background(Circle().fill(Color.accentSubtle))
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(file.filename)

--- a/HealthMd/iOS/Components/AnimatedButton.swift
+++ b/HealthMd/iOS/Components/AnimatedButton.swift
@@ -39,6 +39,7 @@ struct PrimaryButton: View {
                 } else {
                     Image(systemName: icon)
                         .font(.system(size: 16, weight: .semibold))
+                        .accessibilityHidden(true)
                 }
 
                 Text(LocalizedStringKey(isLoading ? "Exporting..." : title))
@@ -103,6 +104,7 @@ struct SecondaryButton: View {
                 if let icon {
                     Image(systemName: icon)
                         .font(.system(size: 13, weight: .medium))
+                        .accessibilityHidden(true)
                 }
                 Text(LocalizedStringKey(title))
                     .font(.subheadline.weight(.medium))
@@ -176,6 +178,7 @@ struct IconButton: View {
                         .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
                 )
                 .scaleEffect(isPressed ? 0.95 : 1.0)
+                .accessibilityHidden(true)
         }
         .buttonStyle(.plain)
         .onLongPressGesture(minimumDuration: .infinity, pressing: { pressing in

--- a/HealthMd/iOS/Components/ExportModal.swift
+++ b/HealthMd/iOS/Components/ExportModal.swift
@@ -36,6 +36,7 @@ struct ExportModal: View {
                                     Image(systemName: "folder")
                                         .font(.system(size: 15, weight: .medium))
                                         .foregroundStyle(Color.accent)
+                                        .accessibilityHidden(true)
 
                                     Text(subfolder.isEmpty ? "Health" : subfolder)
                                         .font(Typography.bodyMono())
@@ -46,6 +47,7 @@ struct ExportModal: View {
                                     Image(systemName: "chevron.right")
                                         .font(.system(size: 13, weight: .semibold))
                                         .foregroundStyle(Color.textMuted)
+                                        .accessibilityHidden(true)
                                 }
                                 .padding(.horizontal, Spacing.md)
                                 .padding(.vertical, Spacing.md)
@@ -81,6 +83,7 @@ struct ExportModal: View {
                                     Image(systemName: "folder.badge.gearshape")
                                         .font(.system(size: 15, weight: .medium))
                                         .foregroundStyle(Color.accent)
+                                        .accessibilityHidden(true)
 
                                     Text(LocalizedStringKey(folderStructureDisplayText))
                                         .font(Typography.bodyMono())
@@ -91,6 +94,7 @@ struct ExportModal: View {
                                     Image(systemName: "chevron.right")
                                         .font(.system(size: 13, weight: .semibold))
                                         .foregroundStyle(Color.textMuted)
+                                        .accessibilityHidden(true)
                                 }
                                 .padding(.horizontal, Spacing.md)
                                 .padding(.vertical, Spacing.md)
@@ -211,6 +215,7 @@ struct ExportModal: View {
                                         Image(systemName: "arrow.right.circle.fill")
                                             .font(.system(size: 16, weight: .medium))
                                             .foregroundStyle(Color.accent)
+                                            .accessibilityHidden(true)
                                     }
 
                                     Text(exportPath)
@@ -224,6 +229,7 @@ struct ExportModal: View {
                                     Image(systemName: "pencil.circle.fill")
                                         .font(.system(size: 18, weight: .medium))
                                         .foregroundStyle(Color.textMuted)
+                                        .accessibilityHidden(true)
                                 }
                                 .padding(.horizontal, Spacing.md)
                                 .padding(.vertical, Spacing.md)
@@ -400,12 +406,15 @@ struct FilenameFormatEditor: View {
                                 Image(systemName: "doc.text")
                                     .font(.system(size: 15, weight: .medium))
                                     .foregroundStyle(Color.accent)
+                                    .accessibilityHidden(true)
 
                                 TextField("{date}", text: $tempFormat)
                                     .font(Typography.bodyMono())
                                     .foregroundStyle(Color.textPrimary)
                                     .textInputAutocapitalization(.never)
                                     .autocorrectionDisabled()
+                                    .accessibilityLabel("Filename format")
+                                    .accessibilityHint("Use placeholders like date, year, or month")
                             }
                             .padding(.horizontal, Spacing.md)
                             .padding(.vertical, Spacing.md)
@@ -492,6 +501,7 @@ struct FilenameFormatEditor: View {
                         } label: {
                             HStack {
                                 Image(systemName: "arrow.counterclockwise")
+                                    .accessibilityHidden(true)
                                 Text("Reset to Default")
                             }
                             .font(.system(size: 14, weight: .medium))
@@ -504,6 +514,8 @@ struct FilenameFormatEditor: View {
                             )
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Reset filename format to default")
+                        .accessibilityHint("Restores the default date-based filename")
 
                         Spacer()
                     }
@@ -635,6 +647,7 @@ struct FolderStructureEditor: View {
                                                 Image(systemName: "checkmark.circle.fill")
                                                     .font(.system(size: 18, weight: .medium))
                                                     .foregroundStyle(Color.accent)
+                                                    .accessibilityHidden(true)
                                             }
                                         }
                                         .padding(.horizontal, Spacing.md)
@@ -673,12 +686,15 @@ struct FolderStructureEditor: View {
                                 Image(systemName: "folder.badge.gearshape")
                                     .font(.system(size: 15, weight: .medium))
                                     .foregroundStyle(Color.accent)
+                                    .accessibilityHidden(true)
 
                                 TextField("e.g. {year}/{month}", text: $tempStructure)
                                     .font(Typography.bodyMono())
                                     .foregroundStyle(Color.textPrimary)
                                     .textInputAutocapitalization(.never)
                                     .autocorrectionDisabled()
+                                    .accessibilityLabel("Custom folder structure")
+                                    .accessibilityHint("Use placeholders to organize exports into dated folders")
                             }
                             .padding(.horizontal, Spacing.md)
                             .padding(.vertical, Spacing.md)
@@ -889,6 +905,7 @@ struct SubfolderEditor: View {
                                                 Image(systemName: "checkmark.circle.fill")
                                                     .font(.system(size: 18, weight: .medium))
                                                     .foregroundStyle(Color.accent)
+                                                    .accessibilityHidden(true)
                                             }
                                         }
                                         .padding(.horizontal, Spacing.md)
@@ -927,12 +944,14 @@ struct SubfolderEditor: View {
                                 Image(systemName: "folder")
                                     .font(.system(size: 15, weight: .medium))
                                     .foregroundStyle(Color.accent)
+                                    .accessibilityHidden(true)
 
                                 TextField("Health", text: $tempSubfolder)
                                     .font(Typography.bodyMono())
                                     .foregroundStyle(Color.textPrimary)
                                     .textInputAutocapitalization(.never)
                                     .autocorrectionDisabled()
+                                    .accessibilityLabel("Custom export folder name")
                             }
                             .padding(.horizontal, Spacing.md)
                             .padding(.vertical, Spacing.md)
@@ -984,6 +1003,7 @@ struct SubfolderEditor: View {
                                 Image(systemName: "info.circle")
                                     .font(.system(size: 15, weight: .medium))
                                     .foregroundStyle(Color.accent)
+                                    .accessibilityHidden(true)
 
                                 Text("This folder will be created inside your selected export location. Leave empty to export directly to the root folder.")
                                     .font(.system(size: 13, weight: .regular))
@@ -1095,6 +1115,7 @@ struct IndividualTrackingExportPreview: View {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundStyle(Color.orange)
+                            .accessibilityHidden(true)
                         
                         Text("No individual entries will be created")
                             .font(.system(size: 13, weight: .medium))
@@ -1123,6 +1144,7 @@ struct IndividualTrackingExportPreview: View {
                         Image(systemName: "doc.on.doc")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundStyle(Color.accent)
+                            .accessibilityHidden(true)
                         
                         Text("Will create individual files for:")
                             .font(.system(size: 13, weight: .medium))
@@ -1137,6 +1159,7 @@ struct IndividualTrackingExportPreview: View {
                                     .font(.system(size: 11))
                                     .foregroundStyle(Color.accent.opacity(0.8))
                                     .frame(width: 16)
+                                    .accessibilityHidden(true)
                                 
                                 Text(category.rawValue)
                                     .font(.system(size: 12, weight: .medium))
@@ -1155,6 +1178,7 @@ struct IndividualTrackingExportPreview: View {
                         Image(systemName: "folder")
                             .font(.system(size: 11))
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                         
                         Text(folderPreview)
                             .font(.system(size: 11, weight: .regular, design: .monospaced))

--- a/HealthMd/iOS/Components/LiquidGlassNavBar.swift
+++ b/HealthMd/iOS/Components/LiquidGlassNavBar.swift
@@ -86,6 +86,7 @@ struct TabButton: View {
             VStack(spacing: 4) {
                 Image(systemName: isSelected ? tab.selectedIcon : tab.icon)
                     .font(.system(size: 22, weight: .medium))
+                    .accessibilityHidden(true)
 
                 Text(LocalizedStringKey(tab.label))
                     .font(.system(size: 11, weight: .medium))

--- a/HealthMd/iOS/Components/SectionCard.swift
+++ b/HealthMd/iOS/Components/SectionCard.swift
@@ -16,6 +16,7 @@ struct CompactStatusBadge: View {
             HStack(spacing: Spacing.sm) {
                 Image(systemName: icon)
                     .font(.system(size: 15, weight: .medium))
+                    .accessibilityHidden(true)
 
                 Text(LocalizedStringKey(title))
                     .font(.footnote.weight(.medium))
@@ -28,10 +29,12 @@ struct CompactStatusBadge: View {
                         .frame(width: 8, height: 8)
                         .blur(radius: isConnected ? 4 : 0)
                         .opacity(isConnected ? 0.6 : 0)
+                        .accessibilityHidden(true)
 
                     Circle()
                         .fill(isConnected ? Color.success : Color.textMuted)
                         .frame(width: 8, height: 8)
+                        .accessibilityHidden(true)
                 }
             }
             .foregroundStyle(isConnected ? Color.textPrimary : Color.textSecondary)
@@ -145,6 +148,7 @@ struct VaultSelectionCard: View {
                                 Image(systemName: "folder.fill")
                                     .font(.system(size: 12))
                                     .foregroundStyle(Color.accent)
+                                    .accessibilityHidden(true)
 
                                 Text(vaultName)
                                     .font(Typography.caption())
@@ -205,6 +209,7 @@ struct ExportSettingsCard: View {
                             Circle()
                                 .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
                         )
+                        .accessibilityHidden(true)
 
                     Text("Export Settings")
                         .font(.headline)
@@ -222,6 +227,7 @@ struct ExportSettingsCard: View {
                         Image(systemName: "folder")
                             .font(.system(size: 15, weight: .medium))
                             .foregroundStyle(Color.accent)
+                            .accessibilityHidden(true)
 
                         TextField("Health", text: $subfolder)
                             .font(Typography.bodyMono())
@@ -317,6 +323,7 @@ struct ExportSettingsCard: View {
 
                         Image(systemName: "arrow.right.circle.fill")
                             .foregroundStyle(Color.accent)
+                            .accessibilityHidden(true)
                     }
                     .font(.system(size: 14, weight: .medium))
 

--- a/HealthMd/iOS/Components/StatusIndicator.swift
+++ b/HealthMd/iOS/Components/StatusIndicator.swift
@@ -73,6 +73,7 @@ struct PulsingHeartIcon: View {
                     .foregroundStyle(Color.accent)
                     .blur(radius: 8)
                     .opacity(0.6)
+                    .accessibilityHidden(true)
             }
 
             // Main icon
@@ -174,6 +175,7 @@ struct ExportStatusBadge: View {
                             .opacity(0.6)
                     }
                 }
+                .accessibilityHidden(true)
 
                 Group {
                     switch status {
@@ -185,6 +187,7 @@ struct ExportStatusBadge: View {
                             .foregroundStyle(Color.error)
                     }
                 }
+                .accessibilityHidden(true)
             }
             .font(.system(size: 18, weight: .medium))
 
@@ -199,6 +202,7 @@ struct ExportStatusBadge: View {
                     HStack(spacing: 3) {
                         Image(systemName: "folder.fill")
                             .font(.system(size: 10, weight: .medium))
+                            .accessibilityHidden(true)
                         Text("Open in Files")
                             .font(.caption.weight(.medium))
                     }

--- a/HealthMd/iOS/ContentView.swift
+++ b/HealthMd/iOS/ContentView.swift
@@ -621,6 +621,7 @@ struct DiscordPromoBanner: View {
                     Circle()
                         .fill(Color.accentSubtle)
                 )
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text("Join the community")
@@ -655,6 +656,7 @@ struct DiscordPromoBanner: View {
                         Circle()
                             .fill(Color.white.opacity(0.06))
                     )
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Dismiss Discord banner")
@@ -669,8 +671,7 @@ struct DiscordPromoBanner: View {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
         )
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Join the Health.md Discord community.")
+        .accessibilityElement(children: .contain)
     }
 }
 
@@ -748,6 +749,7 @@ struct SettingsTabView: View {
                             Circle()
                                 .strokeBorder(Color.white.opacity(0.15), lineWidth: 1)
                         )
+                        .accessibilityHidden(true)
 
                     VStack(spacing: Spacing.xs) {
                         Text("CONFIGURE")
@@ -903,6 +905,7 @@ struct SettingsRow: View {
                     Image(systemName: icon)
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(isActive ? Color.accent : Color.textMuted)
+                        .accessibilityHidden(true)
                 }
                 .frame(width: 36, height: 36)
                 .background(
@@ -929,6 +932,7 @@ struct SettingsRow: View {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 13, weight: .semibold))
                     .foregroundStyle(Color.textMuted)
+                    .accessibilityHidden(true)
             }
             .padding(.horizontal, Spacing.md + 4)
             .padding(.vertical, Spacing.md)

--- a/HealthMd/iOS/Views/DailyNoteInjectionView.swift
+++ b/HealthMd/iOS/Views/DailyNoteInjectionView.swift
@@ -73,6 +73,7 @@ struct DailyNoteInjectionView: View {
                             Image(systemName: "doc.text")
                                 .font(.caption2)
                                 .foregroundColor(Color.accent)
+                                .accessibilityHidden(true)
                             Text(settings.previewPath(for: Date(), healthSubfolder: healthSubfolder))
                                 .font(.caption.monospaced())
                                 .foregroundColor(Color.accent)
@@ -119,6 +120,7 @@ struct DailyNoteInjectionView: View {
                         Spacer()
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(enabledMetricCount > 0 ? Color.accent : Color.textMuted)
+                            .accessibilityHidden(true)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("Metrics to inject: \(enabledMetricCount) enabled")

--- a/HealthMd/iOS/Views/ExportTabView.swift
+++ b/HealthMd/iOS/Views/ExportTabView.swift
@@ -297,6 +297,7 @@ struct ExportTabView: View {
                     HStack(spacing: Spacing.xs) {
                         Image(systemName: "exclamationmark.triangle.fill")
                             .font(.system(size: 12))
+                            .accessibilityHidden(true)
                         Text("Select at least one export format.")
                             .font(.footnote.weight(.medium))
                     }
@@ -456,12 +457,14 @@ struct ExportTabView: View {
                 ZStack {
                     Image(systemName: "arrow.right.circle.fill")
                         .foregroundStyle(Color.accent)
+                        .accessibilityHidden(true)
                         .blur(radius: 4)
                         .opacity(0.5)
                         .accessibilityHidden(true)
 
                     Image(systemName: "arrow.right.circle.fill")
                         .foregroundStyle(Color.accent)
+                        .accessibilityHidden(true)
                 }
                 .font(.system(size: 16, weight: .medium))
 
@@ -544,6 +547,7 @@ struct ExportTabView: View {
                 } else {
                     Image(systemName: "arrow.up")
                         .font(.system(size: 13, weight: .semibold))
+                        .accessibilityHidden(true)
                 }
                 Text(LocalizedStringKey(isExporting ? "Exporting…" : "Review"))
                     .font(.callout.weight(.semibold))
@@ -567,6 +571,7 @@ struct ExportTabView: View {
             HStack(spacing: 6) {
                 Image(systemName: "eye")
                     .font(.system(size: 13, weight: .semibold))
+                    .accessibilityHidden(true)
                 Text("Preview")
                     .font(.callout.weight(.semibold))
                     .tracking(0.4)
@@ -626,6 +631,7 @@ struct ExportTabView: View {
                 .blur(radius: 16)
                 .opacity(shouldPulse ? (pearlPulse ? 0.45 : 0.22) : 0.18)
                 .scaleEffect(shouldPulse && pearlPulse ? 1.14 : 1.0)
+                .accessibilityHidden(true)
 
             // The pearl itself — a tinted dome with specular highlight
             Circle()
@@ -658,10 +664,12 @@ struct ExportTabView: View {
                 ProgressView()
                     .progressViewStyle(CircularProgressViewStyle(tint: iconColor))
                     .scaleEffect(0.6)
+                    .accessibilityHidden(true)
             } else {
                 Image(systemName: icon)
                     .font(.system(size: 12, weight: .heavy))
                     .foregroundStyle(iconColor)
+                    .accessibilityHidden(true)
             }
         }
         .frame(width: 38, height: 38)
@@ -756,6 +764,7 @@ struct ExportTabView: View {
                 .frame(width: 32, height: 32)
                 .background(Circle().fill(.ultraThinMaterial))
                 .overlay(Circle().strokeBorder(Color.white.opacity(0.1), lineWidth: 1))
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 8) {
@@ -786,11 +795,13 @@ struct ExportTabView: View {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(Color.accent)
                     .font(.system(size: 16))
+                    .accessibilityHidden(true)
             }
 
             Image(systemName: "chevron.right")
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(Color.textMuted)
+                .accessibilityHidden(true)
         }
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.md)
@@ -813,6 +824,7 @@ struct ExportTabView: View {
                 .frame(width: 32, height: 32)
                 .background(Circle().fill(.ultraThinMaterial))
                 .overlay(Circle().strokeBorder(Color.white.opacity(0.1), lineWidth: 1))
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 3) {
                 Text(LocalizedStringKey(title))
@@ -831,6 +843,7 @@ struct ExportTabView: View {
             Image(systemName: "pencil.circle.fill")
                 .font(.system(size: 18, weight: .medium))
                 .foregroundStyle(Color.textMuted)
+                .accessibilityHidden(true)
         }
         .padding(.horizontal, Spacing.md)
         .padding(.vertical, Spacing.md)

--- a/HealthMd/iOS/Views/FormatCustomizationView.swift
+++ b/HealthMd/iOS/Views/FormatCustomizationView.swift
@@ -400,6 +400,7 @@ struct FrontmatterCustomizationView: View {
                                     Text(style.displayName)
                                     if config.keyStyle == style {
                                         Image(systemName: "checkmark")
+                                            .accessibilityHidden(true)
                                     }
                                 }
                             }
@@ -410,7 +411,10 @@ struct FrontmatterCustomizationView: View {
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
+                        .accessibilityHidden(true)
                 }
+                .accessibilityLabel("Frontmatter field actions")
+                .accessibilityHint("Opens actions for frontmatter fields and key styles")
             }
         }
         .alert("Add Custom Field", isPresented: $showAddCustomField) {
@@ -530,6 +534,7 @@ struct FrontmatterFieldRow: View {
             }) {
                 Image(systemName: "pencil")
                     .foregroundColor(Color.textMuted)
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Rename \(field.originalKey)")

--- a/HealthMd/iOS/Views/IndividualTrackingView.swift
+++ b/HealthMd/iOS/Views/IndividualTrackingView.swift
@@ -296,6 +296,7 @@ struct CategoryTrackingRow: View {
                         .font(.system(size: 16))
                         .foregroundColor(Color.accent)
                         .frame(width: 24)
+                        .accessibilityHidden(true)
                     
                     Text(LocalizedStringKey(category.rawValue))
                         .font(Typography.body())
@@ -307,9 +308,11 @@ struct CategoryTrackingRow: View {
                     if settings.isCategoryFullyEnabled(category) {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundColor(Color.accent)
+                            .accessibilityHidden(true)
                     } else if settings.isCategoryPartiallyEnabled(category) {
                         Image(systemName: "minus.circle.fill")
                             .foregroundColor(Color.accent.opacity(0.6))
+                            .accessibilityHidden(true)
                     }
                     
                     Text("\(settings.enabledCount(for: category))/\(enabledMetricsInCategory.count)")
@@ -319,10 +322,13 @@ struct CategoryTrackingRow: View {
                     Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundColor(Color.textSecondary)
+                        .accessibilityHidden(true)
                 }
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("\(category.rawValue), \(settings.enabledCount(for: category)) of \(enabledMetricsInCategory.count) individual metrics enabled")
+            .accessibilityHint("Double tap to \(isExpanded ? "collapse" : "expand")")
             
             // Expanded metrics list
             if isExpanded {
@@ -362,6 +368,7 @@ struct MetricTrackingRow: View {
                         Image(systemName: "sparkles")
                             .font(.system(size: 10))
                             .foregroundColor(Color.accent)
+                            .accessibilityHidden(true)
                     }
                 }
                 

--- a/HealthMd/iOS/Views/MetricSelectionView.swift
+++ b/HealthMd/iOS/Views/MetricSelectionView.swift
@@ -47,7 +47,10 @@ struct MetricSelectionView: View {
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
+                        .accessibilityHidden(true)
                 }
+                .accessibilityLabel("Metric actions")
+                .accessibilityHint("Opens actions for selecting or expanding metric groups")
             }
         }
     }
@@ -116,6 +119,7 @@ struct MetricSelectionView: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundColor(.secondary)
+                        .accessibilityHidden(true)
                 }
                 .accessibilityLabel("Clear search")
                 .accessibilityHint("Double tap to clear search text")
@@ -281,12 +285,15 @@ struct MetricSelectionView: View {
         if selectionState.isCategoryFullyEnabled(category) {
             Image(systemName: "checkmark.circle.fill")
                 .foregroundColor(.green)
+                .accessibilityHidden(true)
         } else if selectionState.isCategoryPartiallyEnabled(category) {
             Image(systemName: "minus.circle.fill")
                 .foregroundColor(.orange)
+                .accessibilityHidden(true)
         } else {
             Image(systemName: "circle")
                 .foregroundColor(.secondary)
+                .accessibilityHidden(true)
         }
     }
 

--- a/HealthMd/iOS/Views/OnboardingView.swift
+++ b/HealthMd/iOS/Views/OnboardingView.swift
@@ -123,6 +123,8 @@ struct OnboardingView: View {
                         .font(Typography.bodyEmphasis())
                         .foregroundStyle(Color.textSecondary)
                         .disabled(purchaseManager.isPurchasing || purchaseManager.isRestoring)
+                        .accessibilityLabel("Continue with three free exports")
+                        .accessibilityHint("Skips purchase for now and continues setup")
 
                         Button {
                             Task { await purchaseManager.restore() }
@@ -140,6 +142,8 @@ struct OnboardingView: View {
                         }
                         .buttonStyle(.plain)
                         .disabled(purchaseManager.isPurchasing || purchaseManager.isRestoring)
+                        .accessibilityLabel("Restore purchase")
+                        .accessibilityHint("Checks for a previous Health.md purchase")
                     } else {
                         PrimaryButton(
                             currentStep == totalSteps - 1 ? "Get Started" : "Continue",
@@ -335,6 +339,7 @@ private struct WelcomeStep: View {
                             )
                     )
                     .shadow(color: Color.accent.opacity(0.4), radius: 24, x: 0, y: 12)
+                    .accessibilityHidden(true)
             }
             .heroEntrance(animateIn)
 
@@ -406,6 +411,7 @@ private struct HealthAccessStep: View {
                     .font(.system(size: 52, weight: .medium))
                     .foregroundStyle(isAuthorized ? Color.accent : Color.textMuted)
                     .contentTransition(.symbolEffect(.replace))
+                    .accessibilityHidden(true)
             }
             .frame(width: 100, height: 100)
             .background(
@@ -462,6 +468,7 @@ private struct HealthAccessStep: View {
                 HStack(spacing: 8) {
                     Image(systemName: "checkmark.circle.fill")
                         .foregroundStyle(Color.success)
+                        .accessibilityHidden(true)
                     Text("Access granted")
                         .font(Typography.bodyEmphasis())
                         .foregroundStyle(Color.success)
@@ -473,6 +480,7 @@ private struct HealthAccessStep: View {
                     HStack(spacing: 8) {
                         Image(systemName: "heart.circle.fill")
                             .font(.system(size: 18))
+                            .accessibilityHidden(true)
                         Text("Grant Access")
                             .font(Typography.bodyEmphasis())
                     }
@@ -490,6 +498,8 @@ private struct HealthAccessStep: View {
                 }
                 .staggerIn(animateIn, index: 6)
                 .padding(.top, Spacing.sm)
+                .accessibilityLabel("Grant Health access")
+                .accessibilityHint("Opens the Apple Health permission request")
             }
         }
         .padding(.horizontal, Spacing.lg)
@@ -521,6 +531,7 @@ private struct FolderSetupStep: View {
                     .font(.system(size: 52, weight: .medium))
                     .foregroundStyle(vaultManager.vaultURL != nil ? Color.accent : Color.textMuted)
                     .contentTransition(.symbolEffect(.replace))
+                    .accessibilityHidden(true)
             }
             .frame(width: 100, height: 100)
             .background(
@@ -557,6 +568,7 @@ private struct FolderSetupStep: View {
                         Image(systemName: "checkmark.circle.fill")
                             .font(.system(size: 20))
                             .foregroundStyle(Color.success)
+                            .accessibilityHidden(true)
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(vaultManager.vaultName)
@@ -586,6 +598,8 @@ private struct FolderSetupStep: View {
                             .font(Typography.bodyEmphasis())
                             .foregroundStyle(Color.accent)
                     }
+                    .accessibilityLabel("Change export folder")
+                    .accessibilityHint("Opens the folder picker")
                 } else {
                     // Suggested locations
                     VStack(spacing: Spacing.sm) {
@@ -611,6 +625,7 @@ private struct FolderSetupStep: View {
                         HStack(spacing: 8) {
                             Image(systemName: "folder.badge.plus")
                                 .font(.system(size: 18))
+                                .accessibilityHidden(true)
                             Text("Select Folder")
                                 .font(Typography.bodyEmphasis())
                         }
@@ -628,6 +643,8 @@ private struct FolderSetupStep: View {
                     }
                     .staggerIn(animateIn, index: 5)
                     .padding(.top, Spacing.xs)
+                    .accessibilityLabel("Select export folder")
+                    .accessibilityHint("Opens the folder picker")
                 }
             }
             .padding(.horizontal, Spacing.sm)
@@ -654,6 +671,7 @@ private struct UnlockStep: View {
                 Image(systemName: "lock.open.fill")
                     .font(.system(size: 52, weight: .medium))
                     .foregroundStyle(Color.accent)
+                    .accessibilityHidden(true)
                     .blur(radius: 20)
                     .breathingGlow()
                     .accessibilityHidden(true)
@@ -661,6 +679,7 @@ private struct UnlockStep: View {
                 Image(systemName: "lock.open.fill")
                     .font(.system(size: 52, weight: .medium))
                     .foregroundStyle(Color.accent)
+                    .accessibilityHidden(true)
             }
             .frame(width: 100, height: 100)
             .background(
@@ -737,6 +756,7 @@ private struct UnlockFeatureRow: View {
                 .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(Color.accent)
                 .frame(width: 28)
+                .accessibilityHidden(true)
 
             Text(text)
                 .font(Typography.body())
@@ -765,6 +785,7 @@ private struct ReadyStep: View {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 56, weight: .medium))
                     .foregroundStyle(Color.success)
+                    .accessibilityHidden(true)
                     .blur(radius: 20)
                     .breathingGlow()
                     .accessibilityHidden(true)
@@ -772,6 +793,7 @@ private struct ReadyStep: View {
                 Image(systemName: "checkmark.circle.fill")
                     .font(.system(size: 56, weight: .medium))
                     .foregroundStyle(Color.success)
+                    .accessibilityHidden(true)
             }
             .frame(width: 100, height: 100)
             .background(
@@ -871,6 +893,7 @@ private struct FeatureRow: View {
                     Circle()
                         .fill(Color.accentSubtle)
                 )
+                .accessibilityHidden(true)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
@@ -898,6 +921,7 @@ private struct DataCategoryRow: View {
                 .font(.system(size: 14, weight: .medium))
                 .foregroundStyle(Color.accent)
                 .frame(width: 28)
+                .accessibilityHidden(true)
 
             Text(label)
                 .font(Typography.bodyEmphasis())
@@ -924,6 +948,7 @@ private struct SuggestionRow: View {
                 .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(recommended ? Color.accent : Color.textSecondary)
                 .frame(width: 28)
+                .accessibilityHidden(true)
 
             Text(label)
                 .font(Typography.body())
@@ -959,6 +984,7 @@ private struct SetupSummaryRow: View {
                 .font(.system(size: 16, weight: .medium))
                 .foregroundStyle(isComplete ? Color.accent : Color.textMuted)
                 .frame(width: 28)
+                .accessibilityHidden(true)
 
             Text(label)
                 .font(Typography.bodyEmphasis())
@@ -975,6 +1001,7 @@ private struct SetupSummaryRow: View {
                     .font(.system(size: 14))
                     .foregroundStyle(isComplete ? Color.success : Color.textMuted)
                     .contentTransition(.symbolEffect(.replace))
+                    .accessibilityHidden(true)
             }
         }
         .padding(.horizontal, Spacing.md)

--- a/HealthMd/iOS/Views/PaywallView.swift
+++ b/HealthMd/iOS/Views/PaywallView.swift
@@ -137,6 +137,7 @@ struct PaywallView: View {
                         Circle()
                             .strokeBorder(Color.white.opacity(0.1), lineWidth: 1)
                     )
+                    .accessibilityHidden(true)
             }
             .buttonStyle(.plain)
             .padding(.top, Spacing.lg)

--- a/HealthMd/iOS/Views/ScheduleSettingsView.swift
+++ b/HealthMd/iOS/Views/ScheduleSettingsView.swift
@@ -584,6 +584,7 @@ struct ExportHistoryRow: View {
                 HStack(spacing: Spacing.xs) {
                     Image(systemName: entry.source.icon)
                         .font(.system(size: 10))
+                        .accessibilityHidden(true)
                     Text(formatTimestamp(entry.timestamp))
                         .font(Typography.caption())
                 }
@@ -659,6 +660,7 @@ struct ExportHistoryDetailView: View {
                         Spacer()
                         HStack(spacing: 4) {
                             Image(systemName: entry.source.icon)
+                                .accessibilityHidden(true)
                             Text(entry.source.rawValue)
                         }
                         .foregroundStyle(Color.textPrimary)

--- a/HealthMd/iOS/Views/SyncSettingsView.swift
+++ b/HealthMd/iOS/Views/SyncSettingsView.swift
@@ -170,12 +170,15 @@ struct SyncSettingsView: View {
         case .connected:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(.green)
+                .accessibilityHidden(true)
         case .connecting:
             ProgressView()
                 .controlSize(.small)
+                .accessibilityHidden(true)
         case .disconnected:
             Image(systemName: "circle.dotted")
                 .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
         }
     }
 

--- a/HealthMd/iPad/iPadContentView.swift
+++ b/HealthMd/iPad/iPadContentView.swift
@@ -162,6 +162,7 @@ struct iPadContentView: View {
             Image(systemName: "heart.text.square")
                 .font(.system(size: 48))
                 .foregroundStyle(Color.accent)
+                .accessibilityHidden(true)
             Text("health.md")
                 .font(.system(size: 22, weight: .semibold, design: .monospaced))
                 .foregroundStyle(Color.textPrimary)

--- a/HealthMd/iPad/iPadExportView.swift
+++ b/HealthMd/iPad/iPadExportView.swift
@@ -37,6 +37,7 @@ struct iPadExportView: View {
                         Circle()
                             .fill(healthKitManager.isAuthorized ? Color.success : Color.textMuted)
                             .frame(width: 10, height: 10)
+                            .accessibilityHidden(true)
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(healthKitManager.isAuthorized
@@ -91,6 +92,7 @@ struct iPadExportView: View {
                             Image(systemName: "folder.fill")
                                 .foregroundStyle(Color.accent)
                                 .font(.system(size: 16))
+                                .accessibilityHidden(true)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(vaultManager.vaultName)
                                     .font(.system(size: 13, weight: .medium, design: .monospaced))
@@ -105,6 +107,7 @@ struct iPadExportView: View {
                             Image(systemName: "folder")
                                 .foregroundStyle(Color.textMuted)
                                 .font(.system(size: 16))
+                                .accessibilityHidden(true)
                             Text("No folder selected")
                                 .font(.system(size: 13, weight: .regular, design: .monospaced))
                                 .foregroundStyle(Color.textMuted)
@@ -177,6 +180,8 @@ struct iPadExportView: View {
                             .labelsHidden()
                             .tint(Color.accent)
                             .disabled(advancedSettings.useRollingDateRange)
+                            .accessibilityLabel("Start date")
+                            .accessibilityHint("Select the first day to export")
                     }
 
                     HStack {
@@ -188,6 +193,8 @@ struct iPadExportView: View {
                             .labelsHidden()
                             .tint(Color.accent)
                             .disabled(advancedSettings.useRollingDateRange)
+                            .accessibilityLabel("End date")
+                            .accessibilityHint("Select the last day to export")
                     }
 
                     if !advancedSettings.useRollingDateRange {
@@ -250,6 +257,7 @@ struct iPadExportView: View {
                         .pickerStyle(.menu)
                         .tint(Color.accent)
                         .frame(width: 180)
+                        .accessibilityLabel("Write mode")
                     }
 
                     HStack {
@@ -287,6 +295,7 @@ struct iPadExportView: View {
                                 HStack(spacing: 4) {
                                     Image(systemName: "stop.fill")
                                         .font(.system(size: 10, weight: .semibold))
+                                        .accessibilityHidden(true)
                                     Text("Stop")
                                         .font(.system(size: 12, weight: .medium, design: .monospaced))
                                 }
@@ -303,6 +312,8 @@ struct iPadExportView: View {
                                 )
                             }
                             .buttonStyle(.plain)
+                            .accessibilityLabel("Stop export")
+                            .accessibilityHint("Cancels the current export")
                         }
 
                         HStack(spacing: 8) {
@@ -325,6 +336,7 @@ struct iPadExportView: View {
                     HStack(spacing: 8) {
                         Image(systemName: "info.circle")
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                         Text(readinessMessage)
                             .font(.system(size: 13, weight: .regular, design: .monospaced))
                             .foregroundStyle(Color.textMuted)
@@ -344,6 +356,7 @@ struct iPadExportView: View {
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: "eye")
+                            .accessibilityHidden(true)
                         Text("Preview")
                             .font(.system(size: 12, weight: .medium, design: .monospaced))
                     }
@@ -359,6 +372,7 @@ struct iPadExportView: View {
                 } label: {
                     HStack(spacing: 6) {
                         Image(systemName: purchaseManager.canExport ? "arrow.up.doc.fill" : "lock.fill")
+                            .accessibilityHidden(true)
                         Text(purchaseManager.canExport ? "Review Export" : "Unlock to Export")
                             .font(.system(size: 12, weight: .medium, design: .monospaced))
                     }
@@ -555,6 +569,7 @@ struct iPadMetricSelectionView: View {
                 Image(systemName: category.icon)
                     .foregroundStyle(Color.accent)
                     .frame(width: 20)
+                    .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(category.rawValue)
@@ -569,10 +584,13 @@ struct iPadMetricSelectionView: View {
 
                 Image(systemName: "lock.fill")
                     .foregroundStyle(Color.textMuted)
+                    .accessibilityHidden(true)
             }
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("\(category.rawValue), pending Apple permission")
+        .accessibilityHint("Double tap to learn more")
     }
 
     @ViewBuilder
@@ -610,6 +628,7 @@ struct iPadMetricSelectionView: View {
                 Image(systemName: category.icon)
                     .foregroundStyle(Color.accent)
                     .frame(width: 20)
+                    .accessibilityHidden(true)
 
                 Text(category.rawValue)
                     .font(.system(size: 13, weight: .medium, design: .monospaced))
@@ -626,16 +645,32 @@ struct iPadMetricSelectionView: View {
                     if selectionState.isCategoryFullyEnabled(category) {
                         Image(systemName: "checkmark.circle.fill")
                             .foregroundStyle(Color.success)
+                            .accessibilityHidden(true)
                     } else if selectionState.isCategoryPartiallyEnabled(category) {
                         Image(systemName: "minus.circle.fill")
                             .foregroundStyle(Color.warning)
+                            .accessibilityHidden(true)
                     } else {
                         Image(systemName: "circle")
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Toggle all \(category.rawValue) metrics")
+                .accessibilityValue(categorySelectionAccessibilityValue(for: category))
+                .accessibilityHint("Double tap to change all metrics in this category")
             }
+        }
+    }
+
+    private func categorySelectionAccessibilityValue(for category: HealthMetricCategory) -> String {
+        if selectionState.isCategoryFullyEnabled(category) {
+            return "All selected"
+        } else if selectionState.isCategoryPartiallyEnabled(category) {
+            return "Some selected"
+        } else {
+            return "None selected"
         }
     }
 }

--- a/HealthMd/iPad/iPadHistoryView.swift
+++ b/HealthMd/iPad/iPadHistoryView.swift
@@ -37,6 +37,7 @@ struct iPadHistoryView: View {
                     Image(systemName: "list.bullet.clipboard")
                         .font(.system(size: 40))
                         .foregroundStyle(Color.textMuted)
+                        .accessibilityHidden(true)
                     Text("No Export History")
                         .font(.system(size: 15, weight: .medium, design: .monospaced))
                         .foregroundStyle(Color.textPrimary)
@@ -102,6 +103,9 @@ struct iPadHistoryView: View {
             }
             .padding(.vertical, 2)
             .tag(entry)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(historyEntryAccessibilityLabel(for: entry))
+            .accessibilityHint("Select to view details")
         }
     }
 
@@ -156,6 +160,7 @@ struct iPadHistoryView: View {
                                     Image(systemName: "xmark.circle.fill")
                                         .foregroundStyle(Color.error)
                                         .font(.caption)
+                                        .accessibilityHidden(true)
                                     Text(detail.dateString)
                                         .font(.system(size: 13, weight: .medium, design: .monospaced))
                                         .foregroundStyle(Color.textPrimary)
@@ -179,6 +184,7 @@ struct iPadHistoryView: View {
                 Image(systemName: "doc.text.magnifyingglass")
                     .font(.system(size: 32))
                     .foregroundStyle(Color.textMuted)
+                    .accessibilityHidden(true)
                 Text("Select an export to see details")
                     .font(.system(size: 13, weight: .regular, design: .monospaced))
                     .foregroundStyle(Color.textMuted)
@@ -195,6 +201,7 @@ struct iPadHistoryView: View {
               ? "checkmark.circle.fill"
               : entry.success ? "exclamationmark.circle.fill" : "xmark.circle.fill")
             .foregroundStyle(entry.isFullSuccess ? Color.success : entry.success ? Color.warning : Color.error)
+            .accessibilityHidden(true)
     }
 
     @ViewBuilder
@@ -218,5 +225,10 @@ struct iPadHistoryView: View {
         let start = Self.rangeDateFormatter.string(from: entry.dateRangeStart)
         let end = Self.rangeDateFormatter.string(from: entry.dateRangeEnd)
         return start == end ? start : "\(start) → \(end)"
+    }
+
+    private func historyEntryAccessibilityLabel(for entry: ExportHistoryEntry) -> String {
+        let status = entry.isFullSuccess ? "Success" : entry.success ? "Partial success" : "Failed"
+        return "\(status). \(entry.summaryDescription). \(entry.successCount) of \(entry.totalCount) files. \(Self.dateFormatter.string(from: entry.timestamp)). Source: \(entry.source.rawValue)."
     }
 }

--- a/HealthMd/iPad/iPadScheduleView.swift
+++ b/HealthMd/iPad/iPadScheduleView.swift
@@ -84,6 +84,7 @@ struct iPadScheduleView: View {
                                 Image(systemName: "checkmark.circle.fill")
                                     .foregroundStyle(Color.success)
                                     .font(.caption)
+                                    .accessibilityHidden(true)
                                 Text(lastExport, style: .relative)
                                     .font(.system(size: 13, weight: .medium, design: .monospaced))
                                     .foregroundStyle(Color.textSecondary)

--- a/HealthMd/iPad/iPadSettingsView.swift
+++ b/HealthMd/iPad/iPadSettingsView.swift
@@ -19,6 +19,7 @@ struct iPadSettingsView: View {
                     if let url = vaultManager.vaultURL {
                         Image(systemName: "folder.fill")
                             .foregroundStyle(Color.accent)
+                            .accessibilityHidden(true)
                         VStack(alignment: .leading, spacing: 2) {
                             Text(vaultManager.vaultName)
                                 .font(.system(size: 13, weight: .medium, design: .monospaced))
@@ -31,6 +32,7 @@ struct iPadSettingsView: View {
                     } else {
                         Image(systemName: "folder")
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                         Text("No folder selected")
                             .font(.system(size: 13, weight: .regular, design: .monospaced))
                             .foregroundStyle(Color.textMuted)
@@ -40,6 +42,8 @@ struct iPadSettingsView: View {
                         showFolderPicker = true
                     }
                     .tint(Color.accent)
+                    .accessibilityLabel(vaultManager.vaultURL != nil ? "Change export folder" : "Choose export folder")
+                    .accessibilityHint("Opens the folder picker")
                 }
 
                 if vaultManager.vaultURL != nil {
@@ -232,12 +236,14 @@ struct iPadSettingsView: View {
                         Image(systemName: category.icon)
                             .foregroundStyle(Color.accent)
                             .frame(width: 20)
+                            .accessibilityHidden(true)
                         Text(category.rawValue)
                         Spacer()
                         if category.isPendingAppleApproval {
                             Image(systemName: "lock.fill")
                                 .font(.system(size: 11))
                                 .foregroundStyle(Color.textMuted)
+                                .accessibilityHidden(true)
                             Text("Pending")
                                 .font(.system(size: 13, weight: .medium, design: .monospaced))
                                 .foregroundStyle(Color.textMuted)
@@ -300,14 +306,18 @@ struct iPadSettingsView: View {
                         Image(systemName: "bubble.left.and.bubble.right.fill")
                             .foregroundStyle(Color.accent)
                             .frame(width: 20)
+                            .accessibilityHidden(true)
                         Text("Join our Discord")
                         Spacer()
                         Image(systemName: "arrow.up.forward")
                             .font(.caption)
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Join our Discord")
+                .accessibilityHint("Opens the Health.md Discord community in your browser")
             } header: {
                 iPadBrandLabel("Community")
             } footer: {
@@ -329,14 +339,18 @@ struct iPadSettingsView: View {
                         Image(systemName: "envelope")
                             .foregroundStyle(Color.accent)
                             .frame(width: 20)
+                            .accessibilityHidden(true)
                         Text("Send Feedback")
                         Spacer()
                         Image(systemName: "arrow.up.forward")
                             .font(.caption)
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Send feedback")
+                .accessibilityHint("Opens your email client to send feedback")
 
                 Button {
                     FeedbackHelper.openGitHubIssue()
@@ -345,14 +359,18 @@ struct iPadSettingsView: View {
                         Image(systemName: "ladybug")
                             .foregroundStyle(Color.accent)
                             .frame(width: 20)
+                            .accessibilityHidden(true)
                         Text("Report a Bug on GitHub")
                         Spacer()
                         Image(systemName: "arrow.up.forward")
                             .font(.caption)
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Report a bug on GitHub")
+                .accessibilityHint("Opens GitHub to create a new issue")
             } header: {
                 iPadBrandLabel("Feedback")
             }
@@ -398,8 +416,11 @@ struct iPadPlaceholderFieldsView: View {
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundStyle(Color.textMuted)
+                            .accessibilityHidden(true)
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Remove placeholder field \(key)")
+                    .accessibilityHint("Removes this placeholder from exported frontmatter")
                 }
             }
             

--- a/HealthMd/iPad/iPadSidebar.swift
+++ b/HealthMd/iPad/iPadSidebar.swift
@@ -37,6 +37,7 @@ struct iPadSidebar: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 24, height: 24)
                     .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                    .accessibilityHidden(true)
                 Text("health.md")
                     .font(.system(size: 15, weight: .semibold, design: .monospaced))
                     .foregroundStyle(Color.textPrimary)
@@ -55,8 +56,10 @@ struct iPadSidebar: View {
                     } icon: {
                         Image(systemName: item.icon)
                             .foregroundStyle(Color.accent)
+                            .accessibilityHidden(true)
                     }
                     .tag(item)
+                    .accessibilityLabel(item.rawValue)
                 }
             }
             .listStyle(.sidebar)
@@ -69,6 +72,7 @@ struct iPadSidebar: View {
                 Circle()
                     .fill(syncService.connectionState == .connected ? Color.success : Color.textMuted)
                     .frame(width: 6, height: 6)
+                    .accessibilityHidden(true)
                 Text(sidebarStatusLabel)
                     .font(.system(size: 11, weight: .regular, design: .monospaced))
                     .foregroundStyle(Color.textMuted)
@@ -76,6 +80,9 @@ struct iPadSidebar: View {
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Mac sync status")
+            .accessibilityValue(sidebarStatusLabel)
         }
     }
 

--- a/HealthMd/iPad/iPadSyncView.swift
+++ b/HealthMd/iPad/iPadSyncView.swift
@@ -26,6 +26,7 @@ struct iPadSyncView: View {
                         Circle()
                             .fill(healthKitManager.isAuthorized ? Color.success : Color.textMuted)
                             .frame(width: 10, height: 10)
+                            .accessibilityHidden(true)
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(healthKitManager.isAuthorized ? "Connected" : "Not Connected")
@@ -74,6 +75,7 @@ struct iPadSyncView: View {
                         Circle()
                             .fill(syncEnabled ? (syncService.connectionState == .connected ? Color.success : Color.warning) : Color.textMuted)
                             .frame(width: 10, height: 10)
+                            .accessibilityHidden(true)
 
                         VStack(alignment: .leading, spacing: 2) {
                             Text(syncEnabled ? "Enabled" : "Disabled")
@@ -99,6 +101,8 @@ struct iPadSyncView: View {
                                     syncService.disconnect()
                                 }
                             }
+                            .accessibilityLabel("Mac sync")
+                            .accessibilityHint("Double tap to \(syncEnabled ? "disable" : "enable") syncing health data to your Mac")
                     }
 
                     Text("When enabled, your Mac can discover this iPad and request health data over your local network.")
@@ -119,6 +123,7 @@ struct iPadSyncView: View {
                                 Image(systemName: "desktopcomputer")
                                     .foregroundStyle(Color.accent)
                                     .font(.system(size: 20, weight: .semibold))
+                                    .accessibilityHidden(true)
 
                                 VStack(alignment: .leading, spacing: 2) {
                                     Text("macOS on App Store")
@@ -134,6 +139,7 @@ struct iPadSyncView: View {
                                 Image(systemName: "arrow.up.right")
                                     .font(.system(size: 12, weight: .semibold))
                                     .foregroundStyle(Color.accent)
+                                    .accessibilityHidden(true)
                             }
                         }
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -148,6 +154,8 @@ struct iPadSyncView: View {
                         )
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel("Download Health.md for macOS")
+                    .accessibilityHint("Opens the App Store")
                 }
 
                 // MARK: - Connection Status
@@ -225,6 +233,7 @@ struct iPadSyncView: View {
                         } label: {
                             HStack(spacing: 8) {
                                 Image(systemName: "arrow.triangle.2.circlepath")
+                                    .accessibilityHidden(true)
                                 Text("Sync Last 7 Days Now")
                             }
                             .font(.system(size: 13, weight: .medium, design: .monospaced))
@@ -233,6 +242,8 @@ struct iPadSyncView: View {
                         }
                         .buttonStyle(.bordered)
                         .tint(Color.accent)
+                        .accessibilityLabel("Sync last 7 days now")
+                        .accessibilityHint("Sends the last 7 days of health data to your connected Mac")
 
                         Text("Sends the last 7 days of health data to your connected Mac.")
                             .font(.system(size: 11, weight: .regular, design: .monospaced))
@@ -248,6 +259,7 @@ struct iPadSyncView: View {
                     HStack(spacing: 8) {
                         Image(systemName: "exclamationmark.triangle")
                             .foregroundStyle(Color.warning)
+                            .accessibilityHidden(true)
                         Text(error)
                             .font(.system(size: 13, weight: .regular, design: .monospaced))
                             .foregroundStyle(Color.warning)
@@ -285,12 +297,15 @@ struct iPadSyncView: View {
         case .connected:
             Image(systemName: "checkmark.circle.fill")
                 .foregroundStyle(Color.success)
+                .accessibilityHidden(true)
         case .connecting:
             ProgressView()
                 .controlSize(.small)
+                .accessibilityHidden(true)
         case .disconnected:
             Image(systemName: "circle.dotted")
                 .foregroundStyle(Color.textMuted)
+                .accessibilityHidden(true)
         }
     }
 

--- a/HealthMdTests/Utilities/CIQualityGateTests.swift
+++ b/HealthMdTests/Utilities/CIQualityGateTests.swift
@@ -300,4 +300,65 @@ final class CIQualityGateTests: XCTestCase {
         XCTAssertTrue(content.contains("coverage-thresholds"), "Docs must explain threshold config")
         XCTAssertTrue(content.contains("warning-baseline"), "Docs must explain warning baseline")
     }
+
+    // MARK: - Accessibility Source Checks (issue #38)
+
+    func testIconOnlyControls_haveExplicitAccessibilityLabels() throws {
+        let criticalFiles = [
+            "HealthMd/iPad/iPadExportView.swift": [
+                ".accessibilityLabel(\"Stop export\")",
+                ".accessibilityLabel(\"Preview export\")",
+                ".accessibilityLabel(purchaseManager.canExport ? \"Review export\" : \"Unlock to export\")",
+            ],
+            "HealthMd/iPad/iPadSettingsView.swift": [
+                ".accessibilityLabel(\"Join our Discord\")",
+                ".accessibilityLabel(\"Send feedback\")",
+                ".accessibilityLabel(\"Report a bug on GitHub\")",
+                ".accessibilityLabel(\"Remove placeholder field \\(key)\")",
+            ],
+            "HealthMd/iOS/Views/MetricSelectionView.swift": [
+                ".accessibilityLabel(\"Metric actions\")",
+                ".accessibilityLabel(\"Clear search\")",
+            ],
+            "HealthMd/iOS/Views/FormatCustomizationView.swift": [
+                ".accessibilityLabel(\"Frontmatter field actions\")",
+                ".accessibilityLabel(\"Rename \\(field.originalKey)\")",
+            ],
+        ]
+
+        for (relativePath, expectedSnippets) in criticalFiles {
+            let content = try source(relativePath)
+            for snippet in expectedSnippets {
+                XCTAssertTrue(
+                    content.contains(snippet),
+                    "\(relativePath) must keep explicit accessibility label snippet: \(snippet)"
+                )
+            }
+        }
+    }
+
+    func testDecorativeGlowAndNavigationIcons_areHiddenFromAccessibilityTree() throws {
+        let criticalFiles = [
+            "HealthMd/iOS/Components/StatusIndicator.swift": 5,
+            "HealthMd/iOS/Components/SectionCard.swift": 6,
+            "HealthMd/iOS/Components/ExportModal.swift": 12,
+            "HealthMd/iOS/Views/OnboardingView.swift": 12,
+            "HealthMd/iPad/iPadSidebar.swift": 3,
+        ]
+
+        for (relativePath, minimumHiddenCount) in criticalFiles {
+            let content = try source(relativePath)
+            let hiddenCount = content.components(separatedBy: ".accessibilityHidden(true)").count - 1
+            XCTAssertGreaterThanOrEqual(
+                hiddenCount,
+                minimumHiddenCount,
+                "\(relativePath) must hide decorative icons, status dots, and glow layers from VoiceOver"
+            )
+        }
+    }
+
+    private func source(_ relativePath: String) throws -> String {
+        let path = projectDir.appendingPathComponent(relativePath).path
+        return try String(contentsOfFile: path, encoding: .utf8)
+    }
 }


### PR DESCRIPTION
Closes CodyBontecou/health-md#38

Implemented by Symphony agent automation.

## Issue

https://github.com/CodyBontecou/health-md/issues/38

## Simulator QA

Report: `.symphony/qa-report.md`
Artifact directory: `.symphony/qa-artifacts`

Screenshots: 14
Videos: 4
Other artifacts: 12

- other: `.symphony/qa-artifacts/01-export-accessibility-audit.json`
- other: `.symphony/qa-artifacts/01-export-accessibility.json`
### .symphony/qa-artifacts/01-export-tab.png

![.symphony/qa-artifacts/01-export-tab.png](https://imghost.isolated.tech/7541eac1.png)

- other: `.symphony/qa-artifacts/02-export-accessibility.txt`
- other: `.symphony/qa-artifacts/02-export-audit.txt`
### .symphony/qa-artifacts/02-export-tab-dismissed-prompt.png

![.symphony/qa-artifacts/02-export-tab-dismissed-prompt.png](https://imghost.isolated.tech/27bf9d10.png)

### .symphony/qa-artifacts/04-ipad-export-or-settings.png

![.symphony/qa-artifacts/04-ipad-export-or-settings.png](https://imghost.isolated.tech/a599a723.png)

### .symphony/qa-artifacts/05-ipad-settings-accessibility.png

![.symphony/qa-artifacts/05-ipad-settings-accessibility.png](https://imghost.isolated.tech/301894ea.png)

### .symphony/qa-artifacts/06-ipad-sync-accessibility.png

![.symphony/qa-artifacts/06-ipad-sync-accessibility.png](https://imghost.isolated.tech/634a839f.png)

### .symphony/qa-artifacts/07-ipad-export-preview.png

![.symphony/qa-artifacts/07-ipad-export-preview.png](https://imghost.isolated.tech/3187a0fd.png)

- other: `.symphony/qa-artifacts/08-ipad-export-accessibility.txt`
- other: `.symphony/qa-artifacts/08-ipad-export-audit.txt`
- video: [.symphony/qa-artifacts/ipad-accessibility-flow.mp4](https://imghost.isolated.tech/59d43f80.mp4)
- other: `.symphony/qa-artifacts/ipad-export-accessibility-audit.txt`
- other: `.symphony/qa-artifacts/ipad-export-accessibility-map.json`
### .symphony/qa-artifacts/ipad-export.png

![.symphony/qa-artifacts/ipad-export.png](https://imghost.isolated.tech/c4d9ee73.png)

### .symphony/qa-artifacts/iphone-after-dismiss-attempt.png

![.symphony/qa-artifacts/iphone-after-dismiss-attempt.png](https://imghost.isolated.tech/e1c2f078.png)

- other: `.symphony/qa-artifacts/iphone-export-accessibility-audit.txt`
- video: [.symphony/qa-artifacts/iphone-export-accessibility-flow.mp4](https://imghost.isolated.tech/d338a9af.mp4)
### .symphony/qa-artifacts/iphone-export-preview.png

![.symphony/qa-artifacts/iphone-export-preview.png](https://imghost.isolated.tech/00243e47.png)

- ...and 10 more artifact(s)

<details>
<summary>QA report</summary>

# QA Report: CodyBontecou/health-md#38

## Result

PASS

## Simulator / Device Used

- iPhone 17 Pro simulator, iOS 26.3.1, UDID `0335EECF-93B3-4F95-9D5E-DC339BC055DB`
- iPad Pro 11-inch (M5) simulator, iPadOS 26.3.1, UDID `FDE0243B-2A8D-45BA-ABAD-DCFD46D52E48`
- Note: iPhone 16 Pro was requested first but is not installed in this environment, so iPhone 17 Pro was used.

## Mocked Data Setup

- Launched app with `--uitesting`.
- Used simulator-only deterministic launch state:
  - `UITEST_HEALTH_AUTHORIZED=true`
  - `UITEST_VAULT_SELECTED=true`
  - `UITEST_PURCHASE_UNLOCKED=true`
  - `UITEST_SYNC_STATE=connected`
  - `UITEST_SCHEDULE_ENABLED=true`
- Test mode bypassed production HealthKit, StoreKit, AppsFlyer startup, real sign-in, purchase, Apple Account, and production network flows.
- No real export file write was performed.

## Code Inspection

Reviewed the implementation changed for issue #38. The patch adds `.accessibilityHidden(true)` to decorative symbols, status dots, glow/blur copies, repeated icons, and non-informative visuals across iOS and iPad views. It also adds explicit labels/hints for high-risk icon-only or context-dependent controls in export, settings, sync, onboarding, navigation, status, and card components.

The patch also adds focused source checks in `HealthMdTests/Utilities/CIQualityGateTests.swift` for labeled icon-only controls and hidden decorative layers.

## Build / Tests

- `xcodebuild test -scheme HealthMd-Tests-iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath .symphony/DerivedData -only-testing:HealthMdTests/CIQualityGateTests/testIconOnlyControls_haveExplicitAccessibilityLabels -only-testing:HealthMdTests/CIQualityGateTests/testDecorativeGlowAndNavigationIcons_areHiddenFromAccessibilityTree`
  - Passed: 2 tests, 0 failures.
- `git diff --check`
  - Passed: no whitespace errors.

## Steps Performed

1. Inspected the diff to confirm the requested accessibility work: labels/hints for icon-only controls and hidden decorative icon/blur/glow copies.
2. Built and ran the focused iOS quality-gate tests on iPhone 17 Pro.
3. Installed and launched the current debug app build on iPhone 17 Pro with mocked UI-test state.
4. Captured the iPhone Export tab and dismissed a persisted in-app folder-name prompt with Cancel.
5. Installed and launched the same current build on iPad Pro 11-inch with mocked UI-test state.
6. Verified iPad Export accessibility tree exposed meaningful controls such as `Start date`, `End date`, `Write mode`, and `Configure...` without repeated decorative symbols.
7. Navigated to iPad Settings and verified controls such as `Choose export folder` include a helpful hint.
8. Navigated to iPad Sync and verified controls such as `Mac sync` and `Download Health.md for macOS` include useful labels/hints.
9. Opened iPad Export Preview and verified the decorative empty-state icon was not separately announced; the sheet exposed `Done`, `Export Preview`, and explanatory text.
10. Captured screenshots and screen recordings under the QA artifact directory only.

## Artifacts

- `01-export-tab.png`
- `02-export-tab-dismissed-prompt.png`
- `04-ipad-export-or-settings.png`
- `05-ipad-settings-accessibility.png`
- `06-ipad-sync-accessibility.png`
- `07-ipad-export-preview.png`
- `08-ipad-export-accessibility.txt`
- `08-ipad-export-audit.txt`
- `qa-flow.mp4`
- `ipad-accessibility-flow.mp4`

## Limitations / Follow-up

- The simulator had very large accessibility text enabled, so screenshots are visually oversized. This was useful for stress testing but means the visual layout is not representative of default text size.
- The iOS simulator accessibility helper reports only generic `missing_traits` warnings and no critical issues on the iPad Export screen. I treated this as a helper limitation because Computer Use exposed the relevant labels/hints directly.
- I did not invoke real HealthKit permissions, StoreKit purchases, Apple Account flows, external links, or file-writing export flows.

</details>

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.

- QA screenshots/videos are uploaded externally and embedded/linked above.
