### PR TITLE
refactor: consume central release announcements

### DIFF
--- a/.github/workflows/apple-announce.yml
+++ b/.github/workflows/apple-announce.yml
@@ -1,26 +1,19 @@
-# Fire when ASC review approves a build (per-platform).
+# Run app-specific publication work after the central asc-webhook-worker has
+# verified Apple's webhook, resolved App Store metadata, and handled announcements.
 #
-# Triggered by repository_dispatch from the asc-webhook-worker (Cloudflare Worker
-# that verifies App Store Connect webhook signatures and routes by app id).
-#
-# Dispatch payload from the Worker:
-#   { state: "READY_FOR_SALE", appStoreVersionId: "<uuid>" }
-# Manual mode (workflow_dispatch) accepts version + platform directly so the
-# pipeline can be smoke-tested without a real ASC approval.
+# Required dispatch payload from the Worker:
+#   { deliveryKey, eventTimestamp, state, appStoreId, appStoreVersionId,
+#     version, platform, releaseNotes }
+# Manual mode accepts version + platform and defaults to a side-effect-free
+# metadata and release-notes preview.
 #
 # Effects:
 #   - Promote the draft GitHub release for v<version> to published
-#   - On macOS: publish the Developer ID zip (attached to the draft release) to isolated.tech
-#   - Post the per-platform release announcement to #health-md-updates on Discord
-#
-# Idempotent: if invoked twice for the same platform, the second run is mostly a no-op
-# (release already published; Discord post is the only duplicated side effect).
+#   - On macOS: publish the Developer ID zip attached to the release to isolated.tech
+#   - Record the release and optionally scaffold the launch checklist
 #
 # Required secrets:
-#   ASC_KEY_ID, ASC_ISSUER_ID, ASC_API_KEY_P8 (to look up version + platform from
-#                                              the appStoreVersionId in the webhook payload)
-#   ISOLATED_API_KEY, SPARKLE_ED_PRIVATE_KEY  (macOS isolated.tech publish)
-#   DISCORD_BOT_TOKEN
+#   ISOLATED_API_KEY, SPARKLE_ED_PRIVATE_KEY (macOS isolated.tech publish)
 #   INTERNAL_RELEASE_API_TOKEN
 # Optional secrets:
 #   LLM_WIKI_DISPATCH_TOKEN (fine-grained PAT with contents:write on CodyBontecou/llm-wiki)
@@ -44,9 +37,18 @@ on:
         required: true
         type: choice
         options: [IOS, MAC_OS]
+      dry_run:
+        description: 'Preview release metadata and notes without publishing side effects'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
+
+concurrency:
+  group: apple-announce-release
+  cancel-in-progress: false
 
 env:
   APP_NAME: Health.md
@@ -54,11 +56,10 @@ env:
   ASC_APP_ID: '6757763969'
   APP_STORE_URL: https://apps.apple.com/app/id6757763969
   BUNDLE_ID: com.codybontecou.obsidianhealth
-  DISCORD_CHANNEL_ID: '1498086736465760458'
 
 jobs:
   announce:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -66,138 +67,140 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Configure asc CLI
-        env:
-          ASC_KEY_ID_SECRET: ${{ secrets.ASC_KEY_ID }}
-          ASC_ISSUER_ID_SECRET: ${{ secrets.ASC_ISSUER_ID }}
-          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+      - name: Verify CLI dependencies
         run: |
-          ASC_KEY_DIR="$RUNNER_TEMP/.asc-keys"
-          mkdir -p "$ASC_KEY_DIR"
-          chmod 700 "$ASC_KEY_DIR"
-          ASC_KEY_PATH="$ASC_KEY_DIR/AuthKey_${ASC_KEY_ID_SECRET}.p8"
-          echo "$ASC_API_KEY_P8" | base64 --decode > "$ASC_KEY_PATH"
-          chmod 600 "$ASC_KEY_PATH"
-          {
-            echo "ASC_KEY_ID=$ASC_KEY_ID_SECRET"
-            echo "ASC_ISSUER_ID=$ASC_ISSUER_ID_SECRET"
-            echo "ASC_PRIVATE_KEY_PATH=$ASC_KEY_PATH"
-            echo "ASC_BYPASS_KEYCHAIN=1"
-          } >> "$GITHUB_ENV"
+          set -euo pipefail
+          gh --version
+          jq --version
 
       - name: Resolve dispatch payload
         id: meta
