### PR TITLE
Fix skipped medication export counts

### DIFF
--- a/HealthMd/Shared/Models/MedicationData.swift
+++ b/HealthMd/Shared/Models/MedicationData.swift
@@ -67,6 +67,20 @@ enum MedicationDoseStatus: String, Codable, Sendable {
         case .unknown: return "Unknown"
         }
     }
+
+    /// HealthKit uses several non-`skipped` statuses for scheduled doses that
+    /// were not actually taken (for example, a dose that was never logged).
+    /// Export summaries only expose taken/skipped counts today, so group every
+    /// known non-taken status with skipped rather than letting missed doses look
+    /// like successful adherence.
+    var countsAsSkippedDose: Bool {
+        switch self {
+        case .skipped, .snoozed, .notInteracted, .notificationNotSent, .notLogged:
+            return true
+        case .taken, .unknown:
+            return false
+        }
+    }
 }
 
 enum MedicationDoseScheduleType: String, Codable, Sendable {
@@ -124,6 +138,6 @@ struct MedicationsData: Codable, Hashable, Sendable {
     }
 
     var skippedDoseEvents: [MedicationDoseEvent] {
-        doseEvents.filter { $0.logStatus == .skipped }
+        doseEvents.filter { $0.logStatus.countsAsSkippedDose }
     }
 }

--- a/HealthMdTests/Export/MarkdownExporterContractTests.swift
+++ b/HealthMdTests/Export/MarkdownExporterContractTests.swift
@@ -184,6 +184,62 @@ final class MarkdownExporterContractTests: XCTestCase {
         }
     }
 
+    // MARK: - Medication Contracts
+
+    func testMedications_notLoggedDoseCountsAsSkippedInSummary() {
+        var data = HealthData(date: ExportFixtures.referenceDate)
+        let calendar = Calendar(identifier: .gregorian)
+        let morningDose = calendar.date(byAdding: .hour, value: 8, to: ExportFixtures.referenceDate)!
+        let eveningDose = calendar.date(byAdding: .hour, value: 20, to: ExportFixtures.referenceDate)!
+
+        data.medications = MedicationsData(
+            medications: [
+                Medication(
+                    conceptIdentifier: "rxnorm:617314",
+                    displayName: "Levothyroxine Sodium 50 MCG Oral Tablet",
+                    nickname: "Thyroid",
+                    generalForm: "tablet",
+                    isArchived: false,
+                    hasSchedule: true,
+                    relatedCodings: []
+                )
+            ],
+            doseEvents: [
+                MedicationDoseEvent(
+                    id: UUID(uuidString: "00000000-0000-0000-0000-000000000401")!,
+                    medicationConceptIdentifier: "rxnorm:617314",
+                    medicationName: "Thyroid",
+                    startDate: morningDose,
+                    endDate: morningDose,
+                    scheduledDate: morningDose,
+                    doseQuantity: 1,
+                    scheduledDoseQuantity: 1,
+                    unit: "tablet",
+                    logStatus: .taken,
+                    scheduleType: .scheduled
+                ),
+                MedicationDoseEvent(
+                    id: UUID(uuidString: "00000000-0000-0000-0000-000000000402")!,
+                    medicationConceptIdentifier: "rxnorm:617314",
+                    medicationName: "Thyroid",
+                    startDate: eveningDose,
+                    endDate: eveningDose,
+                    scheduledDate: eveningDose,
+                    doseQuantity: nil,
+                    scheduledDoseQuantity: 1,
+                    unit: "tablet",
+                    logStatus: .notLogged,
+                    scheduleType: .scheduled
+                )
+            ]
+        )
+
+        let md = data.toMarkdown(customization: MDContractCustomizations.metric)
+
+        XCTAssertTrue(md.contains("**Dose events:** 2 (1 taken, 1 skipped)"))
+        XCTAssertTrue(md.contains("**Thyroid:** Not logged"))
+    }
+
     // MARK: - Summary Contracts
 
     func testSummaryIncluded_hasOverview() {

--- a/HealthMdTests/Models/ModelTests.swift
+++ b/HealthMdTests/Models/ModelTests.swift
@@ -391,6 +391,45 @@ final class HealthDataTests: XCTestCase {
         XCTAssertEqual(decoded.medications?.doseEvents.first?.logStatus, .taken)
     }
 
+    func testMedicationsData_countsMissedScheduledDosesAsSkipped() {
+        let startDate = Date(timeIntervalSince1970: 1_800_000_000)
+        let statuses: [MedicationDoseStatus] = [
+            .taken,
+            .skipped,
+            .snoozed,
+            .notInteracted,
+            .notificationNotSent,
+            .notLogged,
+            .unknown
+        ]
+
+        let doseEvents = statuses.enumerated().map { index, status in
+            let doseDate = startDate.addingTimeInterval(TimeInterval(index * 3_600))
+            return MedicationDoseEvent(
+                id: UUID(),
+                medicationConceptIdentifier: "rxnorm:617314",
+                medicationName: "D3",
+                startDate: doseDate,
+                endDate: doseDate,
+                scheduledDate: doseDate,
+                doseQuantity: status == .taken ? 1 : nil,
+                scheduledDoseQuantity: 1,
+                unit: "tablet",
+                logStatus: status,
+                scheduleType: .scheduled
+            )
+        }
+
+        let medications = MedicationsData(doseEvents: doseEvents)
+
+        XCTAssertEqual(medications.takenDoseEvents.map(\.logStatus), [.taken])
+        XCTAssertEqual(
+            medications.skippedDoseEvents.map(\.logStatus),
+            [.skipped, .snoozed, .notInteracted, .notificationNotSent, .notLogged],
+            "Unlogged/missed scheduled doses should count as skipped, not taken"
+        )
+    }
+
     func testFilteredByMetricSelection_disablesSpecificActivityMetricOnly() {
         var data = HealthData(date: Date())
         data.activity.steps = 10_000


### PR DESCRIPTION
## Summary
- Treat HealthKit unlogged/missed scheduled medication dose statuses as skipped for export aggregates
- Keep detailed dose rows/statuses visible (e.g. Not logged)
- Add model and Markdown export coverage

Fixes #69.

## Tests
- `git diff --check`
- `make test` (cannot run in this VM: `xcodebuild: not found`; PR CI will run the Xcode test matrix)