### PR TITLE
ISO-304: Drain pending exports from notification taps and app active

### DIFF
--- a/HealthMd/iOS/HealthMdApp.swift
+++ b/HealthMd/iOS/HealthMdApp.swift
@@ -13,6 +13,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     func applicationDidBecomeActive(_ application: UIApplication) {
         if !TestMode.isUITesting {
             AppsFlyerManager.shared.start()
+            Task { @MainActor in
+                await SchedulingManager.shared.drainPendingExportsIfNeeded(trigger: .appActive)
+                await SchedulingManager.shared.performCatchUpExportIfNeeded()
+            }
         }
     }
 
@@ -88,13 +92,10 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
 
         if let pendingExportPayload = pendingExportPayload {
             Task { @MainActor in
-                await SchedulingManager.shared.performNotificationTriggeredExport(
-                    pendingRequestID: pendingExportPayload.requestID
+                await SchedulingManager.shared.performPendingExport(
+                    requestId: pendingExportPayload.requestID,
+                    source: pendingExportPayload.source
                 )
-            }
-        } else if request.identifier.contains("export.reminder") {
-            Task { @MainActor in
-                await SchedulingManager.shared.performNotificationTriggeredExport()
             }
         }
         completionHandler()

--- a/HealthMd/iOS/SchedulingManager.swift
+++ b/HealthMd/iOS/SchedulingManager.swift
@@ -56,6 +56,13 @@ struct NotificationExportResult: Equatable {
 
 /// Manages background task scheduling for automated health data exports
 class SchedulingManager: ObservableObject {
+    enum PendingExportDrainTrigger {
+        case notificationTap
+        case appActive
+    }
+
+    typealias PendingExportRunner = @MainActor ([Date], PendingExportSource) async -> ExportOrchestrator.ExportResult
+
     @MainActor static let shared = SchedulingManager()
 
     private let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "SchedulingManager")
@@ -69,13 +76,19 @@ class SchedulingManager: ObservableObject {
     private let pendingExportStore: PendingExportStoring
     private let exportNotificationScheduler: ExportNotificationScheduling
     private let scheduledExportCoordinator: ScheduledExportCoordinator
+    private let persistScheduleChanges: Bool
+    private let systemSideEffectsEnabled: Bool
+    private let pendingExportRunner: PendingExportRunner?
 
     /// Result from notification-triggered export, observed by UI to show alert
     @MainActor @Published var notificationExportResult: NotificationExportResult?
 
     @MainActor @Published var schedule: ExportSchedule {
         didSet {
-            schedule.save()
+            if persistScheduleChanges {
+                schedule.save()
+            }
+            guard systemSideEffectsEnabled else { return }
             // Skip background task and HealthKit setup in UI test / marketing capture mode
             guard !TestMode.isUITesting else { return }
             #if DEBUG
@@ -98,17 +111,24 @@ class SchedulingManager: ObservableObject {
         }
     }
 
-    private init(
+    init(
         pendingExportStore: PendingExportStoring = PendingExportStore(),
-        exportNotificationScheduler: ExportNotificationScheduling = UserNotificationExportScheduler()
+        exportNotificationScheduler: ExportNotificationScheduling = UserNotificationExportScheduler(),
+        initialSchedule: ExportSchedule? = nil,
+        persistScheduleChanges: Bool = true,
+        systemSideEffectsEnabled: Bool = true,
+        pendingExportRunner: PendingExportRunner? = nil
     ) {
         self.pendingExportStore = pendingExportStore
         self.exportNotificationScheduler = exportNotificationScheduler
+        self.persistScheduleChanges = persistScheduleChanges
+        self.systemSideEffectsEnabled = systemSideEffectsEnabled
+        self.pendingExportRunner = pendingExportRunner
         self.scheduledExportCoordinator = ScheduledExportCoordinator(
             pendingExportStore: pendingExportStore,
             exportNotificationScheduler: exportNotificationScheduler
         )
-        self.schedule = ExportSchedule.load()
+        self.schedule = initialSchedule ?? ExportSchedule.load()
     }
 
     // MARK: - HealthKit Background Delivery Integration
@@ -256,12 +276,49 @@ class SchedulingManager: ObservableObject {
 
     // MARK: - Catch-Up Logic
 
+    /// Runs the exact persisted pending export request referenced by a recovery notification.
+    @MainActor func performPendingExport(
+        requestId: PendingExportRequest.ID,
+        source expectedSource: PendingExportSource? = nil
+    ) async {
+        guard let request = loadPendingExportRequest(id: requestId, source: expectedSource) else {
+            return
+        }
+
+        await runPendingExport(request, trigger: .notificationTap)
+    }
+
+    /// Drains persisted pending requests when the app becomes active.
+    @MainActor func drainPendingExportsIfNeeded(trigger: PendingExportDrainTrigger) async {
+        let requests: [PendingExportRequest]
+        do {
+            requests = try pendingExportStore.loadAll().sorted(by: pendingExportSort)
+        } catch {
+            logger.error("Failed to load pending export requests: \(error.localizedDescription)")
+            return
+        }
+
+        guard !requests.isEmpty else {
+            logger.info("Pending export drain skipped: no pending requests")
+            return
+        }
+
+        for request in requests {
+            await runPendingExport(request, trigger: trigger)
+        }
+    }
+
     /// Runs an export when the user taps a "tap to retry" notification.
     /// Unlike `performCatchUpExportIfNeeded`, this always runs the full
     /// scheduled export window (yesterday for daily, last 7 days for weekly)
     /// rather than short-circuiting on `lastExportDate` — the user explicitly
     /// asked for an export, so honor that intent.
     @MainActor func performNotificationTriggeredExport(pendingRequestID: PendingExportRequest.ID? = nil) async {
+        if let pendingRequestID {
+            await performPendingExport(requestId: pendingRequestID, source: .scheduled)
+            return
+        }
+
         guard schedule.isEnabled else {
             logger.info("Schedule disabled, skipping notification-triggered export")
             notificationExportResult = NotificationExportResult(
@@ -623,6 +680,279 @@ class SchedulingManager: ObservableObject {
             logger.error("Failed to load pending scheduled export request: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    @MainActor
+    private func loadPendingExportRequest(
+        id: PendingExportRequest.ID,
+        source expectedSource: PendingExportSource?
+    ) -> PendingExportRequest? {
+        do {
+            guard let request = try pendingExportStore.loadAll().first(where: { $0.id == id }) else {
+                logger.info("Pending export request not found for notification tap: \(id.uuidString)")
+                return nil
+            }
+
+            if let expectedSource, request.source != expectedSource {
+                logger.warning(
+                    "Pending export request source mismatch for \(id.uuidString): expected \(expectedSource.rawValue), found \(request.source.rawValue)"
+                )
+                return nil
+            }
+
+            return request
+        } catch {
+            logger.error("Failed to load pending export request: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func pendingExportSort(_ lhs: PendingExportRequest, _ rhs: PendingExportRequest) -> Bool {
+        if lhs.createdAt == rhs.createdAt {
+            return lhs.id.uuidString < rhs.id.uuidString
+        }
+        return lhs.createdAt < rhs.createdAt
+    }
+
+    @MainActor
+    private func runPendingExport(
+        _ request: PendingExportRequest,
+        trigger: PendingExportDrainTrigger
+    ) async {
+        guard shouldAttemptPendingExport(request, trigger: trigger) else {
+            return
+        }
+
+        logger.info("Draining pending export request \(request.id.uuidString) from \(request.source.rawValue)")
+        let result = await performPendingExportRequest(request)
+        await completePendingExportRequest(request, result: result)
+        processPendingExportResult(result, request: request)
+    }
+
+    @MainActor
+    private func shouldAttemptPendingExport(
+        _ request: PendingExportRequest,
+        trigger: PendingExportDrainTrigger
+    ) -> Bool {
+        switch request.source {
+        case .shortcut:
+            return true
+        case .scheduled:
+            guard schedule.isEnabled else {
+                logger.info("Schedule disabled, skipping pending scheduled export request \(request.id.uuidString)")
+                if trigger == .notificationTap {
+                    notificationExportResult = NotificationExportResult(
+                        status: .failure(reason: String(localized: "Scheduling is disabled", comment: "Error message when scheduling is disabled")),
+                        timestamp: Date()
+                    )
+                }
+                return false
+            }
+            return true
+        }
+    }
+
+    @MainActor
+    private func performPendingExportRequest(
+        _ request: PendingExportRequest
+    ) async -> ExportOrchestrator.ExportResult {
+        if let pendingExportRunner {
+            return await pendingExportRunner(request.dates, request.source)
+        }
+
+        switch request.source {
+        case .scheduled:
+            return await performBackgroundExport(dates: request.dates)
+        case .shortcut:
+            return await performShortcutPendingExport(dates: request.dates)
+        }
+    }
+
+    @MainActor
+    private func performShortcutPendingExport(dates: [Date]) async -> ExportOrchestrator.ExportResult {
+        guard !dates.isEmpty else {
+            logger.info("Pending Shortcut export skipped: no dates to export")
+            return ExportOrchestrator.ExportResult(
+                successCount: 0,
+                totalCount: 0,
+                failedDateDetails: []
+            )
+        }
+
+        await PurchaseManager.shared.refreshStatus()
+
+        guard PurchaseManager.shared.canExport else {
+            PricingAnalyticsClient.shared.trackExportBlockedByQuota(
+                context: .shortcut,
+                targetType: .localFile,
+                quotaState: PurchaseManager.shared.analyticsQuotaState
+            )
+            return ExportOrchestrator.ExportResult(
+                successCount: 0,
+                totalCount: 0,
+                failedDateDetails: []
+            )
+        }
+
+        let vaultManager = VaultManager()
+        let advancedSettings = AdvancedExportSettings()
+
+        guard vaultManager.hasVaultAccess else {
+            return ExportOrchestrator.ExportResult(
+                successCount: 0,
+                totalCount: dates.count,
+                failedDateDetails: dates.map { FailedDateDetail(date: $0, reason: .noVaultSelected) },
+                formatsPerDate: advancedSettings.exportFormats.count
+            )
+        }
+
+        vaultManager.refreshVaultAccess()
+        vaultManager.startVaultAccess()
+
+        let result = await ExportOrchestrator.exportDatesBackground(
+            dates,
+            healthKitManager: HealthKitManager.shared,
+            vaultManager: vaultManager,
+            settings: advancedSettings
+        )
+
+        vaultManager.stopVaultAccess()
+
+        if result.successCount > 0 {
+            recordShortcutExportUse(
+                dates: dates,
+                settings: advancedSettings,
+                result: result
+            )
+        }
+
+        return result
+    }
+
+    @MainActor
+    private func recordShortcutExportUse(
+        dates: [Date],
+        settings: AdvancedExportSettings,
+        result: ExportOrchestrator.ExportResult
+    ) {
+        let sortedDates = dates.sorted()
+        guard let startDate = sortedDates.first, let endDate = sortedDates.last else { return }
+
+        PurchaseManager.shared.recordExportUse()
+        let metadata = PricingAnalyticsExportMetadata(
+            targetType: .localFile,
+            formatCount: result.formatsPerDate,
+            metricCount: settings.metricSelection.totalEnabledCount,
+            dateRangePreset: PricingAnalyticsDateRangePreset.custom,
+            startDate: startDate,
+            endDate: endDate
+        )
+        PricingAnalyticsClient.shared.trackExportSucceeded(
+            metadata: metadata,
+            quotaState: PurchaseManager.shared.analyticsQuotaState
+        )
+    }
+
+    @MainActor
+    private func completePendingExportRequest(
+        _ request: PendingExportRequest,
+        result: ExportOrchestrator.ExportResult
+    ) async {
+        do {
+            if result.successCount > 0 {
+                try pendingExportStore.clearCompletedRequests(ids: [request.id])
+                exportNotificationScheduler.cancelPendingExportNotification(id: request.id)
+                return
+            }
+
+            try pendingExportStore.upsert(request)
+
+            if result.primaryFailureReason == .deviceLocked {
+                try await exportNotificationScheduler.sendImmediatePendingExportNotification(for: request)
+            }
+        } catch {
+            logger.error("Failed to complete pending export request: \(error.localizedDescription)")
+        }
+    }
+
+    @MainActor
+    private func processPendingExportResult(
+        _ result: ExportOrchestrator.ExportResult,
+        request: PendingExportRequest
+    ) {
+        let range = scheduledExportHistoryRange(for: request)
+
+        if result.successCount > 0 {
+            updateScheduleAfterPendingExport(request)
+            ExportOrchestrator.recordResult(
+                result,
+                source: exportSource(for: request.source),
+                dateRangeStart: range.start,
+                dateRangeEnd: range.end
+            )
+        } else if result.totalCount > 0 {
+            ExportOrchestrator.recordResult(
+                result,
+                source: exportSource(for: request.source),
+                dateRangeStart: range.start,
+                dateRangeEnd: range.end
+            )
+        }
+
+        notificationExportResult = makeNotificationExportResult(from: result)
+    }
+
+    @MainActor
+    private func updateScheduleAfterPendingExport(_ request: PendingExportRequest) {
+        switch request.source {
+        case .scheduled:
+            var updatedSchedule = schedule
+            updatedSchedule.updateLastExport()
+            schedule = updatedSchedule
+        case .shortcut:
+            let calendar = Calendar.current
+            let yesterday = calendar.startOfDay(
+                for: calendar.date(byAdding: .day, value: -1, to: Date()) ?? Date()
+            )
+            guard request.dates.contains(where: { calendar.isDate($0, inSameDayAs: yesterday) }) else {
+                return
+            }
+
+            var updatedSchedule = schedule
+            updatedSchedule.updateLastExport()
+            schedule = updatedSchedule
+        }
+    }
+
+    private func exportSource(for source: PendingExportSource) -> ExportSource {
+        switch source {
+        case .scheduled:
+            return .scheduled
+        case .shortcut:
+            return .shortcut
+        }
+    }
+
+    private func makeNotificationExportResult(
+        from result: ExportOrchestrator.ExportResult
+    ) -> NotificationExportResult {
+        if result.successCount > 0 {
+            return NotificationExportResult(
+                status: result.isFullSuccess
+                    ? .success(daysExported: result.successCount)
+                    : .partialSuccess(exported: result.successCount, total: result.totalCount),
+                timestamp: Date()
+            )
+        }
+
+        if result.totalCount > 0 {
+            return NotificationExportResult(
+                status: .failure(reason: result.primaryFailureReason?.shortDescription ?? "Unknown error"),
+                timestamp: Date()
+            )
+        }
+
+        return NotificationExportResult(status: .noExportNeeded, timestamp: Date())
     }
 
     @MainActor

--- a/HealthMdTests/iOS/SchedulingManagerPendingExportsTests.swift
+++ b/HealthMdTests/iOS/SchedulingManagerPendingExportsTests.swift
@@ -1,0 +1,248 @@
+#if os(iOS)
+import XCTest
+@testable import HealthMd
+
+@MainActor
+final class SchedulingManagerPendingExportsTests: XCTestCase {
+    private static let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        return calendar
+    }()
+
+    func testPerformPendingExportWithRequestIDExportsStoredDatesAndClearsOnSuccess() async throws {
+        let request = pendingRequest(
+            id: "11111111-1111-1111-1111-111111111111",
+            dates: [
+                date(year: 2026, month: 5, day: 12),
+                date(year: 2026, month: 5, day: 14)
+            ],
+            source: .scheduled
+        )
+        let store = TestPendingExportStore(requests: [request])
+        let notificationScheduler = InspectableExportNotificationScheduler()
+        var runs: [PendingExportRun] = []
+        let manager = makeManager(store: store, notificationScheduler: notificationScheduler) { dates, source in
+            runs.append(PendingExportRun(dates: dates, source: source))
+            return ExportOrchestrator.ExportResult(
+                successCount: dates.count,
+                totalCount: dates.count,
+                failedDateDetails: []
+            )
+        }
+
+        await manager.performPendingExport(requestId: request.id, source: .scheduled)
+
+        XCTAssertEqual(runs, [PendingExportRun(dates: request.dates, source: .scheduled)])
+        XCTAssertEqual(try store.loadAll(), [])
+        XCTAssertTrue(notificationScheduler.canceledRequestIDs.contains(request.id))
+        XCTAssertEqual(manager.notificationExportResult?.status, .success(daysExported: 2))
+    }
+
+    func testPerformPendingExportWithMissingRequestIsNoOp() async throws {
+        let store = TestPendingExportStore()
+        let notificationScheduler = InspectableExportNotificationScheduler()
+        var runs: [PendingExportRun] = []
+        let manager = makeManager(store: store, notificationScheduler: notificationScheduler) { dates, source in
+            runs.append(PendingExportRun(dates: dates, source: source))
+            return ExportOrchestrator.ExportResult(
+                successCount: dates.count,
+                totalCount: dates.count,
+                failedDateDetails: []
+            )
+        }
+
+        await manager.performPendingExport(
+            requestId: UUID(uuidString: "22222222-2222-2222-2222-222222222222")!,
+            source: .scheduled
+        )
+
+        XCTAssertEqual(runs, [])
+        XCTAssertEqual(try store.loadAll(), [])
+        XCTAssertNil(manager.notificationExportResult)
+    }
+
+    func testAppActiveDrainRunsAllPendingScheduledRequestsWhenScheduleEnabled() async throws {
+        let first = pendingRequest(
+            id: "33333333-3333-3333-3333-333333333333",
+            dates: [date(year: 2026, month: 5, day: 10)],
+            source: .scheduled,
+            createdAt: date(year: 2026, month: 5, day: 11, hour: 8)
+        )
+        let second = pendingRequest(
+            id: "44444444-4444-4444-4444-444444444444",
+            dates: [
+                date(year: 2026, month: 5, day: 12),
+                date(year: 2026, month: 5, day: 13)
+            ],
+            source: .scheduled,
+            createdAt: date(year: 2026, month: 5, day: 14, hour: 8)
+        )
+        let store = TestPendingExportStore(requests: [second, first])
+        let notificationScheduler = InspectableExportNotificationScheduler()
+        var runs: [PendingExportRun] = []
+        let manager = makeManager(store: store, notificationScheduler: notificationScheduler) { dates, source in
+            runs.append(PendingExportRun(dates: dates, source: source))
+            return ExportOrchestrator.ExportResult(
+                successCount: dates.count,
+                totalCount: dates.count,
+                failedDateDetails: []
+            )
+        }
+
+        await manager.drainPendingExportsIfNeeded(trigger: .appActive)
+
+        XCTAssertEqual(runs, [
+            PendingExportRun(dates: first.dates, source: .scheduled),
+            PendingExportRun(dates: second.dates, source: .scheduled)
+        ])
+        XCTAssertEqual(try store.loadAll(), [])
+        XCTAssertTrue(notificationScheduler.canceledRequestIDs.contains(first.id))
+        XCTAssertTrue(notificationScheduler.canceledRequestIDs.contains(second.id))
+    }
+
+    func testAppActiveDrainSkipsScheduledRequestsWhenScheduleDisabledButHonorsShortcutRequests() async throws {
+        let scheduled = pendingRequest(
+            id: "55555555-5555-5555-5555-555555555555",
+            dates: [date(year: 2026, month: 5, day: 10)],
+            source: .scheduled
+        )
+        let shortcut = pendingRequest(
+            id: "66666666-6666-6666-6666-666666666666",
+            dates: [date(year: 2026, month: 5, day: 11)],
+            source: .shortcut
+        )
+        let store = TestPendingExportStore(requests: [scheduled, shortcut])
+        let notificationScheduler = InspectableExportNotificationScheduler()
+        var runs: [PendingExportRun] = []
+        let manager = makeManager(
+            store: store,
+            notificationScheduler: notificationScheduler,
+            schedule: ExportSchedule(isEnabled: false)
+        ) { dates, source in
+            runs.append(PendingExportRun(dates: dates, source: source))
+            return ExportOrchestrator.ExportResult(
+                successCount: dates.count,
+                totalCount: dates.count,
+                failedDateDetails: []
+            )
+        }
+
+        await manager.drainPendingExportsIfNeeded(trigger: .appActive)
+
+        XCTAssertEqual(runs, [PendingExportRun(dates: shortcut.dates, source: .shortcut)])
+        XCTAssertEqual(try store.loadAll(), [scheduled])
+        XCTAssertFalse(notificationScheduler.canceledRequestIDs.contains(scheduled.id))
+        XCTAssertTrue(notificationScheduler.canceledRequestIDs.contains(shortcut.id))
+    }
+
+    func testDeviceLockedDrainAttemptKeepsRequestAndRecoveryNotification() async throws {
+        let request = pendingRequest(
+            id: "77777777-7777-7777-7777-777777777777",
+            dates: [date(year: 2026, month: 5, day: 10)],
+            source: .scheduled
+        )
+        let store = TestPendingExportStore(requests: [request])
+        let notificationScheduler = InspectableExportNotificationScheduler()
+        let manager = makeManager(store: store, notificationScheduler: notificationScheduler) { dates, _ in
+            ExportOrchestrator.ExportResult(
+                successCount: 0,
+                totalCount: dates.count,
+                failedDateDetails: [
+                    FailedDateDetail(date: dates[0], reason: .deviceLocked)
+                ]
+            )
+        }
+
+        await manager.performPendingExport(requestId: request.id, source: .scheduled)
+
+        XCTAssertEqual(try store.loadAll(), [request])
+        XCTAssertEqual(notificationScheduler.immediateRequests[request.id], request)
+        XCTAssertFalse(notificationScheduler.canceledRequestIDs.contains(request.id))
+        XCTAssertEqual(manager.notificationExportResult?.status, .failure(reason: ExportFailureReason.deviceLocked.shortDescription))
+    }
+
+    private func makeManager(
+        store: TestPendingExportStore,
+        notificationScheduler: InspectableExportNotificationScheduler,
+        schedule: ExportSchedule = ExportSchedule(isEnabled: true, frequency: .daily, preferredHour: 8),
+        exportRunner: @escaping SchedulingManager.PendingExportRunner
+    ) -> SchedulingManager {
+        SchedulingManager(
+            pendingExportStore: store,
+            exportNotificationScheduler: notificationScheduler,
+            initialSchedule: schedule,
+            persistScheduleChanges: false,
+            systemSideEffectsEnabled: false,
+            pendingExportRunner: exportRunner
+        )
+    }
+
+    private func pendingRequest(
+        id: String,
+        dates: [Date],
+        source: PendingExportSource,
+        createdAt: Date? = nil
+    ) -> PendingExportRequest {
+        PendingExportRequest(
+            id: UUID(uuidString: id)!,
+            dates: dates,
+            source: source,
+            scheduledFireDate: source == .scheduled ? date(year: 2026, month: 5, day: 18, hour: 8) : nil,
+            createdAt: createdAt ?? date(year: 2026, month: 5, day: 18, hour: 9),
+            notificationMetadata: ["notification": ExportNotificationType.pendingExport.rawValue],
+            calendar: Self.calendar
+        )
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int = 0, minute: Int = 0) -> Date {
+        Self.calendar.date(from: DateComponents(
+            timeZone: Self.calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        ))!
+    }
+}
+
+private struct PendingExportRun: Equatable {
+    let dates: [Date]
+    let source: PendingExportSource
+}
+
+private final class TestPendingExportStore: PendingExportStoring {
+    private var requests: [PendingExportRequest]
+
+    init(requests: [PendingExportRequest] = []) {
+        self.requests = requests
+    }
+
+    func loadAll() throws -> [PendingExportRequest] {
+        requests.sorted { lhs, rhs in
+            if lhs.createdAt == rhs.createdAt {
+                return lhs.id.uuidString < rhs.id.uuidString
+            }
+            return lhs.createdAt < rhs.createdAt
+        }
+    }
+
+    func upsert(_ request: PendingExportRequest) throws {
+        requests.removeAll { $0.id == request.id }
+        requests.append(request)
+    }
+
+    func remove(id: PendingExportRequest.ID) throws {
+        requests.removeAll { $0.id == id }
+    }
+
+    func clearCompletedRequests(ids: Set<PendingExportRequest.ID>) throws {
+        requests.removeAll { ids.contains($0.id) }
+    }
+
+    func notificationIdentifier(for request: PendingExportRequest) -> String {
+        ExportNotificationIdentifiers.pendingExport(for: request)
+    }
+}
+#endif


### PR DESCRIPTION
Fixes ISO-304

Implemented by Symphony agent automation.

## Issue

https://linear.app/isotech/issue/ISO-304/drain-pending-exports-from-notification-taps-and-app-active

## Notes for reviewer

- Review generated changes carefully before merge.
- Verify tests/builds relevant to this repository.
