### PR TITLE
Fix blank undismissable sheet on iOS 26 after completing onboarding

### DIFF
--- a/HealthMd/Shared/Managers/HealthKitManager.swift
+++ b/HealthMd/Shared/Managers/HealthKitManager.swift
@@ -406,7 +406,7 @@ final class HealthKitManager: ObservableObject {
         // On iOS 26, calling requestAuthorization when the user has already
         // made a decision shows a blank, undismissable sheet. Check first and
         // skip the system dialog if authorization is already settled.
-        let authRequestStatus = try await healthStore.statusForAuthorizationRequest(
+        let authRequestStatus = try await store.authorizationRequestStatus(
             toShare: [],
             read: allReadTypes
         )

--- a/HealthMd/Shared/Managers/HealthKitManager.swift
+++ b/HealthMd/Shared/Managers/HealthKitManager.swift
@@ -403,6 +403,19 @@ final class HealthKitManager: ObservableObject {
             return
         }
 
+        // On iOS 26, calling requestAuthorization when the user has already
+        // made a decision shows a blank, undismissable sheet. Check first and
+        // skip the system dialog if authorization is already settled.
+        let authRequestStatus = try await healthStore.statusForAuthorizationRequest(
+            toShare: [],
+            read: allReadTypes
+        )
+        if authRequestStatus == .unnecessary {
+            isAuthorized = true
+            authorizationStatus = "Connected"
+            return
+        }
+
         try await store.requestAuth(toShare: [], read: allReadTypes)
         isAuthorized = true
         authorizationStatus = "Connected"

--- a/HealthMd/iOS/HealthMdApp.swift
+++ b/HealthMd/iOS/HealthMdApp.swift
@@ -142,15 +142,6 @@ struct HealthMdApp: App {
         Task { @MainActor in
             SchedulingManager.shared.registerBackgroundTask()
 
-            // If onboarding is complete, request HealthKit authorization on launch.
-            // During onboarding, the OnboardingView handles this at the right step.
-            let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-            if hasCompletedOnboarding {
-                if HealthKitManager.shared.isHealthDataAvailable && !HealthKitManager.shared.isAuthorized {
-                    try? await HealthKitManager.shared.requestAuthorization()
-                }
-            }
-
             // Request notification permissions after HealthKit auth sheet is dismissed
             _ = await SchedulingManager.shared.requestNotificationPermissions()
 


### PR DESCRIPTION
Fixes #66.

Caveat that Claude fixed this and I manually tested this with the iPhone 17 simulator.

`HKHealthStore.requestAuthorization` was being called twice: once by `HealthMdApp.init()` and another by `ContentView.task`.

Now, if `HKAuthorizationRequestStatus` is `.unnecessary` we skip the system dialog. Additionally, the extra call site in `HealthMdApp.init()` is removed.

- Reproduction of #66: https://github.com/user-attachments/assets/a5036004-43f0-4b27-a1f8-eabc6dd17d85
- Fix: https://github.com/user-attachments/assets/5501b67a-82dc-40ab-ba0b-84cb7c8140a2

Note that the sheet still triggers and clears once (not ideal), but it unblocks the app on iOS 26