### PR TITLE
Persist export date range selection

### DIFF
--- a/HealthMd/Shared/Models/ExportDateRangePreset.swift
+++ b/HealthMd/Shared/Models/ExportDateRangePreset.swift
@@ -5,6 +5,199 @@ struct ExportDateRange: Equatable {
     let endDate: Date
 }
 
+struct ExportDateRangeSelection: Equatable {
+    let preset: ExportDateRangePreset
+    let startDate: Date
+    let endDate: Date
+
+    static func defaultSelection(
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> ExportDateRangeSelection {
+        let today = calendar.startOfDay(for: referenceDate)
+        let range = ExportDateRangePreset.today.resolvedRange(
+            referenceDate: referenceDate,
+            currentStartDate: today,
+            currentEndDate: today,
+            calendar: calendar
+        ) ?? ExportDateRange(startDate: today, endDate: today)
+
+        return ExportDateRangeSelection(
+            preset: .today,
+            startDate: range.startDate,
+            endDate: range.endDate
+        )
+    }
+}
+
+struct ExportDateRangeSelectionStore {
+    static let shared = ExportDateRangeSelectionStore()
+
+    private enum Key {
+        static let preset = "exportDateRangeSelection.preset"
+        static let startDate = "exportDateRangeSelection.startDate"
+        static let endDate = "exportDateRangeSelection.endDate"
+        static let customStartDayOffset = "exportDateRangeSelection.customStartDayOffset"
+        static let customEndDayOffset = "exportDateRangeSelection.customEndDayOffset"
+    }
+
+    let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func load(
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) -> ExportDateRangeSelection {
+        let fallback = ExportDateRangeSelection.defaultSelection(
+            referenceDate: referenceDate,
+            calendar: calendar
+        )
+        let preset = userDefaults.string(forKey: Key.preset)
+            .flatMap(ExportDateRangePreset.init(rawValue:)) ?? .today
+
+        switch preset {
+        case .today, .yesterday:
+            let range = preset.resolvedRange(
+                referenceDate: referenceDate,
+                currentStartDate: fallback.startDate,
+                currentEndDate: fallback.endDate,
+                calendar: calendar
+            ) ?? ExportDateRange(startDate: fallback.startDate, endDate: fallback.endDate)
+            return ExportDateRangeSelection(
+                preset: preset,
+                startDate: range.startDate,
+                endDate: range.endDate
+            )
+
+        case .custom:
+            let range = loadRollingCustomRange(
+                referenceDate: referenceDate,
+                calendar: calendar
+            ) ?? loadStoredAbsoluteRange(calendar: calendar)
+              ?? ExportDateRange(startDate: fallback.startDate, endDate: fallback.endDate)
+            return ExportDateRangeSelection(
+                preset: .custom,
+                startDate: range.startDate,
+                endDate: range.endDate
+            )
+
+        case .allTime:
+            let range = loadStoredAbsoluteRange(calendar: calendar)
+                ?? ExportDateRange(startDate: fallback.startDate, endDate: fallback.endDate)
+            return ExportDateRangeSelection(
+                preset: .allTime,
+                startDate: range.startDate,
+                endDate: range.endDate
+            )
+        }
+    }
+
+    func save(
+        preset: ExportDateRangePreset,
+        startDate: Date,
+        endDate: Date,
+        referenceDate: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        let normalizedRange = normalizedRange(
+            startDate: startDate,
+            endDate: endDate,
+            calendar: calendar
+        )
+
+        userDefaults.set(preset.rawValue, forKey: Key.preset)
+        userDefaults.set(
+            normalizedRange.startDate.timeIntervalSinceReferenceDate,
+            forKey: Key.startDate
+        )
+        userDefaults.set(
+            normalizedRange.endDate.timeIntervalSinceReferenceDate,
+            forKey: Key.endDate
+        )
+
+        guard preset == .custom else { return }
+
+        let today = calendar.startOfDay(for: referenceDate)
+        let startOffset = calendar.dateComponents(
+            [.day],
+            from: today,
+            to: normalizedRange.startDate
+        ).day ?? 0
+        let endOffset = min(
+            calendar.dateComponents(
+                [.day],
+                from: today,
+                to: normalizedRange.endDate
+            ).day ?? 0,
+            0
+        )
+
+        userDefaults.set(startOffset, forKey: Key.customStartDayOffset)
+        userDefaults.set(endOffset, forKey: Key.customEndDayOffset)
+    }
+
+    private func loadRollingCustomRange(
+        referenceDate: Date,
+        calendar: Calendar
+    ) -> ExportDateRange? {
+        guard let savedStartOffset = optionalInteger(forKey: Key.customStartDayOffset),
+              let savedEndOffset = optionalInteger(forKey: Key.customEndDayOffset) else {
+            return nil
+        }
+
+        let endOffset = min(savedEndOffset, 0)
+        let startOffset = min(savedStartOffset, endOffset)
+        let today = calendar.startOfDay(for: referenceDate)
+        let startDate = calendar.date(byAdding: .day, value: startOffset, to: today) ?? today
+        let endDate = calendar.date(byAdding: .day, value: endOffset, to: today) ?? today
+
+        return normalizedRange(
+            startDate: startDate,
+            endDate: endDate,
+            calendar: calendar
+        )
+    }
+
+    private func loadStoredAbsoluteRange(calendar: Calendar) -> ExportDateRange? {
+        guard let startInterval = optionalTimeInterval(forKey: Key.startDate),
+              let endInterval = optionalTimeInterval(forKey: Key.endDate) else {
+            return nil
+        }
+
+        return normalizedRange(
+            startDate: Date(timeIntervalSinceReferenceDate: startInterval),
+            endDate: Date(timeIntervalSinceReferenceDate: endInterval),
+            calendar: calendar
+        )
+    }
+
+    private func normalizedRange(
+        startDate: Date,
+        endDate: Date,
+        calendar: Calendar
+    ) -> ExportDateRange {
+        let startOfStart = calendar.startOfDay(for: startDate)
+        let startOfEnd = calendar.startOfDay(for: endDate)
+        if startOfStart <= startOfEnd {
+            return ExportDateRange(startDate: startOfStart, endDate: startOfEnd)
+        }
+        return ExportDateRange(startDate: startOfEnd, endDate: startOfStart)
+    }
+
+    private func optionalInteger(forKey key: String) -> Int? {
+        guard userDefaults.object(forKey: key) != nil else { return nil }
+        return userDefaults.integer(forKey: key)
+    }
+
+    private func optionalTimeInterval(forKey key: String) -> TimeInterval? {
+        guard userDefaults.object(forKey: key) != nil else { return nil }
+        return userDefaults.double(forKey: key)
+    }
+}
+
 enum ExportDateRangePreset: String, CaseIterable, Codable, Equatable, Identifiable {
     case today
     case yesterday

--- a/HealthMd/iOS/ContentView.swift
+++ b/HealthMd/iOS/ContentView.swift
@@ -7,6 +7,7 @@ import os.log
 struct ContentView: View {
     private static let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "Export")
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject var healthKitManager: HealthKitManager
     @EnvironmentObject var syncService: SyncService
     @StateObject private var vaultManager = VaultManager()
@@ -47,6 +48,30 @@ struct ContentView: View {
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @Environment(\.requestReview) private var requestReview
     @ObservedObject private var purchaseManager = PurchaseManager.shared
+
+    init() {
+        let savedDateRange = Self.initialDateRangeSelection()
+        _startDate = State(initialValue: savedDateRange.startDate)
+        _endDate = State(initialValue: savedDateRange.endDate)
+        _dateRangePreset = State(initialValue: savedDateRange.preset)
+    }
+
+    private static func initialDateRangeSelection() -> ExportDateRangeSelection {
+        #if DEBUG
+        if TestMode.isUITesting || MarketingCapture.isActive {
+            return ExportDateRangeSelection.defaultSelection()
+        }
+        #endif
+        return ExportDateRangeSelectionStore.shared.load()
+    }
+
+    private var shouldPersistDateRangeSelection: Bool {
+        #if DEBUG
+        return !TestMode.isUITesting && !MarketingCapture.isActive
+        #else
+        return true
+        #endif
+    }
 
     var body: some View {
         if !hasCompletedOnboarding && !TestMode.isUITesting {
@@ -340,6 +365,21 @@ struct ContentView: View {
                     // Silent fail on launch
                 }
             }
+
+            await refreshDateRangeSelectionForOpening()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active else { return }
+            Task { await refreshDateRangeSelectionForOpening() }
+        }
+        .onChange(of: dateRangePreset) { _, _ in
+            saveDateRangeSelection()
+        }
+        .onChange(of: startDate) { _, _ in
+            saveDateRangeSelection()
+        }
+        .onChange(of: endDate) { _, _ in
+            saveDateRangeSelection()
         }
         .onDisappear {
             statusDismissTimer?.invalidate()
@@ -442,6 +482,46 @@ struct ContentView: View {
             target: exportTargetSelection,
             hasLocalFolder: vaultManager.vaultURL != nil,
             canExportToConnectedMac: syncService.canExportToConnectedMac
+        )
+    }
+
+    // MARK: - Date Range Persistence
+
+    @MainActor
+    private func refreshDateRangeSelectionForOpening() async {
+        guard shouldPersistDateRangeSelection else { return }
+
+        let selection = ExportDateRangeSelectionStore.shared.load()
+        dateRangePreset = selection.preset
+        startDate = selection.startDate
+        endDate = selection.endDate
+
+        guard selection.preset == .allTime,
+              healthKitManager.isAuthorized,
+              let earliestDate = await healthKitManager.findEarliestHealthDataDate() else {
+            return
+        }
+
+        guard dateRangePreset == .allTime,
+              let range = ExportDateRangePreset.allTime.resolvedRange(
+                currentStartDate: startDate,
+                currentEndDate: endDate,
+                allTimeStartDate: earliestDate,
+                allTimeEndDate: Date()
+              ) else {
+            return
+        }
+
+        startDate = range.startDate
+        endDate = range.endDate
+    }
+
+    private func saveDateRangeSelection() {
+        guard shouldPersistDateRangeSelection else { return }
+        ExportDateRangeSelectionStore.shared.save(
+            preset: dateRangePreset,
+            startDate: startDate,
+            endDate: endDate
         )
     }
 

--- a/HealthMd/iPad/iPadContentView.swift
+++ b/HealthMd/iPad/iPadContentView.swift
@@ -7,6 +7,7 @@ import os.log
 struct iPadContentView: View {
     private static let logger = Logger(subsystem: "com.codybontecou.healthmd", category: "Export")
 
+    @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject var healthKitManager: HealthKitManager
     @EnvironmentObject var syncService: SyncService
     @EnvironmentObject var schedulingManager: SchedulingManager
@@ -29,6 +30,30 @@ struct iPadContentView: View {
     @State private var tempSubfolderName = ""
     @State private var showPaywall = false
     @ObservedObject private var purchaseManager = PurchaseManager.shared
+
+    init() {
+        let savedDateRange = Self.initialDateRangeSelection()
+        _startDate = State(initialValue: savedDateRange.startDate)
+        _endDate = State(initialValue: savedDateRange.endDate)
+        _dateRangePreset = State(initialValue: savedDateRange.preset)
+    }
+
+    private static func initialDateRangeSelection() -> ExportDateRangeSelection {
+        #if DEBUG
+        if TestMode.isUITesting || MarketingCapture.isActive {
+            return ExportDateRangeSelection.defaultSelection()
+        }
+        #endif
+        return ExportDateRangeSelectionStore.shared.load()
+    }
+
+    private var shouldPersistDateRangeSelection: Bool {
+        #if DEBUG
+        return !TestMode.isUITesting && !MarketingCapture.isActive
+        #else
+        return true
+        #endif
+    }
 
     var body: some View {
         NavigationSplitView {
@@ -146,6 +171,21 @@ struct iPadContentView: View {
                     // Silent fail on launch
                 }
             }
+
+            await refreshDateRangeSelectionForOpening()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active else { return }
+            Task { await refreshDateRangeSelectionForOpening() }
+        }
+        .onChange(of: dateRangePreset) { _, _ in
+            saveDateRangeSelection()
+        }
+        .onChange(of: startDate) { _, _ in
+            saveDateRangeSelection()
+        }
+        .onChange(of: endDate) { _, _ in
+            saveDateRangeSelection()
         }
     }
 
@@ -172,6 +212,46 @@ struct iPadContentView: View {
         healthKitManager.isAuthorized
             && vaultManager.vaultURL != nil
             && !advancedSettings.exportFormats.isEmpty
+    }
+
+    // MARK: - Date Range Persistence
+
+    @MainActor
+    private func refreshDateRangeSelectionForOpening() async {
+        guard shouldPersistDateRangeSelection else { return }
+
+        let selection = ExportDateRangeSelectionStore.shared.load()
+        dateRangePreset = selection.preset
+        startDate = selection.startDate
+        endDate = selection.endDate
+
+        guard selection.preset == .allTime,
+              healthKitManager.isAuthorized,
+              let earliestDate = await healthKitManager.findEarliestHealthDataDate() else {
+            return
+        }
+
+        guard dateRangePreset == .allTime,
+              let range = ExportDateRangePreset.allTime.resolvedRange(
+                currentStartDate: startDate,
+                currentEndDate: endDate,
+                allTimeStartDate: earliestDate,
+                allTimeEndDate: Date()
+              ) else {
+            return
+        }
+
+        startDate = range.startDate
+        endDate = range.endDate
+    }
+
+    private func saveDateRangeSelection() {
+        guard shouldPersistDateRangeSelection else { return }
+        ExportDateRangeSelectionStore.shared.save(
+            preset: dateRangePreset,
+            startDate: startDate,
+            endDate: endDate
+        )
     }
 
     private func presentExportPaywall() {

--- a/HealthMdTests/Models/ExportDateRangePresetTests.swift
+++ b/HealthMdTests/Models/ExportDateRangePresetTests.swift
@@ -3,11 +3,26 @@ import XCTest
 
 final class ExportDateRangePresetTests: XCTestCase {
     private var calendar: Calendar!
+    private var defaults: UserDefaults!
+    private var defaultsSuiteName: String!
 
     override func setUp() {
         super.setUp()
         calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        defaultsSuiteName = "ExportDateRangePresetTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+    }
+
+    override func tearDown() {
+        if let defaultsSuiteName {
+            defaults.removePersistentDomain(forName: defaultsSuiteName)
+        }
+        defaults = nil
+        defaultsSuiteName = nil
+        calendar = nil
+        super.tearDown()
     }
 
     func testTodayResolvesToCurrentCalendarDay() {
@@ -88,6 +103,95 @@ final class ExportDateRangePresetTests: XCTestCase {
         )
 
         XCTAssertNil(range)
+    }
+
+    func testSelectionStoreLoadsSavedPreset() {
+        let store = ExportDateRangeSelectionStore(userDefaults: defaults)
+        let savedReferenceDate = makeDate(year: 2026, month: 5, day: 13)
+        let nextLaunchDate = makeDate(year: 2026, month: 5, day: 14)
+
+        store.save(
+            preset: .yesterday,
+            startDate: savedReferenceDate,
+            endDate: savedReferenceDate,
+            referenceDate: savedReferenceDate,
+            calendar: calendar
+        )
+
+        let selection = store.load(referenceDate: nextLaunchDate, calendar: calendar)
+
+        XCTAssertEqual(selection.preset, .yesterday)
+        XCTAssertEqual(selection.startDate, makeDate(year: 2026, month: 5, day: 13))
+        XCTAssertEqual(selection.endDate, makeDate(year: 2026, month: 5, day: 13))
+    }
+
+    func testSelectionStoreRollsCustomRangeForwardBySavedOffsets() {
+        let store = ExportDateRangeSelectionStore(userDefaults: defaults)
+        let savedReferenceDate = makeDate(year: 2026, month: 5, day: 13, hour: 17)
+        let customStart = makeDate(year: 2026, month: 5, day: 11, hour: 9)
+        let customEnd = makeDate(year: 2026, month: 5, day: 13, hour: 18)
+
+        store.save(
+            preset: .custom,
+            startDate: customStart,
+            endDate: customEnd,
+            referenceDate: savedReferenceDate,
+            calendar: calendar
+        )
+
+        let selection = store.load(
+            referenceDate: makeDate(year: 2026, month: 5, day: 14, hour: 8),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(selection.preset, .custom)
+        XCTAssertEqual(selection.startDate, makeDate(year: 2026, month: 5, day: 12))
+        XCTAssertEqual(selection.endDate, makeDate(year: 2026, month: 5, day: 14))
+    }
+
+    func testSelectionStorePreservesCustomEndOffsetForYesterdayAnchoredRange() {
+        let store = ExportDateRangeSelectionStore(userDefaults: defaults)
+        let savedReferenceDate = makeDate(year: 2026, month: 5, day: 13)
+
+        store.save(
+            preset: .custom,
+            startDate: makeDate(year: 2026, month: 5, day: 10),
+            endDate: makeDate(year: 2026, month: 5, day: 12),
+            referenceDate: savedReferenceDate,
+            calendar: calendar
+        )
+
+        let selection = store.load(
+            referenceDate: makeDate(year: 2026, month: 5, day: 14),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(selection.preset, .custom)
+        XCTAssertEqual(selection.startDate, makeDate(year: 2026, month: 5, day: 11))
+        XCTAssertEqual(selection.endDate, makeDate(year: 2026, month: 5, day: 13))
+    }
+
+    func testSelectionStoreKeepsAllTimeStoredRangeUntilDataSourceRefreshesIt() {
+        let store = ExportDateRangeSelectionStore(userDefaults: defaults)
+        let start = makeDate(year: 2024, month: 1, day: 5, hour: 10)
+        let end = makeDate(year: 2026, month: 5, day: 12, hour: 18)
+
+        store.save(
+            preset: .allTime,
+            startDate: start,
+            endDate: end,
+            referenceDate: makeDate(year: 2026, month: 5, day: 13),
+            calendar: calendar
+        )
+
+        let selection = store.load(
+            referenceDate: makeDate(year: 2026, month: 5, day: 20),
+            calendar: calendar
+        )
+
+        XCTAssertEqual(selection.preset, .allTime)
+        XCTAssertEqual(selection.startDate, makeDate(year: 2024, month: 1, day: 5))
+        XCTAssertEqual(selection.endDate, makeDate(year: 2026, month: 5, day: 12))
     }
 
     private func makeDate(


### PR DESCRIPTION
## Summary
- Persist the iOS/iPad export date range preset across app opens
- Restore Today/Yesterday dynamically and keep Custom as a rolling relative range (e.g. last 3 days)
- Leave the macOS receiver/export intermediary UI untouched

## Tests
- xcodebuild test -project HealthMd.xcodeproj -scheme HealthMd-Tests-iOS -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' -only-testing:HealthMdTests/ExportDateRangePresetTests