### PR TITLE
chore: coordinate central Discord handoff

### DIFF
--- a/.github/workflows/apple-announce.yml
+++ b/.github/workflows/apple-announce.yml
@@ -298,6 +298,7 @@ jobs:
           echo "Recorded $APP_NAME v${{ steps.meta.outputs.version }} (${{ steps.meta.outputs.platform_label }}) in internal registry"
 
       - name: Post Discord update
+        if: github.event_name != 'repository_dispatch' || github.event.client_payload.discordOwner != 'central'
         env:
           DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
         run: |


### PR DESCRIPTION
Adds the transitional per-event ownership gate. Existing behavior is unchanged while the Worker emits `discordOwner=legacy`; the legacy POST is skipped only after the centralized Worker explicitly owns Discord. No release or message is triggered by this PR.