+        env:
+          ASCV_ID: ${{ github.event.client_payload.appStoreVersionId }}
+          PAYLOAD_APP_STORE_ID: ${{ github.event.client_payload.appStoreId }}
+          PAYLOAD_VERSION: ${{ github.event.client_payload.version }}
+          PAYLOAD_PLATFORM: ${{ github.event.client_payload.platform }}
+          PAYLOAD_DELIVERY_KEY: ${{ github.event.client_payload.deliveryKey }}
+          PAYLOAD_EVENT_TIMESTAMP: ${{ github.event.client_payload.eventTimestamp }}
+          STATE: ${{ github.event.client_payload.state }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
         run: |
-          ASCV_ID='${{ github.event.client_payload.appStoreVersionId }}'
-          STATE='${{ github.event.client_payload.state }}'
+          set -euo pipefail
 
-          if [[ -n "$ASCV_ID" ]]; then
-            # Webhook mode — look up version + platform from the ASC version ID
-            echo "Webhook mode: appStoreVersionId=$ASCV_ID state=$STATE"
-            V_JSON=$(asc versions view --version-id "$ASCV_ID" --output json)
-            VERSION=$(printf '%s' "$V_JSON" | jq -r '.versionString // .attributes.versionString // .data.attributes.versionString // empty')
-            PLATFORM=$(printf '%s' "$V_JSON" | jq -r '.platform // .attributes.platform // .data.attributes.platform // empty')
-            if [[ -z "$VERSION" || "$VERSION" == "null" || -z "$PLATFORM" || "$PLATFORM" == "null" ]]; then
-              echo "::error::asc versions view returned unexpected shape:"
-              printf '%s\n' "$V_JSON"
+          if [[ "$GITHUB_EVENT_NAME" == "repository_dispatch" ]]; then
+            case "$STATE" in
+              READY_FOR_DISTRIBUTION|READY_FOR_SALE) ;;
+              *) echo "::error::Unexpected approval state: ${STATE:-missing}"; exit 1 ;;
+            esac
+            if [[ "$PAYLOAD_APP_STORE_ID" != "$ASC_APP_ID" ]]; then
+              echo "::error::Dispatch App Store ID '${PAYLOAD_APP_STORE_ID:-missing}' does not match '$ASC_APP_ID'"
               exit 1
             fi
+            if [[ -z "$ASCV_ID" || -z "$PAYLOAD_VERSION" || -z "$PAYLOAD_PLATFORM" || -z "$PAYLOAD_DELIVERY_KEY" || -z "$PAYLOAD_EVENT_TIMESTAMP" ]]; then
+              echo "::error::Approval dispatch is missing appStoreVersionId, version, platform, deliveryKey, or eventTimestamp"
+              exit 1
+            fi
+            VERSION="$PAYLOAD_VERSION"
+            PLATFORM="$PAYLOAD_PLATFORM"
+            echo "Webhook mode: appStoreVersionId=$ASCV_ID version=$VERSION platform=$PLATFORM state=$STATE"
           else
-            # Manual mode — version + platform from inputs
-            VERSION='${{ inputs.version }}'
-            PLATFORM='${{ inputs.platform }}'
+            VERSION="$INPUT_VERSION"
+            PLATFORM="$INPUT_PLATFORM"
             echo "Manual mode: version=$VERSION platform=$PLATFORM"
           fi
 
-          if [[ -z "$VERSION" || -z "$PLATFORM" ]]; then
-            echo "::error::Could not resolve version + platform"
+          [[ "$PLATFORM" == "MACOS" ]] && PLATFORM=MAC_OS
+          if [[ ! "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ || -z "$PLATFORM" ]]; then
+            echo "::error::Could not resolve a valid version + platform"
             exit 1
           fi
           case "$PLATFORM" in
             IOS|MAC_OS) ;;
-            *) echo "::error::Unsupported platform: $PLATFORM (only IOS / MAC_OS announced)"; exit 1 ;;
+            *) echo "::error::Unsupported platform: $PLATFORM (only IOS / MAC_OS supported)"; exit 1 ;;
           esac
 
           PLATFORM_LABEL=$([[ "$PLATFORM" == "MAC_OS" ]] && echo macOS || echo iOS)
