### PR TITLE
ISO-293: Add offline monetization regression coverage

### DIFF
--- a/HealthMd/Shared/Analytics/PricingAnalyticsClient.swift
+++ b/HealthMd/Shared/Analytics/PricingAnalyticsClient.swift
@@ -9,7 +9,8 @@ import Foundation
 
 nonisolated final class PricingAnalyticsClient: @unchecked Sendable {
     static let shared = PricingAnalyticsClient(
-        transport: NoOpPricingAnalyticsTransport()
+        transport: PricingAnalyticsTransportFactory.makeDefaultTransport(),
+        retryDelayNanoseconds: PricingAnalyticsClient.defaultRetryDelayForCurrentLaunch
     )
 
     private static let defaultQueueKey = "pricing.analytics.queue.v1"
@@ -70,6 +71,16 @@ nonisolated final class PricingAnalyticsClient: @unchecked Sendable {
         #else
         true
         #endif
+    }
+
+    private static var defaultRetryDelayForCurrentLaunch: UInt64 {
+        #if DEBUG
+        if ProcessInfo.processInfo.environment["UITEST_ANALYTICS_TRANSPORT"] == "offline" {
+            return 0
+        }
+        #endif
+
+        return defaultRetryDelayNanoseconds
     }
 }
 
@@ -136,13 +147,13 @@ nonisolated private final class PricingAnalyticsClientState: @unchecked Sendable
         queue.sync {
             if payloads.isEmpty {
                 flushTask = nil
-            } else if stoppedAfterFailure {
+            } else if stoppedAfterFailure, retryDelayNanoseconds > 0 {
                 flushTask = Task.detached(priority: .background) { [weak self, transport, retryDelayNanoseconds] in
-                    if retryDelayNanoseconds > 0 {
-                        try? await Task.sleep(nanoseconds: retryDelayNanoseconds)
-                    }
+                    try? await Task.sleep(nanoseconds: retryDelayNanoseconds)
                     await self?.flushLoop(transport: transport)
                 }
+            } else if stoppedAfterFailure {
+                flushTask = nil
             } else {
                 flushTask = Task.detached(priority: .background) { [weak self, transport] in
                     await self?.flushLoop(transport: transport)

--- a/HealthMd/Shared/Analytics/PricingAnalyticsTransport.swift
+++ b/HealthMd/Shared/Analytics/PricingAnalyticsTransport.swift
@@ -11,6 +11,26 @@ nonisolated protocol PricingAnalyticsTransport: Sendable {
     func send(_ payload: PricingAnalyticsPayload) async throws
 }
 
+nonisolated enum PricingAnalyticsTransportFactory {
+    static func makeDefaultTransport(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> PricingAnalyticsTransport {
+        #if DEBUG
+        if environment["UITEST_ANALYTICS_TRANSPORT"] == "offline" {
+            return OfflinePricingAnalyticsTransport()
+        }
+        #endif
+
+        return NoOpPricingAnalyticsTransport()
+    }
+}
+
 nonisolated struct NoOpPricingAnalyticsTransport: PricingAnalyticsTransport {
     func send(_ payload: PricingAnalyticsPayload) async throws {}
+}
+
+nonisolated struct OfflinePricingAnalyticsTransport: PricingAnalyticsTransport {
+    func send(_ payload: PricingAnalyticsPayload) async throws {
+        throw URLError(.notConnectedToInternet)
+    }
 }

--- a/HealthMd/Shared/Analytics/PricingExperimentConfig.swift
+++ b/HealthMd/Shared/Analytics/PricingExperimentConfig.swift
@@ -50,7 +50,16 @@ nonisolated struct PricingExperimentConfig: Equatable, Sendable {
         )
     }
 
-    static func resolved(from data: Data?) -> PricingExperimentConfig {
+    static func resolved(
+        from data: Data?,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> PricingExperimentConfig {
+        #if DEBUG
+        if environment["UITEST_REMOTE_CONFIG"] == "offline" {
+            return .baseline
+        }
+        #endif
+
         guard let data else { return .baseline }
 
         let decoder = JSONDecoder()

--- a/HealthMd/Shared/TestMode.swift
+++ b/HealthMd/Shared/TestMode.swift
@@ -64,6 +64,16 @@ enum TestMode {
         env("UITEST_HEALTHKIT_EXPORT_PREVIEW_FIXTURES") == "true"
     }
 
+    /// Simulated pricing analytics transport. Supported values: "noop" or "offline".
+    static var analyticsTransport: String {
+        env("UITEST_ANALYTICS_TRANSPORT") ?? "noop"
+    }
+
+    /// Simulated remote-config state. Supported values: "available" or "offline".
+    static var remoteConfig: String {
+        env("UITEST_REMOTE_CONFIG") ?? "available"
+    }
+
     // MARK: - Private
 
     private static func env(_ key: String) -> String? {

--- a/HealthMdTests/Analytics/PricingAnalyticsClientTests.swift
+++ b/HealthMdTests/Analytics/PricingAnalyticsClientTests.swift
@@ -30,6 +30,26 @@ final class PricingAnalyticsClientTests: XCTestCase {
         XCTAssertEqual(queuedPayloads, [Self.event(variantId: "baseline").encodedPayload()])
     }
 
+    func testUITestOfflineTransportHookFailsSoftlyForRegressionScenarios() async {
+        let transport = PricingAnalyticsTransportFactory.makeDefaultTransport(
+            environment: ["UITEST_ANALYTICS_TRANSPORT": "offline"]
+        )
+
+        do {
+            try await transport.send(Self.event(variantId: "baseline").encodedPayload())
+            XCTFail("Offline UI-test transport should simulate network failure.")
+        } catch let error as URLError {
+            XCTAssertEqual(error.code, .notConnectedToInternet)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testDefaultUITestTransportRemainsNoOpWhenOfflineHookIsAbsent() async throws {
+        let transport = PricingAnalyticsTransportFactory.makeDefaultTransport(environment: [:])
+        try await transport.send(Self.event(variantId: "baseline").encodedPayload())
+    }
+
     func testSlowTransportDoesNotBlockCallerPath() async {
         let transport = BlockingPricingAnalyticsTransport()
         let client = PricingAnalyticsClient(

--- a/HealthMdTests/Analytics/PricingExperimentAssignmentTests.swift
+++ b/HealthMdTests/Analytics/PricingExperimentAssignmentTests.swift
@@ -45,6 +45,30 @@ final class PricingExperimentAssignmentTests: XCTestCase {
         XCTAssertEqual(config.effectiveProductID(defaultProductID: PurchaseManager.productID), PurchaseManager.productID)
     }
 
+    func testOfflineRemoteConfigDefaultsToBaselineAndCurrentProduct() throws {
+        let overrideProductID = "com.codybontecou.obsidianhealth.unlock.1499"
+        let remoteData = try JSONSerialization.data(withJSONObject: [
+            "experimentId": PricingExperimentConfig.currentExperimentId,
+            "variantId": PricingExperimentConfig.testVariantId,
+            "productIdOverride": overrideProductID,
+            "isProductIDOverrideEnabled": true
+        ])
+
+        let config = PricingExperimentConfig.resolved(
+            from: remoteData,
+            environment: ["UITEST_REMOTE_CONFIG": "offline"]
+        )
+        let assignment = PricingExperimentAssignmentStore(
+            defaults: FakeUserDefaults(),
+            now: { Date(timeIntervalSince1970: 1_779_000_000) }
+        ).assignment(for: config)
+
+        XCTAssertEqual(config, .baseline)
+        XCTAssertEqual(assignment.variantId, PricingExperimentConfig.baselineVariantId)
+        XCTAssertNil(assignment.productIdOverride)
+        XCTAssertEqual(config.effectiveProductID(defaultProductID: PurchaseManager.productID), PurchaseManager.productID)
+    }
+
     func testMalformedAndUnknownConfigFallBackToBaseline() throws {
         let malformed = Data("{".utf8)
         XCTAssertEqual(PricingExperimentConfig.resolved(from: malformed), .baseline)

--- a/HealthMdUITests/ExportJourneyUITests.swift
+++ b/HealthMdUITests/ExportJourneyUITests.swift
@@ -63,6 +63,26 @@ final class ExportJourneyUITests: XCTestCase {
         XCTAssertTrue(renderedExport.contains("Running"), "Preview should render fixture workout values")
     }
 
+    func testExportPreview_availableWithAnalyticsOffline() throws {
+        let app = UITestLaunchHelper.configuredApp(
+            healthAuthorized: true,
+            vaultSelected: true,
+            purchaseUnlocked: true,
+            useHealthKitExportPreviewFixtures: true,
+            analyticsTransport: "offline",
+            remoteConfig: "offline"
+        )
+        app.launch()
+
+        let previewButton = app.buttons[UITestLaunchHelper.Export.previewButton]
+        XCTAssertTrue(previewButton.waitForExistence(timeout: 5), "Preview button should be visible with analytics offline")
+        XCTAssertTrue(previewButton.isEnabled, "Preview should remain enabled with analytics offline")
+        previewButton.tap()
+
+        let markdownRow = app.descendants(matching: .any)[UITestLaunchHelper.ExportPreview.markdownFileRow]
+        XCTAssertTrue(markdownRow.waitForExistence(timeout: 10), "Preview should render with analytics offline")
+    }
+
     func testExportButton_disabledWithoutHealthAuth() throws {
         let app = UITestLaunchHelper.configuredApp(
             healthAuthorized: false,
@@ -224,6 +244,32 @@ final class ExportJourneyUITests: XCTestCase {
 
         let unlockTitle = app.staticTexts["Unlock Health.md"]
         XCTAssertTrue(unlockTitle.waitForExistence(timeout: 5), "Paywall should appear before a Mac payload is prepared when quota is exhausted")
+    }
+
+    func testPaywallShown_forMacTargetWhenQuotaExhaustedWithAnalyticsOffline() throws {
+        let app = UITestLaunchHelper.configuredApp(
+            healthAuthorized: true,
+            vaultSelected: false,
+            freeExportsUsed: 3,
+            syncState: "connected",
+            macExportStatus: "ready",
+            analyticsTransport: "offline",
+            remoteConfig: "offline"
+        )
+        app.launch()
+
+        let macTarget = app.buttons[UITestLaunchHelper.Export.macTargetOption]
+        XCTAssertTrue(macTarget.waitForExistence(timeout: 5), "Mac target row should be visible")
+        XCTAssertTrue(waitForEnabled(macTarget), "Mac target should be enabled")
+        macTarget.tap()
+
+        let exportButton = app.buttons[UITestLaunchHelper.Export.exportButton]
+        XCTAssertTrue(exportButton.waitForExistence(timeout: 5), "Export button should be visible")
+        XCTAssertTrue(exportButton.isEnabled, "Mac target should satisfy export readiness even without local folder")
+        exportButton.tap()
+
+        let unlockTitle = app.staticTexts["Unlock Health.md"]
+        XCTAssertTrue(unlockTitle.waitForExistence(timeout: 5), "Quota gate should beat Mac payload preparation with analytics offline")
     }
 
     // MARK: - Date Range Presets

--- a/HealthMdUITests/PaywallJourneyUITests.swift
+++ b/HealthMdUITests/PaywallJourneyUITests.swift
@@ -41,6 +41,24 @@ final class PaywallJourneyUITests: XCTestCase {
         XCTAssertFalse(freeLabel.exists, "Free exports label should be hidden when unlocked")
     }
 
+    func testFreeExportsRemaining_hiddenWhenUnlockedWithAnalyticsOffline() throws {
+        let app = UITestLaunchHelper.configuredApp(
+            healthAuthorized: true,
+            vaultSelected: true,
+            purchaseUnlocked: true,
+            freeExportsUsed: 3,
+            analyticsTransport: "offline",
+            remoteConfig: "offline"
+        )
+        app.launch()
+
+        let exportButton = app.buttons[UITestLaunchHelper.Export.exportButton]
+        XCTAssertTrue(exportButton.waitForExistence(timeout: 5))
+
+        let freeLabel = app.staticTexts[UITestLaunchHelper.Export.freeExportsLabel]
+        XCTAssertFalse(freeLabel.exists, "Unlocked users should not see quota copy when analytics is offline")
+    }
+
     // MARK: - Paywall Gating
 
     func testPaywallShown_whenQuotaExhausted() throws {
@@ -61,6 +79,27 @@ final class PaywallJourneyUITests: XCTestCase {
         // Verify paywall subtitle is visible (confirms paywall content is loaded)
         let subtitle = app.staticTexts["You've used your 3 free exports"]
         XCTAssertTrue(subtitle.waitForExistence(timeout: 3), "Paywall subtitle should be visible")
+    }
+
+    func testPaywallShown_whenQuotaExhaustedWithAnalyticsOffline() throws {
+        let app = UITestLaunchHelper.configuredApp(
+            healthAuthorized: true,
+            vaultSelected: true,
+            freeExportsUsed: 3,
+            analyticsTransport: "offline",
+            remoteConfig: "offline"
+        )
+        app.launch()
+
+        let exportButton = app.buttons[UITestLaunchHelper.Export.exportButton]
+        XCTAssertTrue(exportButton.waitForExistence(timeout: 5))
+        exportButton.tap()
+
+        let unlockTitle = app.staticTexts["Unlock Health.md"]
+        XCTAssertTrue(unlockTitle.waitForExistence(timeout: 5), "Paywall should appear with analytics offline")
+
+        let subtitle = app.staticTexts["You've used your 3 free exports"]
+        XCTAssertTrue(subtitle.waitForExistence(timeout: 3), "Paywall content should load with analytics offline")
     }
 
     func testPaywallDismiss_closesPaywall() throws {
@@ -117,5 +156,24 @@ final class PaywallJourneyUITests: XCTestCase {
             // Paywall should NOT have appeared
             XCTAssertFalse(paywallTitle.exists, "Paywall should not appear when free quota remains")
         }
+    }
+
+    func testExportAllowed_whenFreeQuotaRemainsWithAnalyticsOffline() throws {
+        let app = UITestLaunchHelper.configuredApp(
+            healthAuthorized: true,
+            vaultSelected: true,
+            freeExportsUsed: 2,
+            analyticsTransport: "offline",
+            remoteConfig: "offline"
+        )
+        app.launch()
+
+        let exportButton = app.buttons[UITestLaunchHelper.Export.exportButton]
+        XCTAssertTrue(exportButton.waitForExistence(timeout: 5))
+        exportButton.tap()
+
+        let statusBadge = app.descendants(matching: .any)[UITestLaunchHelper.Status.exportStatusBadge]
+        XCTAssertTrue(statusBadge.waitForExistence(timeout: 10), "Export should succeed with analytics offline")
+        XCTAssertFalse(app.staticTexts[UITestLaunchHelper.Paywall.title].exists, "Paywall should not appear while quota remains")
     }
 }

--- a/HealthMdUITests/UITestLaunchHelper.swift
+++ b/HealthMdUITests/UITestLaunchHelper.swift
@@ -90,7 +90,9 @@ enum UITestLaunchHelper {
         useHealthKitExportPreviewFixtures: Bool = false,
         exportResult: String? = nil,
         macExportStatus: String = "none",
-        macDestinationPath: String = "/tmp/TestMacVault"
+        macDestinationPath: String = "/tmp/TestMacVault",
+        analyticsTransport: String? = nil,
+        remoteConfig: String? = nil
     ) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments = ["--uitesting"]
@@ -107,6 +109,13 @@ enum UITestLaunchHelper {
         ]
         if let exportResult {
             app.launchEnvironment["UITEST_EXPORT_RESULT"] = exportResult
+        }
+        if let analyticsTransport {
+            app.launchEnvironment["UITEST_ANALYTICS_TRANSPORT"] = analyticsTransport
+            app.launchEnvironment["PRICING_ANALYTICS_ENABLED"] = "1"
+        }
+        if let remoteConfig {
+            app.launchEnvironment["UITEST_REMOTE_CONFIG"] = remoteConfig
         }
         return app
     }


### PR DESCRIPTION
## Summary
- Add UI-test hooks for offline pricing analytics transport and remote-config fallback.
- Keep offline analytics fail-soft by queueing failed payloads without retry loops during UI-test offline simulations.
- Add unit and UI regression coverage for preview/export/paywall/quota behavior when analytics and remote config are offline.

## Stacked PR
This PR is intentionally stacked on `cody/iso-292-add-pricing-experiment-assignment-scaffolding` for ISO-293.

## Tests
- `xcodebuild test -quiet -project HealthMd.xcodeproj -scheme HealthMd-Tests-iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.3.1' -only-testing:HealthMdTests/PricingAnalyticsClientTests -only-testing:HealthMdTests/PricingExperimentAssignmentTests`
- `xcodebuild test -quiet -project HealthMd.xcodeproj -scheme HealthMd-UITests-iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.3.1' -only-testing:HealthMdUITests/PaywallJourneyUITests/testPaywallShown_whenQuotaExhaustedWithAnalyticsOffline`
- `xcodebuild test -quiet -project HealthMd.xcodeproj -scheme HealthMd-UITests-iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.3.1' -only-testing:HealthMdUITests/PaywallJourneyUITests/testExportAllowed_whenFreeQuotaRemainsWithAnalyticsOffline`
- `xcodebuild test -project HealthMd.xcodeproj -scheme HealthMd-UITests-iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.3.1' -only-testing:HealthMdUITests/ExportJourneyUITests/testExportPreview_availableWithAnalyticsOffline`
- `xcodebuild test -quiet -project HealthMd.xcodeproj -scheme HealthMd-UITests-iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=26.3.1' -only-testing:HealthMdUITests/ExportJourneyUITests/testPaywallShown_forMacTargetWhenQuotaExhaustedWithAnalyticsOffline`

Note: A broader `PaywallJourneyUITests` + `ExportJourneyUITests` run was attempted; it ran for ~20 minutes and had one pre-fix failure in the new offline free-quota assertion before the test was corrected. The focused post-fix UI regressions above passed.
