### PR TITLE
Disable StoreKit auto access in debug simulators

### DIFF
--- a/HealthMd/Shared/Managers/PurchaseManager.swift
+++ b/HealthMd/Shared/Managers/PurchaseManager.swift
@@ -110,9 +110,11 @@ final class PurchaseManager: ObservableObject {
         self.analytics = .shared
         migrateUserDefaultsToKeychain()
 
-        // In UI test mode, skip all StoreKit interactions.
-        // Test state is configured via configureTestMode() in HealthMdApp.
-        guard !TestMode.isUITesting else { return }
+        // In UI/local simulator modes, skip all StoreKit interactions.
+        // UI test state is configured via configureTestMode() in HealthMdApp.
+        // DEBUG simulator builds opt out by default to prevent Apple's account
+        // sign-in sheet from appearing on every local launch.
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else { return }
 
         Task {
             await refreshStatus()
@@ -210,6 +212,12 @@ final class PurchaseManager: ObservableObject {
         }
         #endif
 
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else {
+            isLegacyUser = false
+            isUnlocked = false
+            return
+        }
+
         // 1. Fast path: the user already has an active entitlement for the IAP.
         for await result in Transaction.currentEntitlements {
             if case .verified(let tx) = result, tx.productID == Self.productID {
@@ -278,6 +286,11 @@ final class PurchaseManager: ObservableObject {
     /// Fetches the IAP product from App Store Connect (or the local .storekit config
     /// during development). Populates `product` so the UI can show the live price.
     func loadProduct() async {
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else {
+            product = nil
+            return
+        }
+
         do {
             let products = try await Product.products(for: [Self.productID])
             product = products.first
@@ -290,6 +303,14 @@ final class PurchaseManager: ObservableObject {
 
     /// Initiates the StoreKit purchase flow. Sets `isUnlocked = true` on success.
     func purchase() async {
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else {
+            purchaseError = String(
+                localized: "Purchases are disabled in local simulator builds. Set HEALTHMD_ENABLE_STOREKIT_IN_SIMULATOR=1 to test StoreKit.",
+                comment: "Local simulator StoreKit disabled error"
+            )
+            return
+        }
+
         analytics.trackPurchaseStarted(quotaState: analyticsQuotaState)
 
         guard let product else {
@@ -380,6 +401,14 @@ final class PurchaseManager: ObservableObject {
     ///      reinstalled after v1.7.0, breaking the local AppTransaction check. On success
     ///      the result is cached in the Keychain so the server is only ever called once.
     func restore() async {
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else {
+            purchaseError = String(
+                localized: "Restore is disabled in local simulator builds. Set HEALTHMD_ENABLE_STOREKIT_IN_SIMULATOR=1 to test StoreKit.",
+                comment: "Local simulator StoreKit restore disabled error"
+            )
+            return
+        }
+
         analytics.trackRestoreStarted(quotaState: analyticsQuotaState)
 
         isRestoring = true
@@ -437,6 +466,7 @@ final class PurchaseManager: ObservableObject {
     /// silently. No UI, no spinner — it just unlocks in the background if Apple
     /// confirms they're a legacy paid user.
     private func attemptSilentServerVerification() async {
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else { return }
         guard !isUnlocked else { return }
 
         #if DEBUG
@@ -470,6 +500,8 @@ final class PurchaseManager: ObservableObject {
     /// 2. Legacy receipt file (works on App Store installs only)
     /// Returns `false` on any failure so the caller falls back gracefully.
     private func verifyLegacyWithServer() async -> Bool {
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else { return false }
+
         // Approach 1: Send AppTransaction JWS to the worker.
         // Available on both TestFlight and App Store. The worker decodes the
         // signed payload and checks originalAppVersion without needing Apple's
@@ -543,6 +575,8 @@ final class PurchaseManager: ObservableObject {
     /// Listens for incoming transactions in the background (deferred purchases,
     /// family sharing grants, etc.) and unlocks the app when one arrives.
     private func startTransactionListener() {
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else { return }
+
         let productID = Self.productID
 
         Task(priority: .background) { [weak self] in
@@ -577,6 +611,10 @@ final class PurchaseManager: ObservableObject {
     /// Runs the full receipt → worker → Apple chain and returns a human-readable
     /// summary of every step. Only surfaced in the UI on DEBUG and TestFlight builds.
     func debugVerifyReceipt() async -> String {
+        guard !StoreKitDevelopmentMode.shouldSkipStoreKitAccess else {
+            return "StoreKit is disabled for this local simulator build. Set HEALTHMD_ENABLE_STOREKIT_IN_SIMULATOR=1 in the scheme environment to run receipt diagnostics."
+        }
+
         var lines: [String] = []
 
         lines.append("=== Purchase State ===")

--- a/HealthMd/Shared/StoreKitDevelopmentMode.swift
+++ b/HealthMd/Shared/StoreKitDevelopmentMode.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Keeps local simulator launches away from StoreKit APIs that can surface the
+/// system "Sign in to Apple Account" sheet before a developer explicitly asks
+/// to test purchases.
+enum StoreKitDevelopmentMode {
+    static let enableStoreKitInSimulatorEnvironmentKey = "HEALTHMD_ENABLE_STOREKIT_IN_SIMULATOR"
+    static let enableStoreKitInSimulatorDefaultsKey = "debugEnableStoreKitInSimulator"
+
+    /// True when the app should avoid automatic StoreKit reads/listeners.
+    ///
+    /// Default behavior: DEBUG simulator builds skip StoreKit so local launches
+    /// do not show Apple's account sign-in sheet. Set
+    /// `HEALTHMD_ENABLE_STOREKIT_IN_SIMULATOR=1` in the scheme environment, or
+    /// `debugEnableStoreKitInSimulator = true` in UserDefaults, to opt back in
+    /// when actively testing IAP with a local `.storekit` configuration.
+    static var shouldSkipStoreKitAccess: Bool {
+        shouldSkipStoreKitAccess(
+            isDebugBuild: isDebugBuild,
+            isSimulator: isSimulator,
+            isUITesting: TestMode.isUITesting,
+            isExplicitlyEnabledInSimulator: isExplicitlyEnabledInSimulator
+        )
+    }
+
+    static var isExplicitlyEnabledInSimulator: Bool {
+        if isTruthy(ProcessInfo.processInfo.environment[enableStoreKitInSimulatorEnvironmentKey]) {
+            return true
+        }
+        return UserDefaults.standard.bool(forKey: enableStoreKitInSimulatorDefaultsKey)
+    }
+
+    static func shouldSkipStoreKitAccess(
+        isDebugBuild: Bool,
+        isSimulator: Bool,
+        isUITesting: Bool,
+        isExplicitlyEnabledInSimulator: Bool
+    ) -> Bool {
+        if isUITesting { return true }
+        return isDebugBuild && isSimulator && !isExplicitlyEnabledInSimulator
+    }
+
+    static func isTruthy(_ value: String?) -> Bool {
+        guard let normalized = value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() else {
+            return false
+        }
+        return ["1", "true", "yes", "y", "on"].contains(normalized)
+    }
+
+    private static var isDebugBuild: Bool {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
+    }
+
+    private static var isSimulator: Bool {
+        #if targetEnvironment(simulator)
+        true
+        #else
+        false
+        #endif
+    }
+}

--- a/HealthMdTests/Utilities/StoreKitDevelopmentModeTests.swift
+++ b/HealthMdTests/Utilities/StoreKitDevelopmentModeTests.swift
@@ -1,0 +1,70 @@
+//
+//  StoreKitDevelopmentModeTests.swift
+//  HealthMdTests
+//
+//  Verifies local development guardrails that keep StoreKit from surfacing
+//  Apple's account sign-in sheet during normal simulator launches.
+//
+
+import XCTest
+@testable import HealthMd
+
+final class StoreKitDevelopmentModeTests: XCTestCase {
+
+    func testTruthyEnvironmentParsing() {
+        XCTAssertTrue(StoreKitDevelopmentMode.isTruthy("1"))
+        XCTAssertTrue(StoreKitDevelopmentMode.isTruthy(" true "))
+        XCTAssertTrue(StoreKitDevelopmentMode.isTruthy("YES"))
+        XCTAssertTrue(StoreKitDevelopmentMode.isTruthy("on"))
+
+        XCTAssertFalse(StoreKitDevelopmentMode.isTruthy(nil))
+        XCTAssertFalse(StoreKitDevelopmentMode.isTruthy(""))
+        XCTAssertFalse(StoreKitDevelopmentMode.isTruthy("0"))
+        XCTAssertFalse(StoreKitDevelopmentMode.isTruthy("false"))
+    }
+
+    func testDebugSimulatorSkipsStoreKitByDefault() {
+        XCTAssertTrue(StoreKitDevelopmentMode.shouldSkipStoreKitAccess(
+            isDebugBuild: true,
+            isSimulator: true,
+            isUITesting: false,
+            isExplicitlyEnabledInSimulator: false
+        ))
+    }
+
+    func testExplicitOptInAllowsStoreKitOnDebugSimulator() {
+        XCTAssertFalse(StoreKitDevelopmentMode.shouldSkipStoreKitAccess(
+            isDebugBuild: true,
+            isSimulator: true,
+            isUITesting: false,
+            isExplicitlyEnabledInSimulator: true
+        ))
+    }
+
+    func testRealDeviceDebugBuildDoesNotSkipStoreKit() {
+        XCTAssertFalse(StoreKitDevelopmentMode.shouldSkipStoreKitAccess(
+            isDebugBuild: true,
+            isSimulator: false,
+            isUITesting: false,
+            isExplicitlyEnabledInSimulator: false
+        ))
+    }
+
+    func testReleaseSimulatorBuildDoesNotSkipStoreKit() {
+        XCTAssertFalse(StoreKitDevelopmentMode.shouldSkipStoreKitAccess(
+            isDebugBuild: false,
+            isSimulator: true,
+            isUITesting: false,
+            isExplicitlyEnabledInSimulator: false
+        ))
+    }
+
+    func testUITestingAlwaysSkipsStoreKit() {
+        XCTAssertTrue(StoreKitDevelopmentMode.shouldSkipStoreKitAccess(
+            isDebugBuild: false,
+            isSimulator: false,
+            isUITesting: true,
+            isExplicitlyEnabledInSimulator: true
+        ))
+    }
+}


### PR DESCRIPTION
## Summary
- Add a local StoreKit development mode guard that defaults DEBUG simulator builds away from StoreKit APIs.
- Gate automatic product loading, entitlement refreshes, transaction listeners, silent receipt verification, restore, purchase, and receipt diagnostics behind that guard.
- Add tests for simulator defaults, explicit opt-in, UI test skipping, and truthy environment parsing.

## How to test StoreKit locally
Set `HEALTHMD_ENABLE_STOREKIT_IN_SIMULATOR=1` in the scheme environment, or set `debugEnableStoreKitInSimulator` in UserDefaults, to opt back into StoreKit on simulator.

## Tests
- `xcodebuild test -project HealthMd.xcodeproj -scheme HealthMd-Tests-iOS -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:HealthMdTests/StoreKitDevelopmentModeTests CODE_SIGNING_ALLOWED=NO`