+          DELIVERY_KEY="${PAYLOAD_DELIVERY_KEY:-manual:${GITHUB_REPOSITORY}:${VERSION}:${PLATFORM}}"
+          EVENT_TIMESTAMP="${PAYLOAD_EVENT_TIMESTAMP:-}"
           {
             echo "version=$VERSION"
             echo "platform=$PLATFORM"
             echo "tag=v$VERSION"
             echo "platform_label=$PLATFORM_LABEL"
+            echo "delivery_key=$DELIVERY_KEY"
+            echo "event_timestamp=$EVENT_TIMESTAMP"
+            echo "dry_run=${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Fetch release (or fall back to ASC notes)
+      - name: Fetch release (or use dispatch notes)
         id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAYLOAD_RELEASE_NOTES: ${{ github.event.client_payload.releaseNotes }}
+          PAYLOAD_EVENT_TIMESTAMP: ${{ steps.meta.outputs.event_timestamp }}
+          VERSION: ${{ steps.meta.outputs.version }}
+          TAG: ${{ steps.meta.outputs.tag }}
         run: |
-          TAG='${{ steps.meta.outputs.tag }}'
+          set -euo pipefail
           NOTES_FILE="$RUNNER_TEMP/notes.md"
+          NOTES=""
 
-          if gh release view "$TAG" --json id,isDraft,body > "$RUNNER_TEMP/release.json" 2>/dev/null; then
-            jq -r .body "$RUNNER_TEMP/release.json" > "$NOTES_FILE"
+          if gh release view "$TAG" --json id,isDraft,body,publishedAt > "$RUNNER_TEMP/release.json" 2>/dev/null; then
+            NOTES=$(jq -r '.body // empty' "$RUNNER_TEMP/release.json")
             IS_DRAFT=$(jq -r .isDraft "$RUNNER_TEMP/release.json")
             HAS_RELEASE=true
           else
-            # No draft release (e.g. submitted to ASC directly or via an already-published GitHub Release).
-            # Fall back to the version's "What's New" text from ASC; the macOS
-            # zip path will be skipped by its own guard below.
-            echo "::notice::No GitHub release for $TAG; falling back to ASC What's New"
-            ASCV_ID='${{ github.event.client_payload.appStoreVersionId }}'
-            VERSION='${{ steps.meta.outputs.version }}'
-            PLATFORM='${{ steps.meta.outputs.platform }}'
-            if [[ -z "$ASCV_ID" ]]; then
-              ASCV_ID=$(asc versions list --app "$ASC_APP_ID" --output json \
-                | jq -r --arg v "$VERSION" --arg p "$PLATFORM" '
-                  def items:
-                    if type == "object" and has("data") then .data[]
-                    elif type == "array" then .[]
-                    else empty
-                    end;
-                  items
-                  | select((.versionString // .attributes.versionString) == $v and (.platform // .attributes.platform) == $p)
-                  | .id
-                ' \
-                | head -1)
-            fi
-            NOTES=""
-            if [[ -n "$ASCV_ID" && "$ASCV_ID" != "null" ]]; then
-              NOTES=$(asc localizations list --version "$ASCV_ID" --locale en-US --output json 2>/dev/null \
-                | jq -r '
-                  def items:
-                    if type == "object" and has("data") then .data[]
-                    elif type == "array" then .[]
-                    else empty
-                    end;
-                  items
-                  | select((.locale // .attributes.locale) == "en-US")
-                  | (.whatsNew // .attributes.whatsNew // empty)
-                ' \
-                | head -c 1500 || true)
-            fi
-            if [[ -z "$NOTES" ]]; then
-              NOTES="${APP_NAME} v${VERSION} is now live."
-            fi
-            printf '%s\n' "$NOTES" > "$NOTES_FILE"
+            echo "::notice::No GitHub release for $TAG; using dispatch release notes"
             IS_DRAFT=false
             HAS_RELEASE=false
           fi
 
+          if [[ -z "$NOTES" ]]; then
+            NOTES="${PAYLOAD_RELEASE_NOTES:-}"
+          fi
+          if [[ -z "$NOTES" ]]; then
+            NOTES="${APP_NAME} v${VERSION} is now live."
+          fi
+          printf '%s\n' "$NOTES" > "$NOTES_FILE"
+
+          PUBLISHED_AT="${PAYLOAD_EVENT_TIMESTAMP:-}"
+          if [[ -z "$PUBLISHED_AT" && "$HAS_RELEASE" == "true" ]]; then
+            PUBLISHED_AT=$(jq -r '.publishedAt // empty' "$RUNNER_TEMP/release.json")
+          fi
+          PUBLISHED_AT="${PUBLISHED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
           {
             echo "is_draft=$IS_DRAFT"
             echo "has_release=$HAS_RELEASE"
+            echo "published_at=$PUBLISHED_AT"
           } >> "$GITHUB_OUTPUT"
 
       - name: Verify isolated CLI
-        if: steps.meta.outputs.platform == 'MAC_OS' && steps.release.outputs.has_release == 'true'
+        if: steps.meta.outputs.dry_run != 'true' && steps.meta.outputs.platform == 'MAC_OS' && steps.release.outputs.has_release == 'true'
         run: |
           if ! command -v isolated &>/dev/null; then
             npm install -g --force @isolatedtech/cli
           fi
           isolated --version
 
+      - name: Check isolated.tech version
+        id: isolated_version
+        if: steps.meta.outputs.dry_run != 'true' && steps.meta.outputs.platform == 'MAC_OS' && steps.release.outputs.has_release == 'true'
+        env:
+          ISOLATED_API_KEY: ${{ secrets.ISOLATED_API_KEY }}
+        run: |
+          set -euo pipefail
+          isolated --json apps versions '${{ vars.ISOLATED_APP_SLUG }}' > "$RUNNER_TEMP/isolated-versions.json"
+          if jq -e --arg version '${{ steps.meta.outputs.version }}' '.versions[]? | select(.version == $version)' "$RUNNER_TEMP/isolated-versions.json" >/dev/null; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "isolated.tech already has v${{ steps.meta.outputs.version }}; skipping duplicate publish"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download macOS zip from release
-        if: steps.meta.outputs.platform == 'MAC_OS' && steps.release.outputs.has_release == 'true'
+        if: steps.meta.outputs.dry_run != 'true' && steps.meta.outputs.platform == 'MAC_OS' && steps.release.outputs.has_release == 'true' && steps.isolated_version.outputs.exists != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -211,7 +214,8 @@ jobs:
           echo "ZIP_PATH=$ZIP_PATH" >> "$GITHUB_ENV"
 
       - name: Publish to isolated.tech
-        if: steps.meta.outputs.platform == 'MAC_OS' && steps.release.outputs.has_release == 'true'
+        id: isolated
+        if: steps.meta.outputs.dry_run != 'true' && steps.meta.outputs.platform == 'MAC_OS' && steps.release.outputs.has_release == 'true' && steps.isolated_version.outputs.exists != 'true'
         env:
           ISOLATED_API_KEY: ${{ secrets.ISOLATED_API_KEY }}
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
@@ -224,12 +228,14 @@ jobs:
             --no-bump
 
       - name: Promote draft GitHub release
-        if: steps.release.outputs.is_draft == 'true'
+        id: promote
+        if: steps.meta.outputs.dry_run != 'true' && steps.release.outputs.is_draft == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit '${{ steps.meta.outputs.tag }}' --draft=false
 
       - name: Trigger llm-wiki launch checklist scaffold
+        if: steps.meta.outputs.dry_run != 'true'
         env:
           LLM_WIKI_DISPATCH_TOKEN: ${{ secrets.LLM_WIKI_DISPATCH_TOKEN }}
         run: |
@@ -242,10 +248,12 @@ jobs:
             -f event_type=generate-launch-checklist \
             -F "client_payload[app]=$APP_SLUG" \
             -F "client_payload[version]=${{ steps.meta.outputs.version }}" \
+            -F "client_payload[delivery_key]=${{ steps.meta.outputs.delivery_key }}" \
             -F "client_payload[asc_id]=$ASC_APP_ID" \
             -F "client_payload[repo]=${{ github.repository }}"
 
       - name: Record release in internal registry
+        if: steps.meta.outputs.dry_run != 'true'
         env:
           INTERNAL_RELEASE_API_URL: ${{ vars.INTERNAL_RELEASE_API_URL }}
           INTERNAL_RELEASE_API_TOKEN: ${{ secrets.INTERNAL_RELEASE_API_TOKEN }}
@@ -267,7 +275,8 @@ jobs:
             --arg version '${{ steps.meta.outputs.version }}' \
             --arg platform '${{ steps.meta.outputs.platform }}' \
             --rawfile releaseNotes "$RUNNER_TEMP/notes.md" \
-            --arg publishedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg publishedAt '${{ steps.release.outputs.published_at }}' \
+            --arg deliveryKey '${{ steps.meta.outputs.delivery_key }}' \
             --arg ascVersionId "${ASCV_ID:-}" \
             --arg source "asc-webhook" \
             --arg sourceUrl "https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}" \
@@ -284,6 +293,7 @@ jobs:
               platform: $platform,
               releaseNotes: $releaseNotes,
               publishedAt: $publishedAt,
+              deliveryKey: $deliveryKey,
               ascVersionId: $ascVersionId,
               source: $source,
               sourceUrl: $sourceUrl
@@ -297,46 +307,48 @@ jobs:
           echo "$RESP" | jq -e '.data.release.id and (.error == null)' >/dev/null
           echo "Recorded $APP_NAME v${{ steps.meta.outputs.version }} (${{ steps.meta.outputs.platform_label }}) in internal registry"
 
-      - name: Post Discord update
-        if: github.event_name != 'repository_dispatch' || github.event.client_payload.discordOwner != 'central'
-        env:
-          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN }}
-        run: |
-          BODY_FILE="$RUNNER_TEMP/discord.md"
-          NOTES=$(head -c 1500 "$RUNNER_TEMP/notes.md")
-          cat > "$BODY_FILE" <<DISCORD_EOF
-          🟢 ${APP_NAME} v${{ steps.meta.outputs.version }} is live on ${{ steps.meta.outputs.platform_label }}.
-
-          ${NOTES}
-
-          App Store: ${APP_STORE_URL}
-          DISCORD_EOF
-
-          PAYLOAD=$(jq -n \
-            --rawfile c "$BODY_FILE" \
-            '{ content: $c, allowed_mentions: { parse: [] } }')
-
-          RESP=$(curl -fsS -X POST "https://discord.com/api/v10/channels/${DISCORD_CHANNEL_ID}/messages" \
-            -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
-            -H "Content-Type: application/json" \
-            -H "User-Agent: DiscordBot (https://github.com/${{ github.repository }}, 1.0)" \
-            -d "$PAYLOAD")
-
-          MSG_ID=$(echo "$RESP" | jq -r .id)
-          echo "Posted to Discord: https://discord.com/channels/1443424100759634003/${DISCORD_CHANNEL_ID}/${MSG_ID}"
-
       - name: Summary
         if: always()
         run: |
           {
             echo "## Announce ${{ steps.meta.outputs.tag }} (${{ steps.meta.outputs.platform_label }})"
             echo ""
-            if [[ "${{ steps.release.outputs.has_release }}" == "true" ]]; then
-              echo "- GitHub release: ${{ steps.release.outputs.is_draft == 'true' && 'promoted from draft' || 'already published' }}"
-              echo "- isolated.tech: ${{ steps.meta.outputs.platform == 'MAC_OS' && 'published' || 'skipped (iOS)' }}"
-            else
+            if [[ "${{ steps.meta.outputs.dry_run }}" == "true" ]]; then
+              echo "- Mode: dry run (no release promotion, isolated.tech publish, registry write, or wiki dispatch)"
+            fi
+            if [[ "${{ steps.meta.outputs.dry_run }}" == "true" ]]; then
+              echo "- GitHub release: unchanged (dry run)"
+              echo "- isolated.tech: skipped (dry run)"
+            elif [[ "${{ steps.release.outputs.has_release }}" != "true" ]]; then
               echo "- GitHub release: skipped (no draft existed; submitted via asc directly)"
               echo "- isolated.tech: skipped (no zip available without a draft release)"
+            else
+              if [[ "${{ steps.release.outputs.is_draft }}" != "true" ]]; then
+                echo "- GitHub release: already published"
+              elif [[ "${{ steps.promote.outcome }}" == "success" ]]; then
+                echo "- GitHub release: promoted from draft"
+              elif [[ "${{ steps.promote.outcome }}" == "failure" ]]; then
+                echo "- GitHub release: promotion failed"
+              else
+                echo "- GitHub release: promotion skipped after an earlier failure"
+              fi
+              if [[ "${{ steps.meta.outputs.platform }}" != "MAC_OS" ]]; then
+                echo "- isolated.tech: skipped (iOS)"
+              elif [[ "${{ steps.isolated_version.outputs.exists }}" == "true" ]]; then
+                echo "- isolated.tech: already published"
+              elif [[ "${{ steps.isolated.outcome }}" == "success" ]]; then
+                echo "- isolated.tech: published"
+              elif [[ "${{ steps.isolated.outcome }}" == "failure" ]]; then
+                echo "- isolated.tech: publish failed"
+              else
+                echo "- isolated.tech: publish skipped after an earlier failure"
+              fi
             fi
-            echo "- Discord: posted to #health-md-updates"
+            if [[ "${{ steps.meta.outputs.dry_run }}" == "true" ]]; then
+              echo ""
+              echo "### Release notes preview"
+              echo '```text'
+              cat "$RUNNER_TEMP/notes.md"
+              echo '```'
+            fi
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Moves ASC metadata resolution and Discord delivery to the centralized queue/D1 Worker while retaining Health.md-specific GitHub release, isolated.tech, llm-wiki, and registry effects. Adds stable delivery metadata and isolated.tech version preflight for at-least-once safety. Manual runs default to dry-run.\n\n**Rollout:** do not merge until one centrally owned live event has validated the transitional `discordOwner` handoff.