### PR TITLE
Add Pi health dashboard reader package

### DIFF
--- a/.github/workflows/pi-health-dashboard-ci.yml
+++ b/.github/workflows/pi-health-dashboard-ci.yml
@@ -1,0 +1,151 @@
+name: Pi Health Dashboard CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/pi-healthmd-dashboard/**'
+      - 'packages/contracts/**'
+      - 'packages/healthmd-core-rust/crates/healthmd-protocol/**'
+      - 'apps/cli/**'
+      - 'apps/apple/docs/reference/generated/**'
+      - 'apps/android/app/src/test/resources/**'
+      - 'apps/android/docs/export-contract/**'
+      - 'Makefile'
+      - 'README.md'
+      - 'LICENSES.md'
+      - '.github/workflows/pi-health-dashboard-ci.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pi-health-dashboard-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout monorepo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: packages/pi-healthmd-dashboard/package-lock.json
+
+      - name: Install package dependencies
+        working-directory: packages/pi-healthmd-dashboard
+        run: npm ci
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@1.85.0
+
+      - name: Cache CLI build
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pi-health-dashboard
+          workspaces: apps/cli -> target
+
+      - name: Verify CLI/MCP canonical query parity
+        working-directory: apps/cli
+        run: cargo test -p healthmd-cli mcp::tests::every_query_operation_has_cli_and_mcp_canonical_parity --locked
+
+      - name: Verify fetched-operation registry against built CLI
+        run: |
+          cargo run --quiet --manifest-path apps/cli/Cargo.toml -p healthmd-cli --bin healthmd -- mcp schema > "$RUNNER_TEMP/healthmd-mcp-catalog.json"
+          cd packages/pi-healthmd-dashboard
+          CATALOG="$RUNNER_TEMP/healthmd-mcp-catalog.json" node --import=tsx --input-type=module <<'NODE'
+          import { readFileSync } from "node:fs";
+          import { HEALTHMD_READ_OPERATIONS } from "./src/source.ts";
+          const catalog = JSON.parse(readFileSync(process.env.CATALOG, "utf8"));
+          const fixedReadOnly = catalog.tools.slice(0, HEALTHMD_READ_OPERATIONS.length);
+          const actual = fixedReadOnly.map(tool => tool.name);
+          if (JSON.stringify(actual) !== JSON.stringify(HEALTHMD_READ_OPERATIONS)) throw new Error(JSON.stringify({ actual, expected: HEALTHMD_READ_OPERATIONS }));
+          if (fixedReadOnly.some(tool => tool.annotations?.readOnlyHint !== true)) throw new Error("Configured fetched operation is not read-only in the built CLI registry");
+          NODE
+
+      - name: Test and typecheck package
+        run: make test-pi-health-dashboard
+
+      - name: Audit production dependencies
+        working-directory: packages/pi-healthmd-dashboard
+        run: npm audit --omit=dev
+
+      - name: Validate shared contracts
+        run: make test-contracts
+
+      - name: Pack and verify published contents
+        id: pack
+        working-directory: packages/pi-healthmd-dashboard
+        run: |
+          mkdir -p "$RUNNER_TEMP/pi-health-pack"
+          npm pack --json --pack-destination "$RUNNER_TEMP/pi-health-pack" > "$RUNNER_TEMP/pi-health-pack.json"
+          jq -e '.[0].files | map(.path) | index("src/extension.ts") != null' "$RUNNER_TEMP/pi-health-pack.json"
+          jq -e '.[0].files | map(.path) | index("src/source.ts") != null' "$RUNNER_TEMP/pi-health-pack.json"
+          jq -e '.[0].files | map(.path) | index("src/query-contract.ts") != null' "$RUNNER_TEMP/pi-health-pack.json"
+          jq -e '.[0].files | map(.path) | index("schemas/unified-health-data-v9.schema.json") != null' "$RUNNER_TEMP/pi-health-pack.json"
+          jq -e '.[0].files | map(.path) | all(startswith("test/") | not)' "$RUNNER_TEMP/pi-health-pack.json"
+          echo "tarball=$RUNNER_TEMP/pi-health-pack/$(jq -r '.[0].filename' "$RUNNER_TEMP/pi-health-pack.json")" >> "$GITHUB_OUTPUT"
+
+      - name: Install the production tarball with pinned Pi
+        env:
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/pi-health-install"
+          cd "$RUNNER_TEMP/pi-health-install"
+          npm init -y >/dev/null
+          npm install --omit=dev "$TARBALL" \
+            @earendil-works/pi-ai@0.84.1 \
+            @earendil-works/pi-coding-agent@0.84.1 \
+            typebox@1.3.7
+
+      - name: Load installed extension with the pinned Pi runtime
+        run: |
+          cd "$RUNNER_TEMP/pi-health-install"
+          node --input-type=module <<'NODE'
+          import { resolve } from "node:path";
+          import { discoverAndLoadExtensions } from "@earendil-works/pi-coding-agent";
+          const target = resolve("node_modules/@healthmd/pi-health-dashboard/src/extension.ts");
+          const result = await discoverAndLoadExtensions([target], process.cwd());
+          if (result.errors.length) {
+            console.error(result.errors);
+            process.exit(1);
+          }
+          const extension = result.extensions.find(item => item.resolvedPath === target);
+          if (!extension) {
+            console.error(`Installed extension not loaded: ${target}`);
+            process.exit(1);
+          }
+          const actual = {
+            tools: [...extension.tools.keys()].sort(),
+            commands: [...extension.commands.keys()].sort(),
+            flags: [...extension.flags.keys()].sort(),
+          };
+          const expected = {
+            tools: ["healthmd_fetch", "healthmd_load", "healthmd_query", "healthmd_view"],
+            commands: ["healthmd"],
+            flags: ["healthmd-cache-dir", "healthmd-cli-path", "healthmd-data", "healthmd-device", "healthmd-fetch-transport", "healthmd-mcp-path", "healthmd-port"],
+          };
+          if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+            console.error({ actual, expected });
+            process.exit(1);
+          }
+          NODE
+
+  gate:
+    name: Pi Health Dashboard CI
+    if: ${{ always() }}
+    needs: [validate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require dashboard checks
+        env:
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+        run: test "$VALIDATE_RESULT" = success

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - `apps/website`: website and generated product documentation.
 - `packages/contracts`: language-neutral schemas and interoperability fixtures.
 - `packages/healthmd-core-rust`: shared Rust core, UniFFI tooling, and direct-protocol crate.
+- `packages/pi-healthmd-dashboard`: experimental TypeScript multi-contract reader and Pi TUI dashboard extension with approved-file and read-only CLI/MCP query sources.
 
 Read the nearest component `AGENTS.md` before changing files in a component. Keep component build commands, lockfiles, and generated artifacts scoped to that component.
 

--- a/LICENSES.md
+++ b/LICENSES.md
@@ -10,5 +10,6 @@ Health.md is a monorepo containing independently built products.
 | `apps/website/` | MIT License |
 | `packages/contracts/` | Not yet established; preserve source-component notices until a contract license is selected |
 | `packages/healthmd-core-rust/` | GNU Affero General Public License v3.0 only |
+| `packages/pi-healthmd-dashboard/` | GNU Affero General Public License v3.0 only |
 
-The root [`LICENSE`](LICENSE) contains the AGPL-3.0 text used by the Apple application, CLI, shared Rust core, and AGPL-scoped root tooling. The website's MIT terms are in [`apps/website/LICENSE`](apps/website/LICENSE). Component-level license files remain authoritative for their directories. Third-party dependencies and bundled assets retain their own license and attribution terms.
+The root [`LICENSE`](LICENSE) contains the AGPL-3.0 text used by the Apple application, CLI, shared Rust core, Pi dashboard package, and AGPL-scoped root tooling. The website's MIT terms are in [`apps/website/LICENSE`](apps/website/LICENSE). Component-level license files remain authoritative for their directories. Third-party dependencies and bundled assets retain their own license and attribution terms.

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ CORE_RUST_DIR := packages/healthmd-core-rust
 CORE_BINDINGS_DIR ?= $(CURDIR)/$(CORE_RUST_DIR)/target/generated-bindings
 
 .PHONY: test test-contracts test-product-parity test-core check-core-registry core-bindings check-core-bindings \
-        test-apple test-android test-cli test-website apple-ios apple-macos cli-build \
+        test-apple test-android test-cli test-website test-pi-health-dashboard apple-ios apple-macos cli-build \
         android-build website-build
 
-test: test-contracts test-core test-apple test-android test-cli test-website
+test: test-contracts test-core test-apple test-android test-cli test-website test-pi-health-dashboard
 
 test-contracts:
 	python3 packages/contracts/validate.py
@@ -51,6 +51,9 @@ test-cli:
 
 test-website:
 	cd apps/website && npm test
+
+test-pi-health-dashboard:
+	cd packages/pi-healthmd-dashboard && npm test && npm run typecheck
 
 apple-ios:
 	$(MAKE) -C apps/apple test-ios

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Health.md is a local-first health data platform. This repository is the canonica
 | [`apps/website`](apps/website) | Product website and documentation | Node.js / Astro |
 | [`packages/contracts`](packages/contracts) | Cross-platform schemas and compatibility fixtures | Language-neutral |
 | [`packages/healthmd-core-rust`](packages/healthmd-core-rust) | Shared export core, UniFFI binding tooling, and direct protocol | Cargo / Rust |
+| [`packages/pi-healthmd-dashboard`](packages/pi-healthmd-dashboard) | Experimental multi-contract Pi dashboard with approved-file and read-only CLI/MCP query sources | Node.js / TypeScript |
 
 The [Health.md Obsidian plugin](https://github.com/CodyBontecou/health-md-visualizations) remains in its own repository and is treated as an external integration.
 

--- a/packages/contracts/manifest.json
+++ b/packages/contracts/manifest.json
@@ -81,7 +81,8 @@
       ],
       "consumers": [
         "apps/apple/Packages/HealthMdConnectivity/Tests/HealthMdConnectionCoreTests/HealthMdConnectionCoreTests.swift",
-        "packages/healthmd-core-rust/crates/healthmd-protocol/tests/swift_v3_query_vectors.rs"
+        "packages/healthmd-core-rust/crates/healthmd-protocol/tests/swift_v3_query_vectors.rs",
+        "packages/pi-healthmd-dashboard/src/source.ts"
       ],
       "fixtures": [
         {
@@ -316,7 +317,8 @@
       ],
       "consumers": [
         "packages/contracts/validate.py",
-        "docs/architecture/rfc-0004-unified-health-data-v9.md"
+        "docs/architecture/rfc-0004-unified-health-data-v9.md",
+        "packages/pi-healthmd-dashboard/src/contracts.ts"
       ],
       "documentation": [
         "docs/architecture/rfc-0002-unified-health-data-v8.md",

--- a/packages/pi-healthmd-dashboard/LICENSE
+++ b/packages/pi-healthmd-dashboard/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/packages/pi-healthmd-dashboard/README.md
+++ b/packages/pi-healthmd-dashboard/README.md
@@ -1,0 +1,105 @@
+# Health.md dashboard for Pi
+
+Experimental, local-first, read-only Pi extension for inspecting approved Health.md JSON or fetching bounded typed query responses through the Health.md CLI/MCP server. Package: `@healthmd/pi-health-dashboard`.
+
+## Safety and model disclosure
+
+There is intentionally no per-tool confirmation. Filesystem loading is restricted to **approved realpath roots**:
+
+- `--healthmd-data <path>` and `HEALTHMD_DATA_PATH=<path>` approve and load that root at startup.
+- The user-authored `/healthmd load <path>` command approves and loads that root.
+- The model-callable `healthmd_load` tool may subsequently load only the approved root or realpath descendants.
+
+Traversal, outside paths, symlink inputs, and symlink aliases escaping a root are rejected. If no root exists, the tool directs the user to approve one by flag, environment variable, or command. Directory traversal ignores symlinks and loads regular `.json` files only.
+
+`healthmd_fetch` is a separate validated source. It invokes only the 13 fixed read-only readiness, catalog, and typed-query operations through newline-delimited MCP stdio; explicit CLI mode supports the nine query operations accepted by `healthmd query`. MCP mode starts `healthmd mcp serve-read-only` unless a standalone helper is explicitly configured. The model cannot supply an executable, arbitrary command, raw-export selector, pairing operation, or file-export operation; no backend/transport fallback occurs. Subprocesses use argument arrays without a shell, an allowlisted environment that excludes unrelated Pi/provider secrets, bounded stdout/stderr, cancellation, a 1–3,600 second timeout, and terminate-to-kill process-group escalation. Typed queries must return structurally valid `healthmd.query_response/1` or `healthmd.mcp_query_pages/1`; wrong versions and malformed pages fail closed. Accepted responses then pass through the same lossless parser, contract classifier, index bounds, and model-output limits as files.
+
+**Loaded or fetched health evidence can enter model context and Pi session/JSON output.** The extension does not add custom Pi session entries, but ordinary tool calls/results may be persisted by Pi. Approve only data intended for model disclosure.
+
+Defaults bound loading to 256 documents, 100,000 traversed directory entries (including non-JSON entries), 32 MiB per file, 128 MiB total, 500,000 scalar leaves, 1,000,000 total nodes, depth 256, 4 KiB per indexed path, 64 MiB across retained index paths, 10,000 digest references, and 1,024 characters per numeric token. Depth is preflighted before parsing. Approved-root confinement is carried through traversal and final open; files are opened no-follow where supported, sized before allocation, rechecked against their opened device/inode and canonical path, read with a hard cap, and closed. Query evidence is at most 24,000 UTF-8 bytes; every tool result is at most 45,000 UTF-8 bytes, below Pi's 50 KB tool-result limit. Structured values, provenance, and tool result objects use bounded previews rather than repeatedly serializing whole subtrees.
+
+## Install and use
+
+From this repository:
+
+```sh
+pi install ./packages/pi-healthmd-dashboard
+# Or try it without installing:
+pi -e ./packages/pi-healthmd-dashboard --healthmd-data /explicit/path/to/export.json
+```
+
+Once the package is published publicly:
+
+```sh
+pi install npm:@healthmd/pi-health-dashboard
+HEALTHMD_DATA_PATH=/explicit/path/to/export-directory pi
+```
+
+For live typed queries, install/pair the standalone `healthmd` CLI, keep Health.md foreground on iPhone, and use the default least-privilege MCP transport. The portable CLI is currently `0.1.0-alpha.1` and its public mobile pairing matrix remains pending physical qualification:
+
+```sh
+healthmd direct pair
+pi --healthmd-cli-path "$(command -v healthmd)" --healthmd-fetch-transport mcp
+```
+
+A Mac app bundled stdio helper can be selected explicitly with `--healthmd-mcp-path /Applications/Health.md.app/Contents/Helpers/healthmd-mcp` or `HEALTHMD_MCP_PATH`. Other configuration variables are `HEALTHMD_CLI_PATH`, `HEALTHMD_FETCH_TRANSPORT=cli|mcp`, `HEALTHMD_DEVICE_ID`, `HEALTHMD_CLI_PORT`, and `HEALTHMD_CACHE_DIR`. CLI mode is explicit (`transport: "cli"` or `--healthmd-fetch-transport cli`); MCP is the default because query arguments travel over stdin rather than the process list.
+
+Tools:
+
+- `healthmd_load`: load a path under an already approved root; hashes exact bytes and checks digest references.
+- `healthmd_fetch`: execute a fixed typed read-only operation over CLI or MCP, then index its canonical response in memory and, when configured, persist it in the cache.
+- `healthmd_query`: bounded semantic metric, generic path, or search evidence from the current file/fetched store.
+- `healthmd_view`: select metric/path/search targets, chart/table, date window, zoom, pan, show, or hide.
+
+Supported MCP fetch operations are `healthmd_status`, `healthmd_doctor`, `healthmd_capabilities`, `healthmd_metrics`, `healthmd_metric_chart`, `healthmd_sleep_sessions`, `healthmd_training_alignment`, `healthmd_workouts`, `healthmd_coverage`, `healthmd_compare_periods`, `healthmd_training_evidence`, `healthmd_query`, and `healthmd_evidence_packet`. Pairing and durable file exports deliberately remain outside this extension.
+
+Interactive commands: `/healthmd dashboard`, `/healthmd load <path>`, `/healthmd fetch <operation> <JSON-object>`, `/healthmd cache <directory|off>`, `/healthmd show`, `/healthmd hide`, `/healthmd reset`, `/healthmd status`. `/healthmd cache <directory>` is an explicit durable opt-in: the extension stores validated response bytes as content-addressed, mode-0600 JSON objects, remembers the canonical directory in the user configuration, and restores up to 64 responses/128 MiB at startup while verifying manifest sizes and SHA-256 digests. Cache files retain exact CLI/MCP origin and operation through a bounded manifest. `off` disables future persistence without deleting health data. `--healthmd-cache-dir` or `HEALTHMD_CACHE_DIR` overrides the remembered directory. Reset clears loaded data and the session's approved roots, returns the compact widget to its hidden startup state, and does not delete or disable the configured cache. `/healthmd dashboard` opens a 96%-width interactive TUI dashboard with curated domain summary cards, available-only grouped navigation, single-identity metric trends, typed records, and coverage/provenance screens. Its first-run view recommends a bounded 30-day history and explains foreground-iPhone readiness; press Enter or F, then choose 1/2/3 to fetch a validated 7/30/90-day range from the configured read-only source. The overview explicitly reports when too few dated days are loaded for trends. Use 1–8 for direct All/Activity/Sleep/Heart/Mobility/Recovery/Body/Other navigation, `/` to search names, semantic IDs, units, sources, and providers, `?` for contextual help, ↑/↓ to navigate, and ←/→ to inspect chart dates. Chart mode defaults to automatic: snapshots remain cards, connected date-ready series use lines, and valid disconnected observations use bars; V cycles auto/bar/line. O/D/T/C or Tab changes screens, A includes unavailable metrics, G cycles domains, W cycles chart windows, `[ ]` pans, `+/-` zooms, R refreshes, and Escape closes. The focused Sleep domain renders validated stage composition as a terminal pie chart when space permits, while constrained and all-domain summaries use a complete stacked bar. Sleep composition is shown only when stage totals are identity-compatible and consistent with total sleep; no clinical reference ranges are invented. Charts never combine distinct metric/unit/source/provider/platform/contract identities. The compact persistent widget starts hidden, remains available for opt-in at-a-glance context, and can be toggled with `/healthmd show` or `/healthmd hide`. RPC/print/JSON modes retain tools without constructing TUI components.
+
+Discussion examples:
+
+- “Chart WHOOP recovery HRV from the approved export.” → query/select `hrv_rmssd_ms`; provider identity remains WHOOP.
+- “Compare Apple and Android HRV.” → separate series by semantic ID/statistic/platform; do not combine SDNN and RMSSD.
+- “Show medication and route evidence.” → generic path/search indexing remains available, subject to output bounds and model disclosure.
+
+## Supported contract matrix
+
+The exported pure `src/contracts.ts` registry/adapter has no Pi imports and explicitly classifies:
+
+| Contract family | Reader behavior |
+|---|---|
+| Proposed `healthmd.health_data` v9 / `unified-cross-platform-v1` | Full bundled JSON Schema validation plus current proposal-fixture mapping, source/platform, calendar, capture, provenance, ordering, exact-number, and provider invariants; valid documents marked experimental; recognized invalid v9 remains generically indexed with bounded errors |
+| Shipped Apple `healthmd.health_data` v5-v8 | Identified as historical Apple daily data; no cross-platform equivalence inferred |
+| Android frozen v4, analytical v5, unversioned samples | Distinct identities retained |
+| `healthmd.healthkit_records` archive | Source-fidelity generic indexing with lossless large integer parsing |
+| Android raw snapshot/manifest and merge/raw references | Distinct raw/reference identities; digest resolution never implies semantic equivalence |
+| Typed `healthmd.provider.whoop_daily` and external-provider daily | Provider identity retained; provider facts do not populate primary metrics |
+| Health.md rollups | Identified as rollup evidence; rollup rules are not inferred for provider/platform data |
+| `healthmd.api_export` and `healthmd.raw_result` envelopes | Envelope identity retained while all nested generic paths remain searchable |
+| Typed CLI/MCP `healthmd.query_response` / `healthmd.mcp_query_pages` | Distinct validated `query_response` / `mcp_query_pages` identities; transport origin and operation retained; metric IDs, typed units, owner dates, source IDs, evidence, coverage, missingness, cursors, and limitations remain indexed |
+| Other `healthmd.*` and arbitrary JSON | `generic_healthmd` or `generic_json` fallback; every domain is indexed without normalization claims |
+
+`LoadedDocument` and index entries expose exact schema identity/version, contract kind, validity, origin/operation, and bounded errors. Date context keeps `ownerDate` separate from nearest `recordTimestamp`; the display date is the nearest record timestamp when present. Charts accept numeric metric/path/search targets, sort and filter the full bounded index before pagination, exclude evidence/coverage metadata from metric series, and refuse mixed contract/schema/path/unit/statistic/provider/platform/source/origin scales or any series containing unsafe exact values.
+
+Numbers are parsed with `lossless-json`'s number/BigInt parser so source-fidelity large integer tokens are not rounded. Model-visible serializers safely render bigint as exact decimal text. Proposed-v9 tagged binary64 and integer objects receive representation-specific validation, including finite IEEE-754 values, canonical signed/unsigned decimal strings, 40-character maximum, negative-zero display, and safe-chart restrictions.
+
+## Interpretation rules
+
+- Preserve units, statistics, owner dates, record timestamps, missingness, explicit zero, capture status, source path, provider/platform identity, provenance, references, and coverage.
+- Never infer Apple/Android/provider equivalence. WHOOP RMSSD, HealthKit SDNN, and Health Connect RMSSD remain distinct.
+- The dashboard is not a medical device and must not diagnose.
+- Unified v9 is a proposed reader contract; this package does not write it and does not indicate a shipped writer.
+
+The contracts manifest has consumer inventory fields, so this experimental reader is listed only for the deferred unified-v9 contract; no authoritative contract bytes or hashes are changed. The npm package carries byte-identical snapshots of the proposed v9 and provider-sections schemas for standalone validation, and tests compare those snapshots to their canonical monorepo sources.
+
+## Development
+
+```sh
+npm install
+npm test
+npm run typecheck
+npm pack --dry-run
+```
+
+Production-package validation installs the generated tarball in a temporary directory and runs the actual Pi 0.84.1 extension loader/command discovery. Runtime peer APIs use Pi's required `*` ranges; development and compatibility tests pin `@earendil-works/pi-coding-agent` and `@earendil-works/pi-ai` 0.84.1.
+
+License: AGPL-3.0-only.

--- a/packages/pi-healthmd-dashboard/package-lock.json
+++ b/packages/pi-healthmd-dashboard/package-lock.json
@@ -1,0 +1,4021 @@
+{
+  "name": "@healthmd/pi-health-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@healthmd/pi-health-dashboard",
+      "version": "0.1.0",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "ajv": "8.20.0",
+        "lossless-json": "^4.3.1",
+        "string-width": "^7.2.0"
+      },
+      "devDependencies": {
+        "@earendil-works/pi-ai": "0.84.1",
+        "@earendil-works/pi-coding-agent": "0.84.1",
+        "@earendil-works/pi-tui": "0.84.1",
+        "@types/node": "^22.20.1",
+        "tsx": "^4.21.0",
+        "typebox": "^1.3.7",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+        "typebox": "*"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.977.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
+      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
+      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.70",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
+      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
+      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-login": "^3.972.75",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
+      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.79",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
+      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.68",
+        "@aws-sdk/credential-provider-http": "^3.972.70",
+        "@aws-sdk/credential-provider-ini": "^3.973.13",
+        "@aws-sdk/credential-provider-process": "^3.972.68",
+        "@aws-sdk/credential-provider-sso": "^3.973.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.68",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
+      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
+      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/token-providers": "3.1108.0",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1108.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
+      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
+      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/nested-clients": "^3.997.42",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.32",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.32.tgz",
+      "integrity": "sha512-rlbmsMG7ZNgrVhWSqqXpq6y9hfiREyzCg3CNTk9UK+AoP7+65kOkqpWmqwLfV1UrRSHATdLnZF2rt9ZTUxYQJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.27.tgz",
+      "integrity": "sha512-M7Ay1VpBpf/YFfic9kkjwE3wyCh4G0gEM4RypRXYm7aPjyfqi+D8FEYMR2E3IqbvN+qi2rEFYAiwWL0XHtQYdQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.50",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.50.tgz",
+      "integrity": "sha512-gdcWRbmIf1dWA/prf44Bnnzgqj+AbsXX2yfhZhOQLwSm7NfKIYPmkRlPqP0CTepHzjxMIBdWBDdtQB+Y/dFUeg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
+      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
+      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.3",
+        "@smithy/signature-v4": "^5.6.12",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
+      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
+      "integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
+      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.84.1.tgz",
+      "integrity": "sha512-ncAqFrG+iybuPGOhMiZoEHkEzTpJgz3guYD32pD+M7ucc0WeHmauP6wa7qwP8V/KWvsZDVNa5XGsdZ7fkC7w7A==",
+      "dev": true,
+      "hasShrinkwrap": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-agent-core": "^0.84.1",
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-client": "^0.84.1",
+        "@earendil-works/pi-protocol": "^0.84.1",
+        "@earendil-works/pi-tui": "^0.84.1",
+        "@silvia-odwyer/photon-node": "0.3.4",
+        "chalk": "5.6.2",
+        "cross-spawn": "7.0.6",
+        "diff": "8.0.4",
+        "glob": "13.0.6",
+        "grok-mermaid": "0.2.2",
+        "highlight.js": "10.7.3",
+        "hosted-git-info": "9.0.3",
+        "ignore": "7.0.5",
+        "jiti": "2.7.0",
+        "minimatch": "10.2.5",
+        "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
+        "typebox": "1.3.7",
+        "undici": "8.9.0",
+        "yaml": "2.9.0"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+      "integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-node": "^3.972.42",
+        "@aws-sdk/eventstream-handler-node": "^3.972.16",
+        "@aws-sdk/middleware-eventstream": "^3.972.12",
+        "@aws-sdk/middleware-websocket": "^3.972.19",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+      "version": "3.974.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+      "integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.24",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+      "integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+      "integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+      "integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-login": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+      "integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.42",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+      "integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.37",
+        "@aws-sdk/credential-provider-http": "^3.972.39",
+        "@aws-sdk/credential-provider-ini": "^3.972.41",
+        "@aws-sdk/credential-provider-process": "^3.972.37",
+        "@aws-sdk/credential-provider-sso": "^3.972.41",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.41",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/credential-provider-imds": "^4.3.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+      "integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+      "integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/token-providers": "3.1048.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+      "integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+      "version": "3.972.16",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+      "integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.9",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+      "integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/fetch-http-handler": "^5.4.2",
+        "@smithy/node-http-handler": "^4.7.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/signature-v4": "^5.4.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1048.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+      "integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.11",
+        "@aws-sdk/nested-clients": "^3.997.9",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/core": "^3.24.2",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-ai": "^0.84.1",
+        "@earendil-works/pi-telemetry": "^0.84.1",
+        "diff": "8.0.4",
+        "ignore": "7.0.5",
+        "typebox": "1.3.7",
+        "yaml": "2.9.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "0.91.1",
+        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
+        "@earendil-works/pi-telemetry": "^0.84.1",
+        "@google/genai": "1.52.0",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
+        "@smithy/node-http-handler": "4.7.3",
+        "http-proxy-agent": "7.0.2",
+        "https-proxy-agent": "7.0.6",
+        "openai": "6.26.0",
+        "partial-json": "0.1.7",
+        "typebox": "1.3.7"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@earendil-works/pi-protocol": "^0.84.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typebox": "1.3.7"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.9.tgz",
+      "integrity": "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.9",
+        "@mariozechner/clipboard-darwin-universal": "0.3.9",
+        "@mariozechner/clipboard-darwin-x64": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.9",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.9",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.9",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.9"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz",
+      "integrity": "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz",
+      "integrity": "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz",
+      "integrity": "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz",
+      "integrity": "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz",
+      "integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz",
+      "integrity": "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz",
+      "integrity": "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz",
+      "integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz",
+      "integrity": "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz",
+      "integrity": "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "ws": "^8.18.0",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.24.3",
+        "@smithy/types": "^4.14.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+      "version": "4.14.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+      "version": "22.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/grok-mermaid": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/grok-mermaid/-/grok-mermaid-0.2.2.tgz",
+      "integrity": "sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
+      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/@earendil-works/pi-telemetry": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-tui": {
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "1.6.0",
+        "marked": "18.0.5"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.32.0.tgz",
+      "integrity": "sha512-NAiCSC78fzbNIEWoheoF74Ob5ZorLijCHpMY26Fqvqg/+9LuyIqMfHDg2p8Yk1rqOyowtiL3y7WX0AW+teL6zw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
+      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
+      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.10.0.tgz",
+      "integrity": "sha512-nrh7VxqzPQS/ip1hS293aI/OAWDWARQvjUxCfuKhyrfHa2gTdk28066RNeWLI1uuoHXaKAkOF8IcSAHuOp0+SA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
+      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.32.0",
+        "@smithy/types": "^4.17.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
+      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.3.1.tgz",
+      "integrity": "sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.1.tgz",
+      "integrity": "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/lossless-json": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.3.1.tgz",
+      "integrity": "sha512-SqD/Bg3ZfltBJ2Z14hJ/BihnvtV553WO4g9/ePtlp4lrnl9jF3AdIJt53A/Wkg/0Li+LMfxaBqgx1MiFZdQlpQ==",
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/partial-json": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+      "integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typebox": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.13.tgz",
+      "integrity": "sha512-rzv/3uBDgWGb5b4+Rqb/WoDFCc+5N0iRC/7kgQyk/mJJeumQjHFFAZ+X+Zs+CNxnNnJOkhIMrQc2irTzfEbKjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/packages/pi-healthmd-dashboard/package.json
+++ b/packages/pi-healthmd-dashboard/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@healthmd/pi-health-dashboard",
+  "version": "0.1.0",
+  "description": "Experimental read-only Health.md JSON dashboard extension for Pi",
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/CodyBontecou/health-md.git",
+    "directory": "packages/pi-healthmd-dashboard"
+  },
+  "homepage": "https://github.com/CodyBontecou/health-md/tree/main/packages/pi-healthmd-dashboard#readme",
+  "bugs": {
+    "url": "https://github.com/CodyBontecou/health-md/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "pi-package",
+    "healthmd",
+    "health-data",
+    "dashboard"
+  ],
+  "files": [
+    "src",
+    "schemas",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": "./src/extension.ts",
+    "./cache": "./src/cache.ts",
+    "./contracts": "./src/contracts.ts",
+    "./dashboard": "./src/dashboard.ts",
+    "./exact": "./src/exact.ts",
+    "./loader": "./src/loader.ts",
+    "./query": "./src/query.ts",
+    "./query-contract": "./src/query-contract.ts",
+    "./render": "./src/render.ts",
+    "./source": "./src/source.ts",
+    "./view": "./src/view.ts"
+  },
+  "pi": {
+    "extensions": [
+      "./src/extension.ts"
+    ]
+  },
+  "scripts": {
+    "test": "node --import=tsx --test test/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ajv": "8.20.0",
+    "lossless-json": "^4.3.1",
+    "string-width": "^7.2.0"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+    "typebox": "*"
+  },
+  "devDependencies": {
+    "@earendil-works/pi-ai": "0.84.1",
+    "@earendil-works/pi-coding-agent": "0.84.1",
+    "@earendil-works/pi-tui": "0.84.1",
+    "@types/node": "^22.20.1",
+    "tsx": "^4.21.0",
+    "typebox": "^1.3.7",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/pi-healthmd-dashboard/schemas/provider-sections-v1.schema.json
+++ b/packages/pi-healthmd-dashboard/schemas/provider-sections-v1.schema.json
@@ -1,0 +1,693 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://health.md/schemas/proposals/provider-sections-v1.schema.json",
+  "title": "Health.md typed provider sections v1",
+  "description": "Canonical value of the providers property in an Apple healthmd.health_data v8 daily record.",
+  "type": "object",
+  "minProperties": 1,
+  "propertyNames": {
+    "pattern": "^[a-z][a-z0-9_]*$"
+  },
+  "properties": {
+    "whoop": {
+      "$ref": "#/$defs/whoopDaily"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "whoopDaily": {
+      "type": "object",
+      "required": [
+        "schema",
+        "schema_version",
+        "capture_status",
+        "fetched_at",
+        "resources",
+        "cycles",
+        "recoveries",
+        "sleep",
+        "workouts",
+        "warnings"
+      ],
+      "properties": {
+        "schema": {
+          "const": "healthmd.provider.whoop_daily"
+        },
+        "schema_version": {
+          "const": 1
+        },
+        "capture_status": {
+          "$ref": "#/$defs/captureStatus"
+        },
+        "fetched_at": {
+          "$ref": "#/$defs/nullableTimestamp"
+        },
+        "resources": {
+          "type": "array",
+          "maxItems": 16,
+          "uniqueItems": true,
+          "items": {
+            "$ref": "#/$defs/resourceResult"
+          }
+        },
+        "cycles": {
+          "type": "array",
+          "maxItems": 10000,
+          "items": {
+            "$ref": "#/$defs/cycle"
+          }
+        },
+        "recoveries": {
+          "type": "array",
+          "maxItems": 10000,
+          "items": {
+            "$ref": "#/$defs/recovery"
+          }
+        },
+        "sleep": {
+          "type": "array",
+          "maxItems": 10000,
+          "items": {
+            "$ref": "#/$defs/sleep"
+          }
+        },
+        "workouts": {
+          "type": "array",
+          "maxItems": 10000,
+          "items": {
+            "$ref": "#/$defs/workout"
+          }
+        },
+        "body": {
+          "$ref": "#/$defs/bodySnapshot"
+        },
+        "warnings": {
+          "type": "array",
+          "maxItems": 256,
+          "items": {
+            "$ref": "#/$defs/warning"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "capture_status": {
+                "const": "not_requested"
+              }
+            },
+            "required": [
+              "capture_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "fetched_at": {
+                "type": "null"
+              },
+              "resources": {
+                "maxItems": 0
+              },
+              "cycles": {
+                "maxItems": 0
+              },
+              "recoveries": {
+                "maxItems": 0
+              },
+              "sleep": {
+                "maxItems": 0
+              },
+              "workouts": {
+                "maxItems": 0
+              }
+            },
+            "not": {
+              "required": [
+                "body"
+              ]
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "capture_status": {
+                "enum": [
+                  "complete",
+                  "partial"
+                ]
+              }
+            },
+            "required": [
+              "capture_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "fetched_at": {
+                "$ref": "#/$defs/timestamp"
+              },
+              "resources": {
+                "minItems": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "capture_status": {
+                "const": "complete"
+              }
+            },
+            "required": [
+              "capture_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "resources": {
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "const": "success"
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "capture_status": {
+                "const": "partial"
+              }
+            },
+            "required": [
+              "capture_status"
+            ]
+          },
+          "then": {
+            "properties": {
+              "resources": {
+                "contains": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "enum": [
+                        "failure",
+                        "cancelled",
+                        "skipped",
+                        "unsupported"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "status"
+                  ]
+                },
+                "minContains": 1
+              }
+            }
+          }
+        }
+      ]
+    },
+    "captureStatus": {
+      "type": "string",
+      "enum": [
+        "complete",
+        "partial",
+        "not_requested"
+      ]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]+)?Z$",
+      "minLength": 20,
+      "maxLength": 64
+    },
+    "nullableTimestamp": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/timestamp"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "providerID": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "timezoneOffset": {
+      "type": "string",
+      "pattern": "^(?:Z|[+-](?:0[0-9]|1[0-4]):[0-5][0-9])$"
+    },
+    "resourceName": {
+      "type": "string",
+      "enum": [
+        "cycles",
+        "recovery",
+        "sleep",
+        "workouts",
+        "body"
+      ]
+    },
+    "resourceResult": {
+      "type": "object",
+      "required": [
+        "resource",
+        "status",
+        "record_count"
+      ],
+      "properties": {
+        "resource": {
+          "$ref": "#/$defs/resourceName"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "success",
+            "failure",
+            "cancelled",
+            "skipped",
+            "unsupported"
+          ]
+        },
+        "record_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "error": {
+          "$ref": "#/$defs/safeError"
+        }
+      },
+      "additionalProperties": false
+    },
+    "safeError": {
+      "type": "object",
+      "required": [
+        "code",
+        "message",
+        "retryable"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "http_status_code": {
+          "type": "integer",
+          "minimum": 100,
+          "maximum": 599
+        },
+        "retry_after_seconds": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 604800
+        }
+      },
+      "additionalProperties": false
+    },
+    "warning": {
+      "type": "object",
+      "required": [
+        "code",
+        "message"
+      ],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9_]*$",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        },
+        "resource": {
+          "$ref": "#/$defs/resourceName"
+        }
+      },
+      "additionalProperties": false
+    },
+    "cycle": {
+      "type": "object",
+      "required": [
+        "id",
+        "start_time"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/providerID"
+        },
+        "start_time": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "end_time": {
+          "$ref": "#/$defs/nullableTimestamp"
+        },
+        "timezone_offset": {
+          "$ref": "#/$defs/timezoneOffset"
+        },
+        "score_state": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "strain_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 21
+        },
+        "energy_kilojoules": {
+          "type": "number",
+          "minimum": 0
+        },
+        "average_heart_rate_bpm": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 300
+        },
+        "max_heart_rate_bpm": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 300
+        }
+      },
+      "additionalProperties": false
+    },
+    "recovery": {
+      "type": "object",
+      "required": [
+        "cycle_id"
+      ],
+      "properties": {
+        "cycle_id": {
+          "$ref": "#/$defs/providerID"
+        },
+        "sleep_id": {
+          "$ref": "#/$defs/providerID"
+        },
+        "score_state": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "user_calibrating": {
+          "type": "boolean"
+        },
+        "recovery_score_percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "resting_heart_rate_bpm": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 300
+        },
+        "hrv_rmssd_ms": {
+          "type": "number",
+          "minimum": 0
+        },
+        "spo2_percent": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 100
+        },
+        "skin_temperature_celsius": {
+          "type": "number",
+          "minimum": -100,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "sleep": {
+      "type": "object",
+      "required": [
+        "id",
+        "cycle_id",
+        "start_time",
+        "end_time",
+        "is_nap"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/providerID"
+        },
+        "cycle_id": {
+          "$ref": "#/$defs/providerID"
+        },
+        "start_time": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "end_time": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "timezone_offset": {
+          "$ref": "#/$defs/timezoneOffset"
+        },
+        "is_nap": {
+          "type": "boolean"
+        },
+        "score_state": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "total_sleep_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_in_bed_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "awake_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "light_sleep_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "slow_wave_sleep_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "rem_sleep_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "no_data_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sleep_cycle_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "disturbance_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "baseline_sleep_need_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "sleep_debt_need_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "recent_strain_need_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "recent_nap_adjustment_milliseconds": {
+          "type": "integer",
+          "maximum": 0
+        },
+        "respiratory_rate_breaths_per_minute": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "sleep_performance_percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "sleep_consistency_percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "sleep_efficiency_percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      },
+      "additionalProperties": false
+    },
+    "zoneDurations": {
+      "type": "object",
+      "properties": {
+        "zone_zero_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "zone_one_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "zone_two_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "zone_three_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "zone_four_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "zone_five_milliseconds": {
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false,
+      "minProperties": 1
+    },
+    "workout": {
+      "type": "object",
+      "required": [
+        "id",
+        "start_time",
+        "end_time",
+        "sport_name"
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/$defs/providerID"
+        },
+        "start_time": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "end_time": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "timezone_offset": {
+          "$ref": "#/$defs/timezoneOffset"
+        },
+        "sport_name": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 128
+        },
+        "score_state": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 64
+        },
+        "strain_score": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 21
+        },
+        "average_heart_rate_bpm": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 300
+        },
+        "max_heart_rate_bpm": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 300
+        },
+        "energy_kilojoules": {
+          "type": "number",
+          "minimum": 0
+        },
+        "distance_meters": {
+          "type": "number",
+          "minimum": 0
+        },
+        "altitude_gain_meters": {
+          "type": "number"
+        },
+        "altitude_change_meters": {
+          "type": "number"
+        },
+        "percent_recorded": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "zone_durations": {
+          "$ref": "#/$defs/zoneDurations"
+        }
+      },
+      "additionalProperties": false
+    },
+    "bodySnapshot": {
+      "type": "object",
+      "required": [
+        "source_kind",
+        "observed_at"
+      ],
+      "properties": {
+        "source_kind": {
+          "const": "current_profile_snapshot"
+        },
+        "observed_at": {
+          "$ref": "#/$defs/timestamp"
+        },
+        "height_meters": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 3
+        },
+        "weight_kilograms": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 1000
+        },
+        "max_heart_rate_bpm": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "maximum": 300
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/pi-healthmd-dashboard/schemas/unified-health-data-v9.schema.json
+++ b/packages/pi-healthmd-dashboard/schemas/unified-health-data-v9.schema.json
@@ -1,0 +1,509 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://health.md/schemas/proposals/unified-health-data-v9.schema.json",
+  "title": "Health.md unified cross-platform daily health data v9 proposal",
+  "description": "Proposed common public daily contract for Apple and Android. This is v9 because healthmd.health_data v8 already identifies the shipped Apple grammar.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "profile",
+    "owner_date",
+    "calendar",
+    "source",
+    "capture",
+    "metrics",
+    "platform"
+  ],
+  "properties": {
+    "schema": { "const": "healthmd.health_data" },
+    "schema_version": { "const": 9 },
+    "profile": { "const": "unified-cross-platform-v1" },
+    "owner_date": { "$ref": "#/$defs/date" },
+    "calendar": { "$ref": "#/$defs/calendar" },
+    "source": { "$ref": "#/$defs/source" },
+    "capture": { "$ref": "#/$defs/capture" },
+    "metrics": {
+      "type": "array",
+      "maxItems": 4096,
+      "items": { "$ref": "#/$defs/metric" }
+    },
+    "platform": { "$ref": "#/$defs/platform" },
+    "providers": {
+      "description": "Provider sections follow their independently versioned contracts. v1 permits WHOOP only.",
+      "type": "object",
+      "minProperties": 1,
+      "maxProperties": 1,
+      "additionalProperties": false,
+      "properties": {
+        "whoop": { "$ref": "#/$defs/whoopReference" }
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "maxItems": 256,
+      "items": { "$ref": "#/$defs/warning" }
+    }
+  },
+  "$defs": {
+    "date": {
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\\.[0-9]{1,9})?Z$",
+      "minLength": 20,
+      "maxLength": 64
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9]*(?:[._-][a-z0-9]+)*$",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "boundedString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 512
+    },
+    "calendar": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["identifier", "time_zone", "interval_start", "interval_end", "assignment_rule"],
+      "properties": {
+        "identifier": { "const": "gregorian" },
+        "time_zone": {
+          "type": "string",
+          "pattern": "^[A-Za-z_+-]+(?:/[A-Za-z0-9_+.-]+)+$|^UTC$",
+          "minLength": 3,
+          "maxLength": 128
+        },
+        "interval_start": { "$ref": "#/$defs/timestamp" },
+        "interval_end": { "$ref": "#/$defs/timestamp" },
+        "assignment_rule": { "const": "record_start_in_half_open_day_interval" }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "source_profile"],
+      "properties": {
+        "platform": { "enum": ["apple", "android"] },
+        "source_profile": {
+          "enum": ["apple_health_data_v8", "android_frozen_v4", "android_analytical_v5"]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "platform": { "const": "apple" } },
+            "required": ["platform"]
+          },
+          "then": {
+            "properties": { "source_profile": { "const": "apple_health_data_v8" } }
+          }
+        },
+        {
+          "if": {
+            "properties": { "platform": { "const": "android" } },
+            "required": ["platform"]
+          },
+          "then": {
+            "properties": {
+              "source_profile": { "enum": ["android_frozen_v4", "android_analytical_v5"] }
+            }
+          }
+        }
+      ]
+    },
+    "capture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "resources"],
+      "properties": {
+        "status": { "enum": ["complete", "partial", "not_requested"] },
+        "resources": {
+          "type": "array",
+          "maxItems": 4096,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/resource" }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "status": { "const": "complete" } },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "resources": {
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "properties": { "status": { "const": "complete" } },
+                  "required": ["status"]
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "status": { "const": "partial" } },
+            "required": ["status"]
+          },
+          "then": {
+            "properties": {
+              "resources": {
+                "minItems": 1,
+                "contains": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "enum": ["unsupported", "unauthorized", "unavailable", "failed", "cancelled"]
+                    }
+                  },
+                  "required": ["status"]
+                },
+                "minContains": 1
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": { "status": { "const": "not_requested" } },
+            "required": ["status"]
+          },
+          "then": { "properties": { "resources": { "maxItems": 0 } } }
+        }
+      ]
+    },
+    "resource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "resource", "status", "record_count"],
+      "properties": {
+        "source": { "enum": ["apple_health", "health_connect"] },
+        "resource": { "$ref": "#/$defs/identifier" },
+        "status": {
+          "enum": ["complete", "not_requested", "unsupported", "unauthorized", "unavailable", "failed", "cancelled"]
+        },
+        "record_count": { "type": "integer", "minimum": 0, "maximum": 10000000 },
+        "error": { "$ref": "#/$defs/safeError" }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "status": { "enum": ["complete", "not_requested", "unsupported", "unauthorized", "unavailable"] }
+            },
+            "required": ["status"]
+          },
+          "then": { "not": { "required": ["error"] } }
+        },
+        {
+          "if": {
+            "properties": { "status": { "enum": ["failed", "cancelled"] } },
+            "required": ["status"]
+          },
+          "then": { "required": ["error"] }
+        }
+      ]
+    },
+    "safeError": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "retryable"],
+      "properties": {
+        "code": { "$ref": "#/$defs/identifier" },
+        "message": { "$ref": "#/$defs/boundedString" },
+        "retryable": { "type": "boolean" }
+      }
+    },
+    "metric": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["semantic_id", "statistic", "value", "provenance"],
+      "properties": {
+        "semantic_id": { "$ref": "#/$defs/identifier" },
+        "statistic": {
+          "enum": ["sum", "average", "minimum", "maximum", "latest", "count", "duration_sum", "first_time", "last_time"]
+        },
+        "value": { "$ref": "#/$defs/value" },
+        "provenance": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 10000,
+          "uniqueItems": true,
+          "items": { "$ref": "#/$defs/provenance" }
+        }
+      }
+    },
+    "value": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value_type", "number", "unit"],
+          "properties": {
+            "value_type": { "const": "number" },
+            "number": { "$ref": "#/$defs/exactNumber" },
+            "unit": { "$ref": "#/$defs/identifier" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value_type", "text"],
+          "properties": {
+            "value_type": { "const": "text" },
+            "text": { "$ref": "#/$defs/boundedString" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value_type", "boolean"],
+          "properties": {
+            "value_type": { "const": "boolean" },
+            "boolean": { "type": "boolean" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["value_type", "items"],
+          "properties": {
+            "value_type": { "const": "text_list" },
+            "items": {
+              "type": "array",
+              "maxItems": 4096,
+              "items": { "$ref": "#/$defs/boundedString" }
+            }
+          }
+        }
+      ]
+    },
+    "exactNumber": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["representation", "bits"],
+          "properties": {
+            "representation": { "const": "binary64" },
+            "bits": { "type": "string", "pattern": "^[0-9a-f]{16}$" }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["representation", "decimal"],
+          "properties": {
+            "representation": { "const": "signed_integer" },
+            "decimal": { "type": "string", "pattern": "^(?:0|-?[1-9][0-9]*)$", "maxLength": 40 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["representation", "decimal"],
+          "properties": {
+            "representation": { "const": "unsigned_integer" },
+            "decimal": { "type": "string", "pattern": "^(?:0|[1-9][0-9]*)$", "maxLength": 40 }
+          }
+        }
+      ]
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["source", "source_semantic_id"],
+      "properties": {
+        "source": { "enum": ["apple_health", "health_connect"] },
+        "source_semantic_id": { "$ref": "#/$defs/identifier" },
+        "source_record_ids": {
+          "type": "array",
+          "maxItems": 10000,
+          "uniqueItems": true,
+          "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+        },
+        "source_statistic": { "$ref": "#/$defs/identifier" }
+      }
+    },
+    "platform": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["apple"],
+          "properties": { "apple": { "$ref": "#/$defs/applePlatform" } }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["android"],
+          "properties": { "android": { "$ref": "#/$defs/androidPlatform" } }
+        }
+      ]
+    },
+    "applePlatform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "schema_version", "source_schema_version"],
+      "properties": {
+        "schema": { "const": "healthmd.platform.apple_daily" },
+        "schema_version": { "const": 1 },
+        "source_schema_version": { "const": 8 },
+        "healthkit_record_archive": {
+          "$ref": "#/$defs/externalContractReference"
+        }
+      }
+    },
+    "androidPlatform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "schema_version", "source_schema_version", "source_profile"],
+      "properties": {
+        "schema": { "const": "healthmd.platform.android_daily" },
+        "schema_version": { "const": 1 },
+        "source_schema_version": { "enum": [4, 5] },
+        "source_profile": { "enum": ["android-frozen-v4", "android-analytical-v5"] },
+        "merge_provenance": {
+          "$ref": "#/$defs/externalContractReference"
+        },
+        "raw_snapshot_reference": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["schema", "schema_version", "sha256"],
+          "properties": {
+            "schema": { "const": "healthmd.raw_snapshot" },
+            "schema_version": { "const": 1 },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "source_schema_version": { "const": 4 } },
+            "required": ["source_schema_version"]
+          },
+          "then": { "properties": { "source_profile": { "const": "android-frozen-v4" } } }
+        },
+        {
+          "if": {
+            "properties": { "source_schema_version": { "const": 5 } },
+            "required": ["source_schema_version"]
+          },
+          "then": { "properties": { "source_profile": { "const": "android-analytical-v5" } } }
+        }
+      ]
+    },
+    "externalContractReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["schema", "schema_version", "sha256", "byte_count"],
+      "properties": {
+        "schema": { "$ref": "#/$defs/identifier" },
+        "schema_version": { "type": "integer", "minimum": 1 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+        "byte_count": { "type": "integer", "minimum": 0, "maximum": 2147483648 }
+      }
+    },
+    "whoopReference": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["schema", "schema_version"],
+      "properties": {
+        "schema": { "const": "healthmd.provider.whoop_daily" },
+        "schema_version": { "const": 1 }
+      },
+      "description": "The full value must satisfy packages/contracts/proposals/provider-sections-v1/provider-sections-v1.schema.json#/$defs/whoopDaily."
+    },
+    "warning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": { "$ref": "#/$defs/identifier" },
+        "message": { "$ref": "#/$defs/boundedString" },
+        "semantic_id": { "$ref": "#/$defs/identifier" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "source": {
+            "type": "object",
+            "properties": { "platform": { "const": "apple" } },
+            "required": ["platform"]
+          }
+        },
+        "required": ["source"]
+      },
+      "then": {
+        "properties": {
+          "capture": {
+            "type": "object",
+            "properties": {
+              "resources": {
+                "items": {
+                  "type": "object",
+                  "properties": { "source": { "const": "apple_health" } },
+                  "required": ["source"]
+                }
+              }
+            }
+          },
+          "platform": {
+            "type": "object",
+            "required": ["apple"],
+            "properties": { "apple": { "$ref": "#/$defs/applePlatform" } }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "source": {
+            "type": "object",
+            "properties": { "platform": { "const": "android" } },
+            "required": ["platform"]
+          }
+        },
+        "required": ["source"]
+      },
+      "then": {
+        "properties": {
+          "capture": {
+            "type": "object",
+            "properties": {
+              "resources": {
+                "items": {
+                  "type": "object",
+                  "properties": { "source": { "const": "health_connect" } },
+                  "required": ["source"]
+                }
+              }
+            }
+          },
+          "platform": {
+            "type": "object",
+            "required": ["android"],
+            "properties": { "android": { "$ref": "#/$defs/androidPlatform" } }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/pi-healthmd-dashboard/src/cache.ts
+++ b/packages/pi-healthmd-dashboard/src/cache.ts
@@ -1,0 +1,189 @@
+import { createHash, randomBytes } from "node:crypto";
+import { constants } from "node:fs";
+import { chmod, lstat, mkdir, open, realpath, rename, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import type { InMemoryJsonInput } from "./loader.js";
+import type { DocumentOrigin } from "./model.js";
+
+const CACHE_SCHEMA = "healthmd.pi_dashboard_cache";
+const CONFIG_SCHEMA = "healthmd.pi_dashboard_cache_config";
+const MANIFEST_FILE = "healthmd-cache.json";
+const MAX_MANIFEST_BYTES = 1024 * 1024;
+const MAX_CACHE_ENTRIES = 256;
+const MAX_RESTORED_FILES = 64;
+const MAX_RESTORED_BYTES = 128 * 1024 * 1024;
+const MAX_FILE_BYTES = 32 * 1024 * 1024;
+const CACHE_LOCK_FILE = ".healthmd-cache.lock";
+const CACHE_LOCK_WAIT_MS = 5_000;
+
+type CacheOrigin = Extract<DocumentOrigin, "healthmd-cli" | "healthmd-mcp">;
+interface CacheEntry {
+  digest: string;
+  file: string;
+  bytes: number;
+  origin: CacheOrigin;
+  operation: string;
+  fetched_at: string;
+}
+interface CacheManifest { schema: typeof CACHE_SCHEMA; schema_version: 1; entries: CacheEntry[] }
+interface CacheConfig { schema: typeof CONFIG_SCHEMA; schema_version: 1; directory: string }
+
+export interface PersistedCacheReceipt {
+  directory: string;
+  file: string;
+  digest: string;
+  entries: number;
+}
+
+function configPath(): string {
+  const root = process.env.XDG_CONFIG_HOME?.trim() || join(homedir(), ".config");
+  return join(root, "healthmd", "pi-dashboard.json");
+}
+function object(value: unknown): value is Record<string, unknown> { return value !== null && typeof value === "object" && !Array.isArray(value); }
+function validDigest(value: unknown): value is string { return typeof value === "string" && /^[a-f0-9]{64}$/.test(value); }
+function validEntry(value: unknown): value is CacheEntry {
+  return object(value) && validDigest(value.digest) && value.file === `${value.digest}.json` && Number.isSafeInteger(value.bytes) && Number(value.bytes) >= 0 && Number(value.bytes) <= MAX_FILE_BYTES && (value.origin === "healthmd-cli" || value.origin === "healthmd-mcp") && typeof value.operation === "string" && /^[A-Za-z0-9_.-]{1,128}$/.test(value.operation) && typeof value.fetched_at === "string" && /^\d{4}-\d{2}-\d{2}T/.test(value.fetched_at) && value.fetched_at.length <= 64;
+}
+function parseManifest(text: string): CacheManifest {
+  const value: unknown = JSON.parse(text);
+  if (!object(value) || value.schema !== CACHE_SCHEMA || value.schema_version !== 1 || !Array.isArray(value.entries) || value.entries.length > MAX_CACHE_ENTRIES || !value.entries.every(validEntry)) throw new Error("Health.md cache manifest is invalid");
+  return value as unknown as CacheManifest;
+}
+async function noFollowRead(path: string, maximum: number): Promise<Buffer> {
+  const before = await lstat(path);
+  if (before.isSymbolicLink() || !before.isFile()) throw new Error(`Health.md cache path is not a regular file: ${path}`);
+  if (before.size > maximum) throw new Error(`Health.md cache file exceeds ${maximum} bytes: ${path}`);
+  const handle = await open(path, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const opened = await handle.stat();
+    if (!opened.isFile() || opened.size > maximum) throw new Error(`Health.md cache file exceeds ${maximum} bytes: ${path}`);
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for (;;) {
+      const buffer = Buffer.allocUnsafe(Math.min(64 * 1024, maximum + 1 - total));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > maximum) throw new Error(`Health.md cache file exceeds ${maximum} bytes: ${path}`);
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+    const current = await lstat(path);
+    if (opened.dev !== current.dev || opened.ino !== current.ino || current.isSymbolicLink()) throw new Error(`Health.md cache path identity changed: ${path}`);
+    await handle.chmod(0o600);
+    return Buffer.concat(chunks, total);
+  } finally { await handle.close(); }
+}
+async function atomicWrite(path: string, data: string | Buffer, mode: number): Promise<void> {
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+  const temporary = join(dirname(path), `.${basename(path)}.${process.pid}.${randomBytes(8).toString("hex")}.tmp`);
+  const handle = await open(temporary, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0), mode);
+  try { await handle.writeFile(data); await handle.sync(); }
+  catch (error) { await handle.close(); await unlink(temporary).catch(() => {}); throw error; }
+  await handle.close();
+  try { await rename(temporary, path); await chmod(path, mode); }
+  catch (error) { await unlink(temporary).catch(() => {}); throw error; }
+}
+async function withCacheLock<T>(directory: string, action: () => Promise<T>): Promise<T> {
+  const lockPath = join(directory, CACHE_LOCK_FILE), deadline = Date.now() + CACHE_LOCK_WAIT_MS;
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  while (!handle) {
+    try {
+      handle = await open(lockPath, constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | (constants.O_NOFOLLOW ?? 0), 0o600);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      const lock = await lstat(lockPath).catch(statError => { if ((statError as NodeJS.ErrnoException).code === "ENOENT") return undefined; throw statError; });
+      if (!lock) continue;
+      if (lock.isSymbolicLink() || !lock.isFile()) throw new Error("Health.md cache lock is not a regular file");
+      if (Date.now() >= deadline) throw new Error(`Health.md cache is busy in another process; if no Health.md process is running, remove ${lockPath}`);
+      await new Promise(resolveDelay => setTimeout(resolveDelay, 25));
+    }
+  }
+  try { return await action(); }
+  finally {
+    const held = await handle.stat();
+    const current = await lstat(lockPath).catch(() => undefined);
+    await handle.close();
+    if (current && !current.isSymbolicLink() && current.dev === held.dev && current.ino === held.ino) await unlink(lockPath).catch(() => {});
+  }
+}
+
+export async function ensureCacheDirectory(path: string): Promise<string> {
+  const requested = resolve(path);
+  await mkdir(requested, { recursive: true, mode: 0o700 });
+  const info = await lstat(requested);
+  if (info.isSymbolicLink() || !info.isDirectory()) throw new Error(`Health.md cache directory is not a regular directory: ${path}`);
+  const canonical = await realpath(requested);
+  await chmod(canonical, 0o700);
+  const objects = join(canonical, "objects");
+  try { await mkdir(objects, { mode: 0o700 }); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error; }
+  const objectsInfo = await lstat(objects);
+  if (objectsInfo.isSymbolicLink() || !objectsInfo.isDirectory() || await realpath(objects) !== objects) throw new Error(`Health.md cache objects path escapes its configured directory: ${objects}`);
+  await chmod(objects, 0o700);
+  return canonical;
+}
+
+export async function rememberCacheDirectory(path: string): Promise<string> {
+  const directory = await ensureCacheDirectory(path);
+  const config: CacheConfig = { schema: CONFIG_SCHEMA, schema_version: 1, directory };
+  await atomicWrite(configPath(), `${JSON.stringify(config)}\n`, 0o600);
+  return directory;
+}
+
+export async function forgetCacheDirectory(): Promise<void> { await unlink(configPath()).catch(error => { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }); }
+
+export async function configuredCacheDirectory(explicit?: string): Promise<string | undefined> {
+  if (explicit?.trim()) return ensureCacheDirectory(explicit.trim());
+  let data: Buffer;
+  try { data = await noFollowRead(configPath(), 16 * 1024); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return undefined; throw error; }
+  const value: unknown = JSON.parse(data.toString("utf8"));
+  if (!object(value) || value.schema !== CONFIG_SCHEMA || value.schema_version !== 1 || typeof value.directory !== "string" || !value.directory) throw new Error("Health.md Pi dashboard cache configuration is invalid");
+  return ensureCacheDirectory(value.directory);
+}
+
+async function readManifest(directory: string): Promise<CacheManifest> {
+  const path = join(directory, MANIFEST_FILE);
+  try { return parseManifest((await noFollowRead(path, MAX_MANIFEST_BYTES)).toString("utf8")); }
+  catch (error) { if ((error as NodeJS.ErrnoException).code === "ENOENT") return { schema: CACHE_SCHEMA, schema_version: 1, entries: [] }; throw error; }
+}
+
+export async function persistFetchedEvidence(directoryPath: string, input: { text: string; origin: CacheOrigin; operation: string }): Promise<PersistedCacheReceipt> {
+  const directory = await ensureCacheDirectory(directoryPath);
+  const bytes = Buffer.byteLength(input.text, "utf8");
+  if (bytes > MAX_FILE_BYTES) throw new Error(`Fetched Health.md cache object exceeds ${MAX_FILE_BYTES} bytes`);
+  const digest = createHash("sha256").update(input.text).digest("hex");
+  const file = `${digest}.json`, objectPath = join(directory, "objects", file);
+  try {
+    const existing = await noFollowRead(objectPath, MAX_FILE_BYTES);
+    if (createHash("sha256").update(existing).digest("hex") !== digest || existing.length !== bytes) throw new Error("Existing Health.md cache object does not match its digest");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    await atomicWrite(objectPath, input.text, 0o600);
+  }
+  const entries = await withCacheLock(directory, async () => {
+    const manifest = await readManifest(directory);
+    const entry: CacheEntry = { digest, file, bytes, origin: input.origin, operation: input.operation, fetched_at: new Date().toISOString() };
+    manifest.entries = [entry, ...manifest.entries.filter(item => item.digest !== digest || item.operation !== input.operation)].slice(0, MAX_CACHE_ENTRIES);
+    await atomicWrite(join(directory, MANIFEST_FILE), `${JSON.stringify(manifest, null, 2)}\n`, 0o600);
+    return manifest.entries.length;
+  });
+  return { directory, file: objectPath, digest, entries };
+}
+
+export async function loadCachedEvidence(directoryPath: string): Promise<InMemoryJsonInput[]> {
+  const directory = await ensureCacheDirectory(directoryPath);
+  const manifest = await readManifest(directory), inputs: InMemoryJsonInput[] = [];
+  let total = 0;
+  for (const entry of manifest.entries) {
+    if (inputs.length >= MAX_RESTORED_FILES || total + entry.bytes > MAX_RESTORED_BYTES) break;
+    const path = join(directory, "objects", entry.file);
+    const bytes = await noFollowRead(path, MAX_FILE_BYTES);
+    if (bytes.length !== entry.bytes) throw new Error(`Health.md cache size mismatch: ${entry.file}`);
+    if (createHash("sha256").update(bytes).digest("hex") !== entry.digest) throw new Error(`Health.md cache digest mismatch: ${entry.file}`);
+    total += bytes.length;
+    inputs.push({ path: `healthmd-cache://${entry.digest}`, text: bytes.toString("utf8"), origin: entry.origin, operation: entry.operation });
+  }
+  return inputs;
+}

--- a/packages/pi-healthmd-dashboard/src/contracts.ts
+++ b/packages/pi-healthmd-dashboard/src/contracts.ts
@@ -1,0 +1,233 @@
+import { decodeExactNumber } from "./exact.js";
+import type { ContractKind, JsonValue } from "./model.js";
+import { validateQueryContract } from "./query-contract.js";
+import { validateProviderSectionsSchema, validateUnifiedV9Schema } from "./schemas.js";
+
+export interface ContractClassification {
+  kind: ContractKind;
+  schema?: string;
+  schemaVersion?: string | number | bigint;
+  profile?: string;
+  ownerDate?: string;
+  platform?: string;
+  captureStatus?: string;
+  valid: boolean;
+  errors: string[];
+  experimentalV9: boolean;
+}
+
+type Obj = { [key: string]: JsonValue };
+const isObject = (value: JsonValue | undefined): value is Obj => value !== null && typeof value === "object" && !Array.isArray(value);
+const version = (value: JsonValue | undefined) => typeof value === "string" || typeof value === "number" || typeof value === "bigint" ? value : undefined;
+const string = (value: JsonValue | undefined) => typeof value === "string" ? value : undefined;
+const ownDate = (value: Obj) => string(value.owner_date) ?? string(value.date) ?? (isObject(value.ownership) ? string(value.ownership.owner_date) : undefined);
+const STATISTICS = ["sum", "average", "minimum", "maximum", "latest", "count", "duration_sum", "first_time", "last_time"] as const;
+const V9_FIXTURE_METRIC_RULES = new Map<string, ReadonlyArray<readonly [string, string]>>([
+  ["steps", [["sum", "count"]]],
+  ["heart_rate_variability_sdnn", [["average", "millisecond"]]],
+  ["heart_rate_variability_rmssd", [["latest", "millisecond"]]],
+]);
+const V9_FIXTURE_SOURCE_RULES = new Map<string, readonly [string, string]>([
+  ["apple:steps", ["steps", "sum"]],
+  ["apple:heart_rate_variability_sdnn", ["hrv", "average"]],
+  ["android:steps", ["steps", "sum"]],
+  ["android:heart_rate_variability_rmssd", ["android.hrv_rmssd", "latest"]],
+]);
+
+function timestampDate(value: string): Date | undefined {
+  const milliseconds = value.replace(/\.(\d{3})\d*Z$/, ".$1Z");
+  const parsed = new Date(milliseconds);
+  return Number.isFinite(parsed.getTime()) ? parsed : undefined;
+}
+
+function localParts(value: Date, timeZone: string): { date: string; time: string } | undefined {
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone, year: "numeric", month: "2-digit", day: "2-digit",
+      hour: "2-digit", minute: "2-digit", second: "2-digit", hourCycle: "h23",
+    }).formatToParts(value);
+    const part = (type: Intl.DateTimeFormatPartTypes) => parts.find(item => item.type === type)?.value;
+    const year = part("year"), month = part("month"), day = part("day");
+    const hour = part("hour"), minute = part("minute"), second = part("second");
+    return year && month && day && hour && minute && second ? { date: `${year}-${month}-${day}`, time: `${hour}:${minute}:${second}` } : undefined;
+  } catch { return undefined; }
+}
+
+function nextDate(value: string): string | undefined {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return undefined;
+  const date = new Date(0);
+  date.setUTCFullYear(Number(match[1]), Number(match[2]) - 1, Number(match[3]) + 1);
+  date.setUTCHours(0, 0, 0, 0);
+  return Number.isFinite(date.getTime()) ? date.toISOString().slice(0, 10) : undefined;
+}
+
+function validateV9(root: Obj): string[] {
+  const errors = validateUnifiedV9Schema(root);
+  const source = isObject(root.source) ? root.source : undefined;
+  const platform = isObject(root.platform) ? root.platform : undefined;
+  const sourcePlatform = source && string(source.platform);
+  const expectedSource = sourcePlatform === "apple" ? "apple_health" : sourcePlatform === "android" ? "health_connect" : undefined;
+  const expectedProfile = sourcePlatform === "apple" ? "apple_health_data_v8" : sourcePlatform === "android" ? new Set(["android_frozen_v4", "android_analytical_v5"]) : undefined;
+
+  if (!source || !platform || !expectedProfile || !expectedSource) errors.push("source/platform shape is invalid");
+  else {
+    const sourceProfile = string(source.source_profile);
+    if (expectedProfile instanceof Set ? !sourceProfile || !expectedProfile.has(sourceProfile) : sourceProfile !== expectedProfile) errors.push("source profile disagrees with platform");
+    const keys = Object.keys(platform);
+    if (keys.length !== 1 || keys[0] !== sourcePlatform) errors.push("source.platform and platform section disagree");
+    const section = isObject(platform[sourcePlatform!]) ? platform[sourcePlatform!] as Obj : undefined;
+    const expectedSchema = sourcePlatform === "apple" ? "healthmd.platform.apple_daily" : "healthmd.platform.android_daily";
+    if (!section || section.schema !== expectedSchema || section.schema_version !== 1) errors.push("nested platform contract identity is invalid");
+    else if (sourcePlatform === "apple" && section.source_schema_version !== 8) errors.push("Apple source schema version is invalid");
+    else if (sourcePlatform === "android") {
+      const expected = sourceProfile === "android_frozen_v4" ? [4, "android-frozen-v4"] : sourceProfile === "android_analytical_v5" ? [5, "android-analytical-v5"] : undefined;
+      if (!expected || section.source_schema_version !== expected[0] || section.source_profile !== expected[1]) errors.push("Android source profile/version disagrees with platform section");
+    }
+  }
+
+  const calendar = isObject(root.calendar) ? root.calendar : undefined;
+  const ownerDate = string(root.owner_date);
+  if (calendar && ownerDate) {
+    const zone = string(calendar.time_zone), startText = string(calendar.interval_start), endText = string(calendar.interval_end);
+    const start = startText && timestampDate(startText), end = endText && timestampDate(endText);
+    const startLocal = start && zone ? localParts(start, zone) : undefined, endLocal = end && zone ? localParts(end, zone) : undefined;
+    if (!start || !end || end <= start) errors.push("owner-day interval must be non-empty and ordered");
+    if (!startLocal || startLocal.date !== ownerDate || startLocal.time !== "00:00:00") errors.push("interval start is not local midnight for owner_date");
+    if (!endLocal || endLocal.date !== nextDate(ownerDate) || endLocal.time !== "00:00:00") errors.push("interval end is not the next local owner-date midnight");
+  }
+
+  const capture = isObject(root.capture) ? root.capture : undefined;
+  const resources = capture && Array.isArray(capture.resources) ? capture.resources : undefined;
+  const resourceKeys = new Set<string>();
+  const resourceStatuses = new Map<string, string>();
+  if (!capture || !resources) errors.push("capture/resources shape is invalid");
+  else {
+    for (const item of resources) {
+      if (!isObject(item)) continue;
+      const itemSource = string(item.source), resource = string(item.resource), status = string(item.status);
+      if (expectedSource && itemSource !== expectedSource) errors.push(`capture resource ${resource ?? "?"} has wrong primary source`);
+      if (itemSource && resource) {
+        const key = `${itemSource}\0${resource}`;
+        if (resourceKeys.has(key)) errors.push(`duplicate resource key ${itemSource}/${resource}`);
+        resourceKeys.add(key);
+        if (status) resourceStatuses.set(resource, status);
+      }
+    }
+    const expected = resources.length === 0 ? "not_requested" : resources.every(item => isObject(item) && item.status === "complete") ? "complete" : "partial";
+    if (capture.status !== expected) errors.push("capture.status is not mechanically derived from resources");
+  }
+
+  const metrics = Array.isArray(root.metrics) ? root.metrics : undefined;
+  if (!metrics) errors.push("metrics must be an array");
+  else {
+    const metricKeys = new Set<string>();
+    const semanticIds = new Set<string>();
+    const order = new Map(STATISTICS.map((name, index) => [name, index]));
+    let prior = "";
+    for (const metric of metrics) {
+      if (!isObject(metric)) continue;
+      const semanticId = string(metric.semantic_id), statistic = string(metric.statistic);
+      const key = `${semanticId ?? "?"}\0${statistic ?? "?"}`;
+      if (metricKeys.has(key)) errors.push(`duplicate metric key ${key.replace("\0", "/")}`);
+      metricKeys.add(key);
+      if (semanticId) semanticIds.add(semanticId);
+      const sortKey = `${semanticId ?? ""}\0${String(order.get(statistic as typeof STATISTICS[number]) ?? 999).padStart(3, "0")}`;
+      if (prior && sortKey < prior) errors.push("metrics are not in canonical semantic/statistic order");
+      prior = sortKey;
+      if (semanticId && resourceStatuses.get(semanticId) !== "complete") errors.push(`metric ${semanticId} has no completed matching capture resource`);
+      if (Array.isArray(metric.provenance) && expectedSource) for (const provenance of metric.provenance) {
+        if (!isObject(provenance) || provenance.source !== expectedSource) {
+          errors.push(`metric ${semanticId ?? "?"} contains provider or wrong-platform provenance`);
+          continue;
+        }
+        const sourceRule = sourcePlatform && semanticId ? V9_FIXTURE_SOURCE_RULES.get(`${sourcePlatform}:${semanticId}`) : undefined;
+        if (!sourceRule || provenance.source_semantic_id !== sourceRule[0]) errors.push(`metric ${semanticId ?? "?"} source_semantic_id is not approved by the current v9 proposal fixtures`);
+        if (provenance.source_statistic !== undefined && provenance.source_statistic !== sourceRule?.[1]) errors.push(`metric ${semanticId ?? "?"} source_statistic is not approved by the current v9 proposal fixtures`);
+      }
+      const fact = isObject(metric.value) ? metric.value : undefined;
+      if (fact?.value_type === "number" && isObject(fact.number)) {
+        try { if (!decodeExactNumber(fact.number)) errors.push(`metric ${semanticId ?? "?"} has unknown exact-number representation`); }
+        catch (error) { errors.push(`metric ${semanticId ?? "?"} exact number invalid: ${error instanceof Error ? error.message : String(error)}`); }
+      }
+      const rules = semanticId ? V9_FIXTURE_METRIC_RULES.get(semanticId) : undefined;
+      if (!rules) errors.push(`metric ${semanticId ?? "?"} is not approved by the current v9 proposal fixtures`);
+      else if (!fact || fact.value_type !== "number" || typeof fact.unit !== "string" || !rules.some(([allowedStatistic, allowedUnit]) => statistic === allowedStatistic && fact.unit === allowedUnit)) errors.push(`metric ${semanticId} statistic/unit is not approved by the current v9 proposal fixtures`);
+    }
+    if (semanticIds.has("hrv")) errors.push("ambiguous hrv semantic id is forbidden");
+    if (sourcePlatform === "apple" && semanticIds.has("heart_rate_variability_rmssd")) errors.push("Apple primary data must not be relabeled as RMSSD");
+    if (sourcePlatform === "android" && semanticIds.has("heart_rate_variability_sdnn")) errors.push("Android primary data must not be relabeled as SDNN");
+  }
+
+  if (root.providers !== undefined) {
+    errors.push(...validateProviderSectionsSchema(root.providers).map(error => `providers${error.startsWith("$") ? error.slice(1) : `: ${error}`}`));
+    if (capture?.status === "not_requested") errors.push("provider-only v9 days are forbidden");
+  }
+  return [...new Set(errors)].slice(0, 100);
+}
+
+function genericIdentity(root: Obj): Pick<ContractClassification, "schema" | "schemaVersion" | "profile" | "ownerDate" | "platform" | "captureStatus"> {
+  const source = isObject(root.source) ? root.source : undefined;
+  const capture = isObject(root.capture) ? root.capture : undefined;
+  const header = isObject(root.header) ? root.header : undefined;
+  const nestedSchema = header && string(header.schema);
+  const nestedVersion = header && version(header.version);
+  const schema = string(root.schema) ?? nestedSchema;
+  const schemaVersion = version(root.schema_version) ?? version(root.version) ?? nestedVersion;
+  const captureStatus = (capture ? string(capture.status) : undefined) ?? string(root.capture_status);
+  return {
+    ...(schema ? { schema } : {}),
+    ...(schemaVersion !== undefined ? { schemaVersion } : {}),
+    ...(string(root.profile) ?? string(root.schemaProfile) ? { profile: (string(root.profile) ?? string(root.schemaProfile))! } : {}),
+    ...(ownDate(root) ? { ownerDate: ownDate(root)! } : {}),
+    ...(source && string(source.platform) ? { platform: string(source.platform)! } : {}),
+    ...(captureStatus ? { captureStatus } : {}),
+  };
+}
+
+export function classifyContract(value: JsonValue, exactQueryTokens?: unknown): ContractClassification {
+  if (!isObject(value)) return { kind: "generic_json", valid: true, errors: [], experimentalV9: false };
+  const identity = genericIdentity(value);
+  let kind: ContractKind = "generic_json";
+  const schema = identity.schema;
+  const schemaVersion = identity.schemaVersion;
+  const profile = identity.profile;
+  if (schema === "healthmd.health_data" && schemaVersion === 9) kind = "unified_v9";
+  else if (schema === "healthmd.health_data" && [5, 6, 7, 8].includes(Number(schemaVersion))) kind = "apple_health_data";
+  else if (value.type === "health-data" && (profile === "android-analytical-v5" || value.profileVersion === 5 || value.schemaVersion === 5)) kind = "android_analytical_v5";
+  else if ((schema === "healthmd.health_data" && Number(schemaVersion) === 4) || value.type === "health-data" && value.schemaVersion === 4) kind = "android_frozen_v4";
+  else if (value.type === "health-data" && schemaVersion === undefined && value.schemaVersion === undefined) kind = "android_unversioned";
+  else if (schema === "healthmd.healthkit_records") kind = "healthkit_archive";
+  else if (schema === "healthmd.raw-snapshot" || schema === "healthmd.raw_snapshot") kind = "android_raw_snapshot";
+  else if (schema === "healthmd.raw-snapshot.manifest" || schema === "healthmd.raw_snapshot.manifest") kind = "android_raw_manifest";
+  else if (schema === "healthmd.android_merge_provenance") kind = "android_merge_reference";
+  else if (["healthmd.raw_record", "healthmd.raw_changes", "healthmd.raw-changes"].includes(schema ?? "")) kind = "android_raw_reference";
+  else if (schema === "healthmd.provider.whoop_daily" || isObject(value.whoop) && value.whoop.schema === "healthmd.provider.whoop_daily") kind = "whoop_typed_daily";
+  else if (schema === "healthmd.external_provider_daily") kind = "external_provider_daily";
+  else if (schema?.includes("rollup")) kind = "rollup";
+  else if (schema === "healthmd.api_export" || Array.isArray(value.external_records) && value.external_record_schema === "healthmd.external_provider_daily" || value.daily_record_schema === "healthmd.health_data" && Array.isArray(value.records)) kind = "api_envelope";
+  else if (schema === "healthmd.raw_result" || isObject(value.raw_result) && value.raw_result.schema === "healthmd.raw_result") kind = "raw_envelope";
+  else if (schema === "healthmd.query_response") kind = "query_response";
+  else if (schema === "healthmd.mcp_query_pages") kind = "mcp_query_pages";
+  else if (isObject(value.schema) && "source_version" in value.schema || "categories" in value && Array.isArray(value.periods)) kind = "rollup";
+  else if ("header" in value && "manifest" in value && "records" in value) kind = "android_raw_snapshot";
+  else if (schema?.startsWith("healthmd.")) kind = "generic_healthmd";
+  const errors = kind === "unified_v9" ? validateV9(value) : kind === "query_response" || kind === "mcp_query_pages" ? validateQueryContract(value, 1_000, exactQueryTokens) : [];
+  return { kind, ...identity, valid: errors.length === 0, errors, experimentalV9: kind === "unified_v9" && errors.length === 0 };
+}
+
+export function extractContext(object: Obj): Partial<{ ownerDate: string; recordTimestamp: string; unit: string; statistic: string; semanticId: string; provenance: JsonValue; platform: string; provider: string; source: string; captureStatus: string }> {
+  const owner = string(object.owner_date) ?? string(object.date) ?? (isObject(object.ownership) ? string(object.ownership.owner_date) : undefined);
+  const timestamp = ["start_time", "start_date", "startTime", "startDate", "observed_at", "observedAt", "fetched_at", "fetchedAt", "timestamp", "end_time", "end_date", "endTime", "endDate"].map(key => string(object[key])).find(Boolean);
+  const typedUnit = object.type === "count" && object.value !== undefined ? "count" : object.type === "duration" && object.seconds !== undefined ? "s" : undefined;
+  const evidenceSources = Array.isArray(object.evidence) ? [...new Set(object.evidence.flatMap(item => isObject(item) && string(item.source_id) ? [string(item.source_id)!] : []))] : [];
+  const source = string(object.source_id) ?? (evidenceSources.length > 0 ? evidenceSources.sort().join(",") : undefined);
+  return {
+    ...(owner ? { ownerDate: owner } : {}), ...(timestamp ? { recordTimestamp: timestamp } : {}),
+    ...(string(object.unit) ?? typedUnit ? { unit: (string(object.unit) ?? typedUnit)! } : {}), ...(string(object.statistic) ? { statistic: string(object.statistic)! } : {}),
+    ...(string(object.semantic_id) ?? string(object.metric_id) ? { semanticId: (string(object.semantic_id) ?? string(object.metric_id))! } : {}),
+    ...(object.provenance !== undefined ? { provenance: object.provenance } : object.evidence !== undefined ? { provenance: object.evidence } : {}),
+    ...(string(object.platform) ? { platform: string(object.platform)! } : {}), ...(string(object.provider) ? { provider: string(object.provider)! } : {}),
+    ...(source ? { source } : {}), ...(string(object.capture_status) ? { captureStatus: string(object.capture_status)! } : {}),
+  };
+}

--- a/packages/pi-healthmd-dashboard/src/dashboard.ts
+++ b/packages/pi-healthmd-dashboard/src/dashboard.ts
@@ -1,0 +1,881 @@
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { decodeKittyPrintable, matchesKey, truncateToWidth, visibleWidth, type KeyId } from "@earendil-works/pi-tui";
+import { displayValue, numericValue } from "./exact.js";
+import type { HealthStore, JsonValue } from "./model.js";
+
+interface Obj { [key: string]: JsonValue }
+const object = (value: JsonValue | undefined): value is Obj => value !== null && typeof value === "object" && !Array.isArray(value);
+const text = (value: JsonValue | undefined): string | undefined => typeof value === "string" && value ? value : undefined;
+const finiteValue = (value: JsonValue | undefined): number | undefined => value === undefined ? undefined : numericValue(value);
+const numericCandidate = (value: JsonValue): boolean => typeof value === "number" || typeof value === "bigint" || object(value) && ["binary64", "signed_integer", "unsigned_integer"].includes(String(value.representation));
+
+export interface DashboardPoint {
+  date: string;
+  value?: number;
+  display: string;
+  status: string;
+  numericExpected: boolean;
+  revision?: string;
+}
+export type DashboardDomain = "Activity" | "Sleep" | "Heart" | "Mobility" | "Recovery" | "Body" | "Other";
+export interface DashboardMetric {
+  key: string;
+  id: string;
+  name: string;
+  domain: DashboardDomain;
+  comparisonIdentity: string;
+  unit?: string;
+  source?: string;
+  provider?: string;
+  platform?: string;
+  statistic?: string;
+  contract?: string;
+  origin?: string;
+  operation?: string;
+  points: DashboardPoint[];
+  statuses: string[];
+}
+export interface DashboardTypedItem { type: string; label: string; date?: string; status?: string; detail: string }
+export interface DashboardCoverage { statuses: string[]; daysConsidered: number; daysWithValues: number; missingIntervals: number; missingTruncated: boolean; requestedRange?: string; availableRange?: string }
+export interface FullDashboardModel {
+  metrics: DashboardMetric[];
+  typedItems: DashboardTypedItem[];
+  typedItemCount: number;
+  coverage: DashboardCoverage;
+  dates: string[];
+  sources: string[];
+  origins: string[];
+  contracts: string[];
+  documentCount: number;
+  itemCount: number;
+  availableCount: number;
+  chartableCount: number;
+  unavailableCount: number;
+}
+export type DashboardScreen = "overview" | "metric" | "records" | "coverage";
+export type DashboardChartMode = "auto" | "line" | "bar";
+export interface FullDashboardState {
+  screen: DashboardScreen;
+  selected: number;
+  pointWindow: number;
+  pointOffset: number;
+  recordOffset: number;
+  cursor?: number;
+  availableOnly?: boolean;
+  domain?: DashboardDomain | "All";
+  fetchMenu?: boolean;
+  fetching?: boolean;
+  fetchStatus?: string;
+  chartMode?: DashboardChartMode;
+  help?: boolean;
+  searchEditing?: boolean;
+  searchQuery?: string;
+}
+export type DashboardFetchHandler = (days: 7 | 30 | 90, metricIds: string[], signal: AbortSignal) => Promise<void>;
+
+const DASHBOARD_DOMAINS: DashboardDomain[] = ["Activity", "Sleep", "Heart", "Mobility", "Recovery", "Body", "Other"];
+const DEFAULT_TREND_METRICS = ["steps", "distance_walking_running", "flights_climbed", "sleep_total", "sleep_deep", "sleep_core", "sleep_rem", "sleep_awake", "resting_heart_rate", "blood_oxygen", "vo2_max", "respiratory_rate", "walking_speed", "walking_step_length", "walking_asymmetry", "walking_double_support"];
+function metricDomain(id: string): DashboardDomain {
+  const value = id.toLowerCase();
+  if (/sleep|bedtime|wake_time|awake/.test(value)) return "Sleep";
+  if (/^walking_|gait|mobility|stair|speed|asymmetry|double_support/.test(value)) return "Mobility";
+  if (/(?:^|_)steps?$|active_energy|exercise|stand_|flight|distance_walking|distance_cycl|move_|activity/.test(value)) return "Activity";
+  if (/heart|pulse|blood_pressure|blood_oxygen|vo2|cardio/.test(value)) return "Heart";
+  if (/respiratory|recovery|strain|stress|temperature|hrv/.test(value)) return "Recovery";
+  if (/weight|height|body_|bmi|waist|lean_mass|fat_/.test(value)) return "Body";
+  return "Other";
+}
+
+function queryValue(value: JsonValue | undefined): { numeric?: number; display: string; unit?: string; numericExpected: boolean } {
+  if (!object(value)) return { display: value === undefined || value === null ? "—" : displayValue(value), numericExpected: false };
+  const kind = text(value.type);
+  if (kind === "quantity") {
+    const numeric = finiteValue(value.value), unit = text(value.unit);
+    return { ...(numeric === undefined ? {} : { numeric }), display: value.value === undefined ? "—" : displayValue(value.value), ...(unit ? { unit } : {}), numericExpected: true };
+  }
+  if (kind === "count") {
+    const numeric = finiteValue(value.value);
+    return { ...(numeric === undefined ? {} : { numeric }), display: value.value === undefined ? "—" : displayValue(value.value), unit: "count", numericExpected: true };
+  }
+  if (kind === "duration") {
+    const numeric = finiteValue(value.seconds);
+    return { ...(numeric === undefined ? {} : { numeric }), display: value.seconds === undefined ? "—" : displayValue(value.seconds), unit: "s", numericExpected: true };
+  }
+  if (kind === "category") return { display: text(value.display) ?? text(value.identifier) ?? "—", numericExpected: false };
+  return { display: displayValue(value), numericExpected: false };
+}
+
+function metricIdentity(parts: Array<string | number | bigint | undefined>): string { return parts.map(part => part === undefined ? "" : String(part)).join("\0"); }
+function addRangeDates(target: Set<string>, value: JsonValue | undefined): void {
+  if (!object(value) || !text(value.start_date) || !text(value.end_date)) return;
+  const start = Date.parse(`${text(value.start_date)}T00:00:00Z`), end = Date.parse(`${text(value.end_date)}T00:00:00Z`), day = 86_400_000;
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start || (end - start) / day > 36_600) return;
+  for (let time = start; time <= end; time += day) target.add(new Date(time).toISOString().slice(0, 10));
+}
+function rangeText(value: JsonValue | undefined): string | undefined { return object(value) && text(value.start_date) && text(value.end_date) ? `${text(value.start_date)}..${text(value.end_date)}` : undefined; }
+function typedItem(type: string, payload: Obj): DashboardTypedItem {
+  if (type === "workout") { const start = text(payload.start); return { type, label: text(payload.activity) ?? "Workout", ...(start ? { date: start.slice(0, 10) } : {}), detail: `${start ?? "—"} → ${text(payload.end) ?? "—"}` }; }
+  if (type === "sleep_session") { const date = text(payload.owner_date), status = text(payload.completeness); return { type, label: `${text(payload.classification) ?? "Sleep"} sleep`, ...(date ? { date } : {}), ...(status ? { status } : {}), detail: `${payload.asleep_duration_seconds === undefined ? "—" : displayValue(payload.asleep_duration_seconds)} s asleep` }; }
+  if (type === "comparison") { const status = text(payload.direction); return { type, label: text(payload.metric_id) ?? "Period comparison", ...(status ? { status } : {}), detail: `${rangeText(payload.first_range) ?? "—"} vs ${rangeText(payload.second_range) ?? "—"}` }; }
+  if (type === "workout_sleep_alignment") {
+    const workout = object(payload.workout) ? payload.workout : undefined, start = workout ? text(workout.start) : undefined, status = text(payload.status);
+    return { type, label: workout && text(workout.activity) ? text(workout.activity)! : "Workout/sleep alignment", ...(start ? { date: start.slice(0, 10) } : {}), ...(status ? { status } : {}), detail: `${payload.physiology_sample_count === undefined ? "—" : displayValue(payload.physiology_sample_count)} physiology samples` };
+  }
+  if (type === "evidence") return { type, label: Array.isArray(payload.metric_ids) ? payload.metric_ids.filter(value => typeof value === "string").join(", ") || "Evidence" : "Evidence", detail: text(payload.note) ?? "Context evidence" };
+  return { type, label: type.replaceAll("_", " "), detail: "Canonical typed item" };
+}
+
+export function buildFullDashboardModel(store: HealthStore): FullDashboardModel {
+  const metrics = new Map<string, DashboardMetric>(), typedItems: DashboardTypedItem[] = [];
+  const revisions = new Map(store.documents.filter(document => document.origin !== "file").map(document => [document.id, document.id]));
+  const dates = new Set<string>(), sources = new Set<string>(), origins = new Set<string>(), contracts = new Set<string>(), coverageStatuses = new Set<string>(), coverageSnapshots = new Set<string>(), coverageRequestedDates = new Set<string>(), coverageAvailableDates = new Set<string>(), missingIntervals = new Set<string>();
+  const coverageFragments: Array<{ start: number; end: number; daysWithValues: number }> = [];
+  let itemCount = 0, typedItemCount = 0, daysConsidered = 0, daysWithValues = 0, reportedMissingIntervals = 0, missingTruncated = false, requestedRange: string | undefined, availableRange: string | undefined;
+  for (const document of store.documents) {
+    origins.add(document.origin);
+    contracts.add([document.schema, document.schemaVersion].filter(value => value !== undefined).map(String).join("@") || document.contractKind);
+    const root = object(document.value) ? document.value : undefined;
+    const pages: Obj[] = root?.schema === "healthmd.query_response" ? [root] : root?.schema === "healthmd.mcp_query_pages" && Array.isArray(root.pages) ? root.pages.filter(object) : [];
+    if (root?.schema === "healthmd.mcp_query_pages" && object(root.receipt) && finiteValue(root.receipt.item_count) !== undefined) itemCount += finiteValue(root.receipt.item_count)! + (finiteValue(root.receipt.packet_fact_count) ?? 0);
+    else itemCount += pages.reduce((total, page) => total + (Array.isArray(page.items) ? page.items.length : 0), 0);
+    for (const page of pages) {
+      if (Array.isArray(page.sources)) for (const value of page.sources) if (object(value) && text(value.source_id)) sources.add(text(value.source_id)!);
+      if (object(page.coverage)) {
+        const coverage = page.coverage, status = text(coverage.status), considered = finiteValue(coverage.days_considered), withValues = finiteValue(coverage.days_with_values), declaredMissing = finiteValue(coverage.missing_interval_count);
+        if (declaredMissing !== undefined && declaredMissing >= 0) reportedMissingIntervals = Math.max(reportedMissingIntervals, Math.trunc(declaredMissing));
+        if (status) coverageStatuses.add(status);
+        const requested = rangeText(coverage.requested_range), available = rangeText(coverage.available_range), snapshot = `${status ?? ""}\0${considered ?? ""}\0${withValues ?? ""}\0${requested ?? ""}\0${available ?? ""}`;
+        if (!coverageSnapshots.has(snapshot)) {
+          coverageSnapshots.add(snapshot); daysConsidered += considered ?? 0; daysWithValues += withValues ?? 0;
+          if (object(coverage.requested_range) && text(coverage.requested_range.start_date) && text(coverage.requested_range.end_date) && withValues !== undefined) {
+            const start = Date.parse(`${text(coverage.requested_range.start_date)}T00:00:00Z`), end = Date.parse(`${text(coverage.requested_range.end_date)}T00:00:00Z`);
+            if (Number.isFinite(start) && Number.isFinite(end) && end >= start) coverageFragments.push({ start, end, daysWithValues: withValues });
+          }
+        }
+        requestedRange ??= requested;
+        availableRange ??= available;
+        addRangeDates(coverageRequestedDates, coverage.requested_range);
+        addRangeDates(coverageAvailableDates, coverage.available_range);
+        missingTruncated ||= coverage.missing_truncated === true;
+        if (Array.isArray(coverage.missing)) for (const missing of coverage.missing) if (object(missing)) missingIntervals.add(`${rangeText(missing.range) ?? "unknown"}\0${text(missing.status) ?? "unknown"}\0${text(missing.reason) ?? ""}`);
+      }
+      if (object(page.packet) && Array.isArray(page.packet.facts)) for (const fact of page.packet.facts) if (object(fact)) {
+        typedItemCount++;
+        const decoded = queryValue(fact.value), date = text(fact.owner_date);
+        if (date) dates.add(date);
+        if (typedItems.length < 5_000) typedItems.push({ type: "packet_fact", label: text(fact.label) ?? text(fact.fact_id) ?? "Evidence fact", ...(date ? { date } : {}), detail: `${decoded.display}${decoded.unit ? ` ${decoded.unit}` : ""}` });
+      }
+      if (!Array.isArray(page.items)) continue;
+      for (const itemValue of page.items) {
+        if (!object(itemValue)) continue;
+        const itemType = text(itemValue.type);
+        if (!itemType) continue;
+        if (itemType !== "metric") {
+          const payload = itemValue[itemType];
+          if (object(payload)) {
+            const item = typedItem(itemType, payload);
+            typedItemCount++;
+            if (item.date) dates.add(item.date);
+            if (typedItems.length < 5_000) typedItems.push(item);
+          }
+          continue;
+        }
+        if (!object(itemValue.metric)) continue;
+        const metric = itemValue.metric, id = text(metric.metric_id);
+        if (!id) continue;
+        const name = text(metric.display_name) ?? id, date = text(metric.owner_date) ?? "undated", status = text(metric.status) ?? "unknown";
+        const decoded = queryValue(metric.value), evidence = Array.isArray(metric.evidence) ? metric.evidence.filter(object) : [];
+        const sourceIds = [...new Set(evidence.map(item => text(item.source_id)).filter((value): value is string => Boolean(value)))].sort();
+        const providerIds = [...new Set(evidence.map(item => text(item.provider_id)).filter((value): value is string => Boolean(value)))].sort();
+        const source = sourceIds.length ? sourceIds.join("+") : undefined, provider = providerIds.length ? providerIds.join("+") : undefined;
+        for (const sourceId of sourceIds) sources.add(sourceId);
+        if (date !== "undated") dates.add(date);
+        const comparisonIdentity = metricIdentity([decoded.unit, source, provider, document.platform, undefined, document.schema, document.schemaVersion, document.origin, document.operation]);
+        const key = metricIdentity([id, comparisonIdentity]);
+        let series = metrics.get(key);
+        if (!series) {
+          const contract = [document.schema, document.schemaVersion].filter(value => value !== undefined).map(String).join("@") || document.contractKind;
+          series = { key, id, name, domain: metricDomain(id), comparisonIdentity, ...(decoded.unit ? { unit: decoded.unit } : {}), ...(source ? { source } : {}), ...(provider ? { provider } : {}), ...(document.platform ? { platform: document.platform } : {}), contract, origin: document.origin, ...(document.operation ? { operation: document.operation } : {}), points: [], statuses: [] };
+          metrics.set(key, series);
+        }
+        if (!series.statuses.includes(status)) series.statuses.push(status);
+        const pointKey = `${date}\0${decoded.display}\0${status}`, revision = document.origin === "file" ? undefined : document.id;
+        const superseded = revision !== undefined && series.points.some(point => point.date === date && point.revision !== undefined && point.revision !== revision);
+        if (!superseded && !series.points.some(point => `${point.date}\0${point.display}\0${point.status}` === pointKey)) series.points.push({ date, ...(decoded.numeric === undefined ? {} : { value: decoded.numeric }), display: decoded.display, status, numericExpected: decoded.numericExpected, ...(revision ? { revision } : {}) });
+      }
+    }
+  }
+
+  // Generic/v9 fallback: retain exact semantic, unit, statistic, provider, platform, source, and contract identity.
+  const names = new Map<string, string>();
+  for (const entry of store.entries) if (entry.semanticId && entry.path.endsWith(".display_name") && typeof entry.value === "string") names.set(entry.semanticId, entry.value);
+  for (const entry of store.entries) {
+    if (entry.contractKind === "query_response" || entry.contractKind === "mcp_query_pages") continue;
+    if (!entry.semanticId || /(?:^|\.|\[)(?:evidence|provenance|sources|coverage|limitations)(?:\.|\[|$)/.test(entry.path)) continue;
+    if (!(entry.path.endsWith(".number") || /\.value\.(?:value|seconds)$/.test(entry.path)) || !numericCandidate(entry.value)) continue;
+    const numeric = numericValue(entry.value);
+    const comparisonIdentity = metricIdentity([entry.unit, entry.source, entry.provider, entry.platform, entry.statistic, entry.schema, entry.schemaVersion, entry.origin, entry.operation]);
+    const key = metricIdentity([entry.semanticId, comparisonIdentity]);
+    let series = metrics.get(key);
+    if (!series) {
+      const contract = [entry.schema, entry.schemaVersion].filter(value => value !== undefined).map(String).join("@") || entry.contractKind;
+      series = { key, id: entry.semanticId, name: names.get(entry.semanticId) ?? entry.semanticId, domain: metricDomain(entry.semanticId), comparisonIdentity, ...(entry.unit ? { unit: entry.unit } : {}), ...(entry.source ? { source: entry.source } : {}), ...(entry.provider ? { provider: entry.provider } : {}), ...(entry.platform ? { platform: entry.platform } : {}), ...(entry.statistic ? { statistic: entry.statistic } : {}), contract, origin: entry.origin, ...(entry.operation ? { operation: entry.operation } : {}), points: [], statuses: ["available"] };
+      metrics.set(key, series);
+    }
+    const date = entry.ownerDate ?? entry.date ?? "undated";
+    if (date !== "undated") dates.add(date);
+    const shown = displayValue(entry.value), pointKey = `${date}\0${shown}`, revision = revisions.get(entry.documentId);
+    const superseded = revision !== undefined && series.points.some(point => point.date === date && point.revision !== undefined && point.revision !== revision);
+    if (!superseded && !series.points.some(point => `${point.date}\0${point.display}` === pointKey)) series.points.push({ date, ...(numeric === undefined ? {} : { value: numeric }), display: shown, status: "available", numericExpected: true, ...(revision ? { revision } : {}) });
+  }
+
+  const sorted = [...metrics.values()], priority = ["steps", "active_energy", "sleep_total", "resting_heart_rate", "heart_rate", "walking_running_distance"];
+  const priorityOf = (metric: DashboardMetric) => { const index = priority.indexOf(metric.id); return index < 0 ? priority.length : index; };
+  for (const metric of sorted) metric.points.sort((a, b) => a.date.localeCompare(b.date));
+  sorted.sort((a, b) => Number(metricHasAvailableEvidence(b)) - Number(metricHasAvailableEvidence(a)) || Number(b.points.some(point => point.value !== undefined)) - Number(a.points.some(point => point.value !== undefined)) || priorityOf(a) - priorityOf(b) || a.domain.localeCompare(b.domain) || a.name.localeCompare(b.name) || a.key.localeCompare(b.key));
+  const availableCount = sorted.filter(metricHasAvailableEvidence).length;
+  const chartableCount = sorted.filter(metricTrendReady).length;
+  if (coverageRequestedDates.size) {
+    const requestedDates = [...coverageRequestedDates].sort(), availableDates = [...coverageAvailableDates].sort();
+    daysConsidered = coverageRequestedDates.size;
+    requestedRange = `${requestedDates[0]}..${requestedDates.at(-1)}`;
+    if (availableDates.length) availableRange = `${availableDates[0]}..${availableDates.at(-1)}`;
+    if (coverageFragments.length) {
+      const fragments = [...coverageFragments].sort((left, right) => left.start - right.start || left.end - right.end), groups: Array<{ end: number; daysWithValues: number }> = [];
+      for (const fragment of fragments) { const group = groups.at(-1); if (group && fragment.start <= group.end) { group.end = Math.max(group.end, fragment.end); group.daysWithValues = Math.max(group.daysWithValues, fragment.daysWithValues); } else groups.push({ end: fragment.end, daysWithValues: fragment.daysWithValues }); }
+      daysWithValues = groups.reduce((sum, group) => sum + group.daysWithValues, 0);
+    }
+  }
+  return {
+    metrics: sorted,
+    typedItems,
+    typedItemCount,
+    coverage: { statuses: [...coverageStatuses].sort(), daysConsidered, daysWithValues, missingIntervals: Math.max(missingIntervals.size, reportedMissingIntervals), missingTruncated, ...(requestedRange ? { requestedRange } : {}), ...(availableRange ? { availableRange } : {}) },
+    dates: [...dates].sort(),
+    sources: [...sources].sort(),
+    origins: [...origins].sort(),
+    contracts: [...contracts].sort(),
+    documentCount: store.documents.length,
+    itemCount: itemCount || sorted.length,
+    availableCount,
+    chartableCount,
+    unavailableCount: Math.max(0, sorted.length - availableCount),
+  };
+}
+
+type DashboardTheme = Pick<Theme, "fg" | "bg" | "bold">;
+function statusTone(status: string | undefined): Parameters<DashboardTheme["fg"]>[0] {
+  if (status === "available" || status === "complete") return "success";
+  if (["failed", "unsupported", "cancelled", "redacted", "not_synchronized", "unavailable"].includes(status ?? "")) return "warning";
+  return status ? "accent" : "text";
+}
+function printableInput(data: string): string | undefined {
+  const kitty = decodeKittyPrintable(data);
+  if (kitty) return kitty;
+  const bracketedStart = "\x1b[200~", bracketedEnd = "\x1b[201~";
+  if (data.startsWith(bracketedStart) && data.endsWith(bracketedEnd)) {
+    const pasted = data.slice(bracketedStart.length, -bracketedEnd.length).replace(/[\r\n\t]+/gu, " ").replace(/[\0-\x1f\x7f]/gu, "");
+    return pasted || undefined;
+  }
+  return data && !/[\0-\x1f\x7f]/u.test(data) ? data : undefined;
+}
+function fit(value: string, width: number): string { const shown = truncateToWidth(value, Math.max(0, width), "…"); return shown + " ".repeat(Math.max(0, width - visibleWidth(shown))); }
+function frameLine(content: string, width: number, theme: DashboardTheme): string { return theme.fg("border", "│") + fit(content, Math.max(0, width - 2)) + theme.fg("border", "│"); }
+function border(width: number, top: boolean, theme: DashboardTheme): string { return theme.fg("border", `${top ? "╭" : "╰"}${"─".repeat(Math.max(0, width - 2))}${top ? "╮" : "╯"}`); }
+function metricHasAvailableEvidence(metric: DashboardMetric): boolean { return metric.statuses.some(status => status === "available" || status === "partial") && metric.points.some(point => point.status === "available" || point.status === "partial"); }
+function hasUnsafeExact(metric: DashboardMetric): boolean { return metric.points.some(point => point.numericExpected && point.value === undefined); }
+function latest(metric: DashboardMetric): DashboardPoint | undefined { return metric.points.at(-1); }
+function compactNumber(value: number, maximumFractionDigits = 2): string {
+  if (!Number.isFinite(value)) return displayValue(value);
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits, useGrouping: true }).format(value);
+}
+function chartDomain(values: number[], includeZero = false): { low: number; high: number } {
+  let low = Math.min(...values), high = Math.max(...values);
+  if (includeZero) { low = Math.min(0, low); high = Math.max(0, high); }
+  if (low === high) {
+    const padding = Math.max(Math.abs(low) * 0.05, 1), candidateLow = low - padding, candidateHigh = high + padding;
+    if (Number.isFinite(candidateLow) && Number.isFinite(candidateHigh)) return { low: candidateLow, high: candidateHigh };
+    return low > 0 ? { low: low * 0.9, high } : { low, high: high * 0.9 };
+  }
+  const span = high - low;
+  if (Number.isFinite(span)) {
+    const padding = span * 0.08, candidateLow = low - padding, candidateHigh = high + padding;
+    if (Number.isFinite(candidateLow) && Number.isFinite(candidateHigh)) return { low: candidateLow, high: candidateHigh };
+  }
+  return { low, high };
+}
+function stableRatio(value: number, low: number, high: number): number {
+  if (low === high) return 0.5;
+  const span = high - low;
+  let ratio: number;
+  if (Number.isFinite(span) && span !== 0) ratio = (value - low) / span;
+  else {
+    const scale = Math.max(Math.abs(low), Math.abs(high), Math.abs(value));
+    ratio = scale === 0 ? 0.5 : (value / scale - low / scale) / (high / scale - low / scale);
+  }
+  return Number.isFinite(ratio) ? Math.max(0, Math.min(1, ratio)) : 0.5;
+}
+function stableAverage(values: number[]): number {
+  const scale = Math.max(...values.map(Math.abs));
+  if (scale === 0) return 0;
+  const normalized = values.reduce((sum, value) => sum + value / scale, 0) / values.length;
+  return Math.max(-1, Math.min(1, normalized)) * scale;
+}
+function stableDifference(current: number, first: number): number | undefined { const difference = current - first; return Number.isFinite(difference) ? difference : undefined; }
+function durationText(seconds: number, compact = false): string {
+  const sign = seconds < 0 || Object.is(seconds, -0) ? "−" : "", total = Math.round(Math.abs(seconds));
+  const hours = Math.floor(total / 3600), minutes = Math.floor(total % 3600 / 60), remaining = total % 60;
+  if (compact) return hours ? `${sign}${hours}h${minutes ? `${minutes}m` : ""}` : minutes ? `${sign}${minutes}m${remaining ? `${remaining}s` : ""}` : `${sign}${remaining}s`;
+  return `${sign}${hours ? `${hours}h ` : ""}${minutes || hours ? `${minutes}m ` : ""}${remaining}s`.trim();
+}
+function friendlyNumeric(metric: DashboardMetric, value: number, compact = false): string {
+  const unit = metric.unit?.toLowerCase();
+  if (unit === "s" || unit === "sec" || unit === "seconds") return durationText(value, compact);
+  const number = compactNumber(value, compact ? 1 : 2);
+  if (unit === "percent" || unit === "%") return `${number}%`;
+  return `${number}${metric.unit ? ` ${metric.unit}` : ""}`;
+}
+function friendlyPoint(metric: DashboardMetric, point: DashboardPoint | undefined): string {
+  if (!point) return "unavailable";
+  return point.value === undefined ? `${point.display}${metric.unit ? ` ${metric.unit}` : ""}` : friendlyNumeric(metric, point.value);
+}
+function rawPoint(metric: DashboardMetric, point: DashboardPoint | undefined): string {
+  return point ? `${point.display}${metric.unit ? ` ${metric.unit}` : ""}` : "unavailable";
+}
+function shownValue(metric: DashboardMetric): string { return friendlyPoint(metric, latest(metric)); }
+function sparkline(metric: DashboardMetric, maximum = 10): string {
+  if (hasUnsafeExact(metric)) return "⚠ unsafe exact";
+  const points = numericPoints(metric).slice(-maximum);
+  if (!points.length) return "";
+  if (points.length === 1) return "1 observation";
+  if (!metricTrendReady(metric)) return `${points.length} disconnected observations`;
+  const values = points.map(point => point.value), minimum = Math.min(...values), maximumValue = Math.max(...values), blocks = "▁▂▃▄▅▆▇█", day = 86_400_000;
+  return values.map((value, index) => {
+    const block = blocks[Math.max(0, Math.min(blocks.length - 1, Math.round(stableRatio(value, minimum, maximumValue) * (blocks.length - 1))))];
+    if (!index) return block;
+    const gap = Date.parse(`${points[index]!.date}T00:00:00Z`) - Date.parse(`${points[index - 1]!.date}T00:00:00Z`);
+    return gap > day * 1.5 ? `·${block}` : block;
+  }).join("");
+}
+function visibleMetricIndexes(model: FullDashboardModel, state: FullDashboardState): number[] {
+  const domain = state.domain ?? "All", availableOnly = state.availableOnly !== false, query = state.searchQuery?.trim().toLowerCase();
+  return model.metrics.map((_metric, index) => index).filter(index => {
+    const metric = model.metrics[index]!;
+    const searchable = `${metric.name}\0${metric.id}\0${metric.domain}\0${metric.unit ?? ""}\0${metric.source ?? ""}\0${metric.provider ?? ""}`.toLowerCase();
+    return (!availableOnly || metricHasAvailableEvidence(metric)) && (domain === "All" || metric.domain === domain) && (!query || searchable.includes(query));
+  }).sort((left, right) => DASHBOARD_DOMAINS.indexOf(model.metrics[left]!.domain) - DASHBOARD_DOMAINS.indexOf(model.metrics[right]!.domain) || left - right);
+}
+function pointObserved(point: DashboardPoint): point is DashboardPoint & { value: number } { return point.value !== undefined && (point.status === "available" || point.status === "partial"); }
+function numericPoints(metric: DashboardMetric): Array<DashboardPoint & { value: number }> { return metric.points.filter(pointObserved); }
+function pointsTrendReady(points: Array<DashboardPoint & { value: number }>): boolean {
+  const timestamps = points.map(point => Date.parse(`${point.date}T00:00:00Z`)), day = 86_400_000;
+  if (timestamps.some(time => !Number.isFinite(time)) || timestamps.some((time, index) => index > 0 && time <= timestamps[index - 1]!)) return false;
+  return timestamps.some((time, index) => index > 0 && time - timestamps[index - 1]! <= day * 1.5);
+}
+function metricTrendReady(metric: DashboardMetric): boolean { return !hasUnsafeExact(metric) && pointsTrendReady(numericPoints(metric)); }
+function representativeMetric(model: FullDashboardModel, ids: string[], domain?: DashboardDomain): DashboardMetric | undefined {
+  return model.metrics.find(metric => ids.includes(metric.id) && metricHasAvailableEvidence(metric)) ?? (domain ? model.metrics.find(metric => metric.domain === domain && metricHasAvailableEvidence(metric) && numericPoints(metric).length > 0) : undefined);
+}
+function periodComparison(metric: DashboardMetric): { label: string; coverage: string } | undefined {
+  const points = numericPoints(metric), last = points.at(-1), day = 86_400_000;
+  if (points.length < 2 || !last || new Set(points.map(point => point.date)).size !== points.length || !/^\d{4}-\d{2}-\d{2}$/.test(last.date)) return undefined;
+  const end = Date.parse(`${last.date}T00:00:00Z`);
+  if (!Number.isFinite(end)) return undefined;
+  const current = points.filter(point => { const time = Date.parse(`${point.date}T00:00:00Z`); return time > end - 7 * day && time <= end; });
+  const previous = points.filter(point => { const time = Date.parse(`${point.date}T00:00:00Z`); return time > end - 14 * day && time <= end - 7 * day; });
+  const currentDays = new Set(current.map(point => point.date)).size, previousDays = new Set(previous.map(point => point.date)).size, coverage = `now ${currentDays}/7 · prior ${previousDays}/7`;
+  if (currentDays < 4 || previousDays < 4 || Math.abs(currentDays - previousDays) > 2) return { label: "Insufficient coverage", coverage };
+  const average = (values: Array<DashboardPoint & { value: number }>) => stableAverage(values.map(point => point.value));
+  const before = average(previous), now = average(current), relative = before === 0 ? undefined : now / Math.abs(before) - before / Math.abs(before), change = relative === undefined || !Number.isFinite(relative * 100) ? undefined : relative * 100;
+  if (change === undefined || !Number.isFinite(change)) return { label: "Prior average was zero", coverage };
+  return { label: `${change > 0 ? "↑" : change < 0 ? "↓" : "→"} ${compactNumber(Math.abs(change), 1)}% vs prior 7d`, coverage };
+}
+function selectedPoints(metric: DashboardMetric | undefined, state: FullDashboardState): DashboardPoint[] {
+  if (!metric) return [];
+  const end = Math.max(0, metric.points.length - state.pointOffset);
+  return metric.points.slice(Math.max(0, end - state.pointWindow), end);
+}
+function brailleBit(x: number, y: number): number {
+  const bits = [[0x01, 0x08], [0x02, 0x10], [0x04, 0x20], [0x40, 0x80]];
+  return bits[y]?.[x] ?? 0;
+}
+function plot(metric: DashboardMetric | undefined, state: FullDashboardState, width: number, height: number, theme: DashboardTheme): string[] {
+  const points = selectedPoints(metric, state), numeric = points.filter(pointObserved);
+  if (!metric) return [theme.fg("dim", "No metric selected.")];
+  if (hasUnsafeExact(metric)) return [theme.fg("warning", "Chart refused: series contains an unsafe exact numeric value.")];
+  if (numericPoints(metric).some(point => !Number.isFinite(Date.parse(`${point.date}T00:00:00Z`)))) return [theme.fg("warning", "Trend unavailable: series contains an undated or invalid-date observation.")];
+  if (numeric.length === 0) return [theme.fg("dim", "No numeric observations for this metric.")];
+  if (numeric.length === 1) {
+    const point = numeric[0]!, cardWidth = Math.max(18, Math.min(width, 58)), inside = cardWidth - 2;
+    const cardLine = (content: string) => `${theme.fg("borderMuted", "│")}${fit(` ${content}`, inside)}${theme.fg("borderMuted", "│")}`;
+    return [
+      theme.fg("borderMuted", `╭${"─".repeat(inside)}╮`),
+      cardLine(theme.bold(theme.fg("text", friendlyPoint(metric, point)))),
+      cardLine(`${theme.fg("muted", point.date)}  ${theme.fg(statusTone(point.status), point.status)}`),
+      cardLine(theme.fg("dim", "One observation is a snapshot, not a trend.")),
+      cardLine(theme.fg("dim", "Load at least two dates to draw a meaningful chart.")),
+      theme.fg("borderMuted", `╰${"─".repeat(inside)}╯`),
+    ];
+  }
+  const labelWidth = Math.min(12, Math.max(7, Math.floor(width * 0.16))), plotWidth = Math.max(8, width - labelWidth - 2), chartHeight = Math.max(3, height - 1);
+  const values = numeric.map(point => point.value), minimum = Math.min(...values), maximum = Math.max(...values), { low, high } = chartDomain(values);
+  const pixelWidth = plotWidth * 2, pixelHeight = chartHeight * 4, pixels = Array.from({ length: pixelHeight }, () => new Uint8Array(pixelWidth));
+  const timestamps = numeric.map(point => Date.parse(`${point.date}T00:00:00Z`)), dated = timestamps.every(Number.isFinite) && timestamps.every((time, index) => index === 0 || time > timestamps[index - 1]!);
+  if (!dated) return [theme.fg("warning", "Trend unavailable: observations require distinct valid owner dates."), ...numeric.slice(-4).map(point => `${fit(point.date, 12)} ${friendlyPoint(metric, point)}`)];
+  const coordinates = numeric.map((point, index) => ({ x: Math.round((dated ? (timestamps[index]! - timestamps[0]!) / (timestamps.at(-1)! - timestamps[0]!) : index / (numeric.length - 1)) * (pixelWidth - 1)), y: pixelHeight - 1 - Math.round(stableRatio(point.value, low, high) * (pixelHeight - 1)) }));
+  for (const coordinate of coordinates) pixels[coordinate.y]![coordinate.x] = 1;
+  for (let index = 1; index < coordinates.length; index++) {
+    if (dated && timestamps[index]! - timestamps[index - 1]! > 86_400_000 * 1.5) continue;
+    const start = coordinates[index - 1]!, end = coordinates[index]!, dx = Math.abs(end.x - start.x), dy = Math.abs(end.y - start.y), sx = start.x < end.x ? 1 : -1, sy = start.y < end.y ? 1 : -1;
+    let x = start.x, y = start.y, error = dx - dy;
+    for (;;) { pixels[y]![x] = 1; if (x === end.x && y === end.y) break; const twice = error * 2; if (twice > -dy) { error -= dy; x += sx; } if (twice < dx) { error += dx; y += sy; } }
+  }
+  const rows = Array.from({ length: chartHeight }, (_, row) => Array.from({ length: plotWidth }, (_, column) => {
+    let code = 0;
+    for (let py = 0; py < 4; py++) for (let px = 0; px < 2; px++) if (pixels[row * 4 + py]?.[column * 2 + px]) code |= brailleBit(px, py);
+    return code ? String.fromCodePoint(0x2800 + code) : " ";
+  }));
+  const cursor = Math.max(0, Math.min(state.cursor ?? numeric.length - 1, numeric.length - 1)), cursorPoint = numeric[cursor]!, cursorCoordinate = coordinates[cursor]!;
+  rows[Math.floor(cursorCoordinate.y / 4)]![Math.floor(cursorCoordinate.x / 2)] = "◆";
+  const rendered = rows.map((row, index) => {
+    const axis = index === 0 ? friendlyNumeric(metric, high, true) : index === chartHeight - 1 ? friendlyNumeric(metric, low, true) : "";
+    return `${fit(theme.fg("dim", axis), labelWidth)} ${theme.fg("borderMuted", "│")}${theme.fg("accent", row.join(""))}`;
+  });
+  const firstDate = numeric[0]!.date, lastDate = numeric.at(-1)!.date, dateSpace = Math.max(1, plotWidth - firstDate.length - lastDate.length);
+  rendered.push(`${" ".repeat(labelWidth + 2)}${theme.fg("dim", `${firstDate}${" ".repeat(dateSpace)}${lastDate}`)}`);
+  rendered.push(`${theme.fg("muted", "Selected")} ${cursorPoint.date}  ${theme.bold(theme.fg("accent", friendlyPoint(metric, cursorPoint)))}  ${theme.fg(statusTone(cursorPoint.status), cursorPoint.status)}`);
+  return rendered;
+}
+function barPlot(metric: DashboardMetric | undefined, state: FullDashboardState, width: number, height: number, theme: DashboardTheme): string[] {
+  if (!metric) return [theme.fg("dim", "No metric selected.")];
+  if (hasUnsafeExact(metric)) return [theme.fg("warning", "Chart refused: series contains an unsafe exact numeric value.")];
+  const numeric = selectedPoints(metric, state).filter(pointObserved);
+  if (!numeric.length) return [theme.fg("dim", "No numeric observations for this metric.")];
+  if (numeric.length === 1) return plot(metric, state, width, height, theme);
+  const shown = numeric.slice(-Math.max(2, height - 2)), labelWidth = width >= 32 ? 10 : 5, valueWidth = Math.max(6, Math.min(18, Math.floor(width * 0.25))), barWidth = Math.max(3, width - labelWidth - valueWidth - 4);
+  const { low: minimum, high: maximum } = chartDomain(shown.map(point => point.value), true), zero = Math.round(stableRatio(0, minimum, maximum) * (barWidth - 1)), mixed = minimum < 0 && maximum > 0;
+  const rows = shown.map(point => {
+    const cells = Array.from({ length: barWidth }, () => " "), position = Math.round(stableRatio(point.value, minimum, maximum) * (barWidth - 1));
+    if (mixed) cells[zero] = "│";
+    const start = Math.min(zero, position), end = Math.max(zero, position);
+    for (let index = start; index <= end; index++) cells[index] = "█";
+    const label = labelWidth >= 10 ? point.date.slice(0, 10) : point.date.slice(-5);
+    return `${fit(theme.fg("dim", label), labelWidth)} ${theme.fg("accent", cells.join(""))} ${fit(friendlyPoint(metric, point), valueWidth)}`;
+  });
+  return [theme.fg("dim", `Relative bars for ${shown.length} visible observations · exact values shown`), "", ...rows];
+}
+type ResolvedChartMode = "snapshot" | "line" | "bar";
+function resolvedChartMode(metric: DashboardMetric | undefined, state: FullDashboardState): ResolvedChartMode {
+  if (!metric) return "snapshot";
+  const points = selectedPoints(metric, state).filter(pointObserved);
+  if (points.length <= 1) return "snapshot";
+  const requested = state.chartMode ?? "auto";
+  if (requested !== "auto") return requested;
+  const dates = points.map(point => point.date), validDiscreteDates = dates.every(date => /^\d{4}-\d{2}-\d{2}$/.test(date) && Number.isFinite(Date.parse(`${date}T00:00:00Z`))) && new Set(dates).size === dates.length;
+  return validDiscreteDates && !pointsTrendReady(points) ? "bar" : "line";
+}
+function metricChart(metric: DashboardMetric | undefined, state: FullDashboardState, width: number, height: number, theme: DashboardTheme): string[] {
+  return resolvedChartMode(metric, state) === "bar" ? barPlot(metric, state, width, height, theme) : plot(metric, state, width, height, theme);
+}
+function availabilityBar(model: FullDashboardModel, _width: number, theme: DashboardTheme): string {
+  return `${theme.fg("success", `● ${model.availableCount} available`)}   ${theme.fg("accent", `◆ ${model.chartableCount} trend-ready`)}   ${theme.fg("dim", `○ ${model.unavailableCount} unavailable or empty`)}`;
+}
+function summaryCard(metric: DashboardMetric | undefined, domain: DashboardDomain, width: number, theme: DashboardTheme): string[] {
+  const inside = Math.max(12, width - 2), title = truncateToWidth(`─ ${domain}${metric ? ` · ${metric.name}` : ""} `, inside, "…"), top = `╭${title}${"─".repeat(Math.max(0, inside - visibleWidth(title)))}╮`, bottom = `╰${"─".repeat(inside)}╯`;
+  if (!metric) return [theme.fg("borderMuted", top), `${theme.fg("borderMuted", "│")}${fit(theme.fg("dim", " No available evidence"), inside)}${theme.fg("borderMuted", "│")}`, `${theme.fg("borderMuted", "│")}${" ".repeat(inside)}${theme.fg("borderMuted", "│")}`, theme.fg("borderMuted", bottom)];
+  const comparison = periodComparison(metric), trend = hasUnsafeExact(metric) ? "⚠ exact" : sparkline(metric, 14), observationCount = numericPoints(metric).length, latestPoint = latest(metric);
+  return [
+    theme.fg("borderMuted", top),
+    `${theme.fg("borderMuted", "│")}${fit(` ${theme.fg("text", shownValue(metric))}  ${latestPoint ? theme.fg(statusTone(latestPoint.status), latestPoint.status) : ""}  ${theme.fg("accent", trend)}`, inside)}${theme.fg("borderMuted", "│")}`,
+    `${theme.fg("borderMuted", "│")}${fit(` ${theme.fg("dim", comparison ? `${comparison.label} • ${comparison.coverage}` : `${observationCount} observation${observationCount === 1 ? "" : "s"}`)}`, inside)}${theme.fg("borderMuted", "│")}`,
+    theme.fg("borderMuted", bottom),
+  ];
+}
+function joinedCards(left: string[], right: string[], width: number): string[] {
+  const leftWidth = Math.floor((width - 2) / 2), rightWidth = width - leftWidth - 2;
+  return Array.from({ length: Math.max(left.length, right.length) }, (_, index) => `${fit(left[index] ?? "", leftWidth)}  ${fit(right[index] ?? "", rightWidth)}`);
+}
+type PieSlice = { label: string; color: Parameters<DashboardTheme["fg"]>[0]; glyph: string; value: number };
+function pieRows(stages: PieSlice[], width: number, theme: DashboardTheme): string[] {
+  const total = stages.reduce((sum, stage) => sum + stage.value, 0), radiusX = Math.max(3, Math.min(10, Math.floor((width - 4) / 4))), radiusY = Math.max(2, Math.min(4, Math.floor(radiusX / 2)));
+  const cumulative: number[] = []; let sum = 0;
+  for (const stage of stages) { sum += stage.value / total; cumulative.push(sum); }
+  return Array.from({ length: radiusY * 2 + 1 }, (_, row) => {
+    const y = row - radiusY;
+    return Array.from({ length: radiusX * 2 + 1 }, (_, column) => {
+      const x = column - radiusX, normalizedX = x / radiusX, normalizedY = y / radiusY;
+      if (normalizedX * normalizedX + normalizedY * normalizedY > 1) return "  ";
+      const fraction = (Math.atan2(normalizedY, normalizedX) + Math.PI) / (Math.PI * 2), index = Math.max(0, cumulative.findIndex(value => fraction <= value)), stage = stages[index] ?? stages.at(-1)!;
+      return theme.fg(stage.color, stage.glyph.repeat(2));
+    }).join("");
+  });
+}
+function sleepComposition(model: FullDashboardModel, width: number, theme: DashboardTheme, pie = false): string[] {
+  const definitions: Array<[string, string, Parameters<DashboardTheme["fg"]>[0], string]> = [["sleep_deep", "Deep", "accent", "█"], ["sleep_core", "Core", "text", "▓"], ["sleep_rem", "REM", "muted", "▒"], ["sleep_awake", "Awake", "dim", "░"]];
+  const first = definitions.map(([id]) => representativeMetric(model, [id])).find(Boolean);
+  if (!first) return [];
+  const date = latest(first)?.date;
+  const stages = definitions.flatMap(([id, label, color, glyph]) => { const metric = model.metrics.find(candidate => candidate.id === id && candidate.comparisonIdentity === first.comparisonIdentity); const point = metric?.points.find(candidate => candidate.date === date && pointObserved(candidate)); return metric && point?.value !== undefined ? [{ label, color, glyph, value: point.value }] : []; });
+  if (stages.some(stage => stage.value < 0)) return [];
+  const asleepStages = stages.filter(stage => stage.label !== "Awake"), asleepTotal = asleepStages.reduce((sum, stage) => sum + stage.value, 0);
+  const totalMetric = model.metrics.find(metric => metric.id === "sleep_total" && metric.comparisonIdentity === first.comparisonIdentity), totalPoint = totalMetric?.points.find(point => point.date === date && pointObserved(point)), expectedAsleep = totalPoint?.value;
+  if (!date || !totalMetric || asleepStages.length !== 3 || !Number.isFinite(asleepTotal) || asleepTotal <= 0 || expectedAsleep === undefined || expectedAsleep <= 0 || asleepTotal / expectedAsleep < 0.95 || asleepTotal / expectedAsleep > 1.05) return [];
+  const total = stages.reduce((sum, stage) => sum + stage.value, 0);
+  if (!Number.isFinite(total) || total <= 0) return [];
+  const barWidth = Math.max(12, Math.min(48, width - 20));
+  const sizes = stages.map(stage => stage.value > 0 ? Math.floor(stage.value / total * barWidth) : 0), order = stages.map((stage, index) => ({ index, remainder: stage.value > 0 ? stage.value / total * barWidth - sizes[index]! : -1 })).sort((left, right) => right.remainder - left.remainder);
+  let remaining = barWidth - sizes.reduce((sum, size) => sum + size, 0);
+  for (let index = 0; remaining > 0 && order.length; index++, remaining--) sizes[order[index % order.length]!.index]!++;
+  const bar = stages.map((stage, index) => theme.fg(stage.color, stage.glyph.repeat(sizes[index]!))).join("");
+  const legend = stages.map(stage => `${stage.glyph} ${stage.label} ${compactNumber(stage.value / total * 100, 0)}%`).join(" • "), title = theme.bold(theme.fg("accent", `Sleep composition · ${date}`)), totalText = friendlyNumeric(totalMetric, total, true);
+  return pie ? [title, ...pieRows(stages.filter(stage => stage.value > 0), width, theme), `${theme.fg("muted", "Total")} ${totalText}`, theme.fg("dim", legend)] : [title, `${bar}  ${totalText}`, theme.fg("dim", legend)];
+}
+function activitySnapshot(model: FullDashboardModel, theme: DashboardTheme): string[] {
+  const metrics = ([['steps', 'Steps'], ['distance_walking_running', 'Distance'], ['flights_climbed', 'Flights']] as Array<[string, string]>).map(([id, label]) => ({ label, metric: representativeMetric(model, [id]) })).filter((value): value is { label: string; metric: DashboardMetric } => Boolean(value.metric));
+  return metrics.length ? [
+    theme.bold(theme.fg("accent", "Latest activity observations · independent identities")),
+    ...metrics.map(({ label, metric }) => { const point = latest(metric), identity = metric.provider ?? metric.source ?? metric.platform ?? "source retained"; return `${theme.fg("muted", label)}  ${theme.fg("text", friendlyPoint(metric, point))}  ${point ? theme.fg(statusTone(point.status), point.status) : ""}  ${theme.fg("dim", `${point?.date ?? "undated"} • ${identity}`)}`; }),
+  ] : [];
+}
+function historyGuidance(model: FullDashboardModel): string | undefined {
+  if (!model.documentCount || model.chartableCount > 0) return undefined;
+  if (model.dates.length < 4) return `${model.dates.length || "No"} dated day${model.dates.length === 1 ? "" : "s"} loaded. Press F, then 2, for the recommended 30-day range.`;
+  return "No continuous identity-safe trends yet; discrete observations use bars automatically.";
+}
+function overviewLines(model: FullDashboardModel, metric: DashboardMetric | undefined, state: FullDashboardState, width: number, height: number, theme: DashboardTheme): string[] {
+  const dates = model.dates.length ? `${model.dates[0]} → ${model.dates.at(-1)}` : "No dated evidence";
+  const representatives: Array<[DashboardDomain, DashboardMetric | undefined]> = [
+    ["Activity", representativeMetric(model, ["steps", "active_energy", "distance_walking_running"], "Activity")],
+    ["Sleep", representativeMetric(model, ["sleep_total", "sleep_duration"], "Sleep")],
+    ["Heart", representativeMetric(model, ["resting_heart_rate", "heart_rate", "blood_oxygen"], "Heart")],
+    ["Mobility", representativeMetric(model, ["walking_speed", "walking_step_length"], "Mobility")],
+    ["Recovery", representativeMetric(model, ["respiratory_rate", "hrv_rmssd", "hrv_sdnn"], "Recovery")],
+    ["Body", representativeMetric(model, ["body_mass", "weight", "bmi"], "Body")],
+  ];
+  const domain = state.domain ?? "All", filteredRepresentatives = domain === "All" ? representatives : representatives.filter(([candidate]) => candidate === domain);
+  let available = filteredRepresentatives.filter((value): value is [DashboardDomain, DashboardMetric] => Boolean(value[1]));
+  if (!available.length && state.availableOnly === false && domain !== "All" && metric?.domain === domain) available = [[domain, metric]];
+  const unsafeCount = model.metrics.filter(hasUnsafeExact).length, guidance = height >= 16 ? historyGuidance(model) : undefined;
+  const twoColumns = width >= 100, reservedLines = guidance ? 10 : 9, maximumCards = twoColumns ? Math.max(2, Math.floor((height - reservedLines) / 4) * 2) : Math.max(1, Math.floor((height - reservedLines) / 4));
+  const shown = available.slice(0, maximumCards), cardWidth = twoColumns ? Math.floor((width - 2) / 2) : width, cards = shown.map(([domain, metric]) => summaryCard(metric, domain, cardWidth, theme));
+  const cardLines = twoColumns ? Array.from({ length: Math.ceil(cards.length / 2) }, (_, row) => joinedCards(cards[row * 2]!, cards[row * 2 + 1] ?? [], width)).flat() : cards.flat();
+  const pieFits = domain === "Sleep" && height >= 17 + cardLines.length + (unsafeCount ? 1 : 0) + (guidance ? 1 : 0);
+  const composition = domain === "All" || domain === "Sleep" ? sleepComposition(model, width, theme, pieFits) : [], activity = domain === "All" || domain === "Activity" ? activitySnapshot(model, theme) : [];
+  return [
+    `${theme.bold(theme.fg("accent", "Summary"))}  ${theme.fg("muted", `${dates} • navigation ${state.availableOnly === false ? "all" : "available"} / ${domain}`)}`,
+    availabilityBar(model, width, theme),
+    ...(guidance ? [theme.fg("accent", `Trend setup · ${guidance}`)] : []),
+    metric ? `${theme.fg("muted", `Selected · ${metric.domain}`)}  ${theme.bold(metric.name)}  ${theme.fg("text", shownValue(metric))}  ${latest(metric) ? theme.fg(statusTone(latest(metric)!.status), latest(metric)!.status) : ""}  ${theme.fg("dim", "D/Enter details")}` : theme.fg("dim", "No metric selected · F fetches dashboard data"),
+    ...(unsafeCount ? [theme.fg("warning", `⚠ unsafe exact: ${unsafeCount} series retained but not charted`)] : []),
+    "",
+    ...(cardLines.length ? cardLines : [theme.fg("dim", "No available summary metrics. Press F to fetch trend data.")]),
+    "",
+    ...composition,
+    ...(composition.length ? [""] : []),
+    ...activity,
+  ];
+}
+function metricLines(metric: DashboardMetric | undefined, state: FullDashboardState, width: number, height: number, theme: DashboardTheme): string[] {
+  if (!metric) return [theme.fg("warning", "No metrics are available in the loaded evidence.")];
+  const points = selectedPoints(metric, state), numeric = points.filter(pointObserved), values = numeric.map(point => point.value), current = numeric.at(-1), latestPoint = latest(metric), requestedChart = state.chartMode ?? "auto", activeChart = resolvedChartMode(metric, state);
+  const identity = [metric.contract, metric.origin, metric.operation, metric.unit, metric.statistic, metric.source, metric.provider, metric.platform].filter(Boolean).join(" • "), chartLabel = requestedChart === "auto" ? `AUTO→${activeChart.toUpperCase()}` : activeChart === "snapshot" ? `${requestedChart.toUpperCase()}→SNAPSHOT` : activeChart.toUpperCase();
+  let summary: string[];
+  if (hasUnsafeExact(metric)) summary = [
+    `${theme.fg("muted", "Latest")} ${theme.bold(theme.fg("warning", friendlyPoint(metric, latestPoint)))}`,
+    theme.fg("warning", "Exact source value is outside the safe chart range."),
+  ];
+  else if (!values.length) summary = [
+    `${theme.fg("muted", "Latest")} ${theme.bold(theme.fg("text", friendlyPoint(metric, latestPoint)))}  ${latestPoint ? theme.fg(statusTone(latestPoint.status), latestPoint.status) : ""}`,
+    theme.fg("warning", "No available or partial numeric observations."),
+  ];
+  else if (values.length === 1) {
+    const latestIsObserved = latestPoint === current && latestPoint !== undefined && pointObserved(latestPoint);
+    summary = latestIsObserved ? [
+      `${theme.fg("muted", "Snapshot")} ${theme.bold(theme.fg("text", friendlyPoint(metric, current)))}  ${theme.fg("dim", `on ${current!.date}`)}  ${theme.fg(statusTone(current!.status), current!.status)}`,
+      ...(friendlyPoint(metric, current) !== rawPoint(metric, current) ? [theme.fg("dim", `Source value ${rawPoint(metric, current)}`)] : []),
+    ] : [
+      `${theme.fg("muted", "Latest")} ${theme.bold(theme.fg("text", friendlyPoint(metric, latestPoint)))}  ${latestPoint ? theme.fg(statusTone(latestPoint.status), latestPoint.status) : ""}`,
+      `${theme.fg("muted", "Most recent observed")} ${friendlyPoint(metric, current)}  ${current!.date}`,
+    ];
+  } else {
+    const first = numeric[0]!, change = stableDifference(current!.value, first.value), average = stableAverage(values), changeText = change === undefined ? "outside finite display range" : `${change > 0 ? "+" : ""}${friendlyNumeric(metric, change)}`;
+    summary = [
+      `${theme.fg("muted", "Latest")} ${theme.bold(theme.fg("text", friendlyPoint(metric, latestPoint)))}  ${latestPoint ? theme.fg(statusTone(latestPoint.status), latestPoint.status) : ""}   ${theme.fg("muted", "Observed average")} ${friendlyNumeric(metric, average)}   ${theme.fg("muted", "Observations")} ${numeric.length}`,
+      `${theme.fg("muted", "Observed change")} ${theme.fg("accent", changeText)}   ${theme.fg("muted", "Observed range")} ${friendlyNumeric(metric, Math.min(...values))} – ${friendlyNumeric(metric, Math.max(...values))}`,
+    ];
+  }
+  const lines = [
+    `${theme.bold(theme.fg("accent", metric.name))} ${theme.fg("muted", metric.id)}`,
+    theme.fg("dim", `${identity || "source identity retained from loaded contract"} • ${chartLabel} • window ${state.pointWindow >= 3650 ? "all" : `last ${state.pointWindow} observations`}`),
+    ...summary,
+    "",
+    ...metricChart(metric, state, width, Math.max(3, Math.min(10, height - 12)), theme),
+    "",
+    theme.fg("muted", values.length === 1 ? "Observation" : "Recent observations"),
+    ...points.slice(-3).map(point => `${fit(point.date, 12)} ${fit(friendlyPoint(metric, point), 22)} ${theme.fg(statusTone(point.status), point.status)}`),
+  ];
+  return lines;
+}
+function recordLines(model: FullDashboardModel, state: FullDashboardState, height: number, theme: DashboardTheme): string[] {
+  const capacity = Math.max(1, height - 4), maximum = Math.max(0, model.typedItems.length - capacity), offset = Math.max(0, Math.min(state.recordOffset, maximum));
+  return [
+    theme.bold(theme.fg("accent", `Typed records (${model.typedItemCount})`)),
+    theme.fg("dim", "Workouts, sleep sessions, comparisons, alignments, context evidence, and packet facts"),
+    "",
+    ...(model.typedItems.length ? model.typedItems.slice(offset, offset + capacity).map((item, index) => `${index === 0 ? theme.fg("accent", "▶") : " "} ${fit(item.date ?? "—", 12)} ${fit(item.type, 24)} ${fit(item.label, 28)} ${theme.fg(item.status ? statusTone(item.status) : "text", item.status ?? item.detail)}`) : [theme.fg("dim", "No non-metric typed records in this response.")]),
+  ];
+}
+function coverageLines(model: FullDashboardModel, width: number, theme: DashboardTheme): string[] {
+  return [
+    theme.bold(theme.fg("accent", "Coverage & provenance")),
+    `${theme.fg("muted", "Documents")}  ${model.documentCount}   ${theme.fg("muted", "Items")} ${model.itemCount}`,
+    `${theme.fg("muted", "Dates")}      ${model.dates[0] ?? "—"} → ${model.dates.at(-1) ?? "—"}`,
+    `${theme.fg("muted", "Coverage")}   ${model.coverage.statuses.join(", ") || "unspecified"} • ${model.coverage.daysWithValues}/${model.coverage.daysConsidered} days with values`,
+    `${theme.fg("muted", "Ranges")}     requested ${model.coverage.requestedRange ?? "—"} • available ${model.coverage.availableRange ?? "—"}`,
+    `${theme.fg("muted", "Missing")}    ${model.coverage.missingIntervals}${model.coverage.missingTruncated ? " total • details truncated" : " intervals"}`,
+    `${theme.fg("muted", "Sources")}    ${model.sources.join(", ") || "unspecified"}`,
+    `${theme.fg("muted", "Origins")}    ${model.origins.join(", ") || "unknown"}`,
+    `${theme.fg("muted", "Contracts")}  ${model.contracts.join(", ") || "unknown"}`,
+    "",
+    availabilityBar(model, width, theme),
+    theme.fg("muted", `${model.chartableCount} identity-safe series have connected dated observations.`),
+    "",
+    theme.fg("dim", "Availability is contract evidence, not a health interpretation."),
+  ];
+}
+function welcomeLines(theme: DashboardTheme): string[] {
+  return [
+    theme.bold(theme.fg("accent", "Welcome to Health.md")),
+    theme.fg("muted", "A private, read-only view of health evidence you explicitly load or fetch."),
+    "",
+    theme.bold("Start with history"),
+    `${theme.fg("accent", "F")}  Choose a bounded 7, 30, or 90-day fetch`,
+    `${theme.fg("accent", "Enter")}  Open the fetch choices`,
+    "",
+    theme.fg("muted", "30 days is recommended: it gives charts enough history without requesting an open-ended range."),
+    theme.fg("dim", "Keep Health.md foregrounded with Direct CLI Access enabled while fetching."),
+    "",
+    theme.bold("Already have an export?"),
+    theme.fg("muted", "Close this view and run /healthmd load <file-or-directory>."),
+    "",
+    theme.fg("dim", "Evidence stays identity-separated by metric, unit, source, provider, platform, schema, and origin."),
+  ];
+}
+function helpLines(theme: DashboardTheme): string[] {
+  return [
+    theme.bold(theme.fg("accent", "Dashboard help")),
+    theme.fg("muted", "The dashboard chooses snapshots, bars, or connected lines from the evidence shape."),
+    "",
+    `${theme.bold("1–8")}  All · Activity · Sleep · Heart · Mobility · Recovery · Body · Other`,
+    `${theme.bold("/")}    Search metric name, semantic ID, unit, source, or provider`,
+    `${theme.bold("↑↓")}   Select metric             ${theme.bold("Enter / D")}  Open metric detail`,
+    `${theme.bold("←→")}   Inspect observations      ${theme.bold("V")}          Auto / bar / line`,
+    `${theme.bold("W")}    7 / 30 / 90 / all window  ${theme.bold("[ ]")}        Pan history`,
+    `${theme.bold("F")}    Fetch bounded history     ${theme.bold("A")}          Available / all`,
+    `${theme.bold("O/T/C")} Overview / records / coverage`,
+    "",
+    theme.fg("dim", "One observation remains a snapshot. Missing dates are never connected."),
+    theme.fg("dim", "Comparisons require adequate coverage and are descriptive, not medical guidance."),
+    "",
+    theme.fg("dim", "Press ? or Esc to return"),
+  ];
+}
+function searchLines(model: FullDashboardModel, state: FullDashboardState, theme: DashboardTheme): string[] {
+  const matches = visibleMetricIndexes(model, state).map(index => model.metrics[index]!), query = state.searchQuery ?? "";
+  return [
+    theme.bold(theme.fg("accent", "Search metrics")),
+    `${theme.fg("muted", ">")} ${query}${theme.fg("accent", "▌")}`,
+    theme.fg("dim", "Name, semantic ID, domain, unit, source, and provider are searchable."),
+    "",
+    theme.fg("muted", `${matches.length} matching metric${matches.length === 1 ? "" : "s"}`),
+    ...matches.slice(0, 8).map((metric, index) => `${index === 0 ? theme.fg("accent", "▶") : " "} ${theme.bold(metric.name)}  ${theme.fg("dim", `${metric.id} · ${metric.domain}${metric.unit ? ` · ${metric.unit}` : ""}`)}`),
+    ...(!matches.length ? [theme.fg("warning", "No metrics match. Backspace to broaden the search.")] : []),
+    "",
+    theme.fg("dim", "Enter applies • Backspace edits • Ctrl+U clears • Esc keeps the current filter"),
+  ];
+}
+function sidebarLines(model: FullDashboardModel, state: FullDashboardState, height: number, width: number, theme: DashboardTheme): string[] {
+  const indexes = visibleMetricIndexes(model, state), domain = state.domain ?? "All", mode = state.availableOnly === false ? "all" : "available";
+  const rows: Array<{ index?: number; text: string }> = [];
+  let previousDomain: DashboardDomain | undefined;
+  for (const index of indexes) {
+    const metric = model.metrics[index]!;
+    if (domain === "All" && metric.domain !== previousDomain) { rows.push({ text: theme.bold(theme.fg("muted", metric.domain.toUpperCase())) }); previousDomain = metric.domain; }
+    const selected = index === state.selected, marker = selected ? "▶" : " ", status = metricHasAvailableEvidence(metric) ? theme.fg("success", "●") : theme.fg("dim", "○"), label = `${marker} ${status} ${metric.name}`;
+    rows.push({ index, text: selected ? theme.bg("selectedBg", fit(theme.fg("accent", label), width)) : fit(label, width) });
+  }
+  const capacity = Math.max(1, height - 2), selectedRow = Math.max(0, rows.findIndex(row => row.index === state.selected)), start = Math.max(0, Math.min(selectedRow - Math.floor(capacity / 2), Math.max(0, rows.length - capacity)));
+  const query = state.searchQuery?.trim(), lines = [theme.bold(theme.fg("accent", `${domain} · ${mode} (${indexes.length})`)), theme.fg("dim", query ? `/ “${query}” · Ctrl+U clear` : "1–8 domains · / search")];
+  lines.push(...rows.slice(start, start + capacity).map(row => row.text));
+  if (!indexes.length) lines.push(theme.fg("dim", "No matching metrics"));
+  while (lines.length < height) lines.push(" ".repeat(width));
+  return lines.slice(0, height).map(line => fit(line, width));
+}
+
+function fetchLines(model: FullDashboardModel, state: FullDashboardState, theme: DashboardTheme): string[] {
+  const discovered = [...new Set(model.metrics.filter(metric => metricHasAvailableEvidence(metric) && metric.points.some(point => point.numericExpected)).map(metric => metric.id))], ids = discovered.length ? discovered : DEFAULT_TREND_METRICS;
+  if (state.fetching) return [theme.bold(theme.fg("accent", "Fetching Health.md trend data…")), "", theme.fg("muted", state.fetchStatus ?? "Contacting the configured read-only source."), "", theme.fg("dim", "Keep Health.md foregrounded with Direct CLI Access enabled."), theme.fg("dim", "The validated response will be added to the configured persistent cache.")];
+  return [
+    theme.bold(theme.fg("accent", "Fetch trend data")),
+    ...(state.fetchStatus ? [theme.fg(state.fetchStatus.startsWith("Fetch failed") ? "warning" : "muted", state.fetchStatus)] : []),
+    theme.fg("muted", `${ids.length || "All"} queryable metric${ids.length === 1 ? "" : "s"} • configured read-only source`),
+    "",
+    `${theme.bold("1")}  Last 7 days     Quick recent trend`,
+    `${theme.bold("2")}  Last 30 days    Recommended dashboard range`,
+    `${theme.bold("3")}  Last 90 days    Longer personal baseline`,
+    "",
+    theme.fg("dim", "Dates are inclusive. Existing cached evidence is retained."),
+    theme.fg("dim", "Keep Health.md foregrounded with Direct CLI Access enabled."),
+    "",
+    theme.fg("dim", "Esc cancels"),
+  ];
+}
+
+export function renderFullDashboard(model: FullDashboardModel, state: FullDashboardState, width: number, theme: DashboardTheme, height = 30): string[] {
+  const w = Math.max(1, width), totalHeight = Math.max(1, height);
+  if (w < 20 || totalHeight < 11) return ["Health.md dashboard", `${model.availableCount}/${model.metrics.length} available`, "Resize terminal", "Esc close"].slice(0, totalHeight).map(line => truncateToWidth(line, w, ""));
+  const inner = w - 2, visibleIndexes = visibleMetricIndexes(model, state), selectedIndex = visibleIndexes.includes(state.selected) ? state.selected : visibleIndexes[0] ?? -1, metric = selectedIndex >= 0 ? model.metrics[selectedIndex] : undefined, bodyHeight = Math.max(3, totalHeight - 8);
+  const tabs = (["overview", "metric", "records", "coverage"] as const).map(screen => screen === state.screen ? theme.bg("selectedBg", theme.fg("accent", ` ${screen.toUpperCase()} `)) : theme.fg("dim", ` ${screen.toUpperCase()} `)).join(" ");
+  const header = [
+    border(w, true, theme),
+    frameLine(` ${theme.bold(theme.fg("accent", "Health.md"))}  ${theme.fg("muted", "interactive health evidence dashboard")}`, w, theme),
+    frameLine(` ${tabs}`, w, theme),
+    frameLine(` ${theme.fg(state.fetchStatus && !state.fetching ? (state.fetchStatus.startsWith("Fetch failed") ? "warning" : "success") : "dim", state.fetchStatus ?? `${model.documentCount} document${model.documentCount === 1 ? "" : "s"} • ${model.itemCount} items • ${model.dates[0] ?? "—"}..${model.dates.at(-1) ?? "—"}${state.searchQuery ? ` • search “${state.searchQuery}”` : ""}`)}`, w, theme),
+    frameLine(theme.fg("borderMuted", ` ${"─".repeat(Math.max(0, inner - 2))}`), w, theme),
+  ];
+  const useSidebar = inner >= 92 && model.metrics.length > 0, sidebarWidth = useSidebar ? Math.min(34, Math.floor(inner * 0.3)) : 0, mainWidth = useSidebar ? inner - sidebarWidth - 4 : inner - 2;
+  const mainRaw = state.help ? helpLines(theme) : state.searchEditing ? searchLines(model, state, theme) : state.fetchMenu || state.fetching ? fetchLines(model, state, theme) : !model.documentCount ? welcomeLines(theme) : state.screen === "overview" ? overviewLines(model, metric, state, mainWidth, bodyHeight, theme) : state.screen === "metric" ? metricLines(metric, state, mainWidth, bodyHeight, theme) : state.screen === "records" ? recordLines(model, state, bodyHeight, theme) : coverageLines(model, mainWidth, theme);
+  const main = Array.from({ length: bodyHeight }, (_, index) => fit(mainRaw[index] ?? "", mainWidth));
+  let body: string[];
+  if (useSidebar) {
+    const side = sidebarLines(model, state, bodyHeight, sidebarWidth, theme);
+    body = main.map((line, index) => frameLine(` ${side[index]} ${theme.fg("borderMuted", "│")} ${line}`, w, theme));
+  } else body = main.map(line => frameLine(` ${line}`, w, theme));
+  const footerHint = state.help ? "? / Esc return" : state.searchEditing ? "Type to search • Enter apply • Ctrl+U clear • Esc return" : state.fetchMenu || state.fetching ? "1 7d • 2 30d recommended • 3 90d • Esc cancel" : "1–8 domains • / search • ? help • ↑↓ select • Enter detail • F fetch • Esc close";
+  const footer = [
+    frameLine(theme.fg("borderMuted", ` ${"─".repeat(Math.max(0, inner - 2))}`), w, theme),
+    frameLine(` ${theme.fg("dim", footerHint)}`, w, theme),
+    border(w, false, theme),
+  ];
+  return [...header, ...body, ...footer].map(line => truncateToWidth(line, w, ""));
+}
+
+export class FullDashboardComponent {
+  private model: FullDashboardModel;
+  private disposed = false;
+  private fetchController: AbortController | undefined;
+  private state: FullDashboardState = { screen: "overview", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0, availableOnly: true, domain: "All", chartMode: "auto" };
+  constructor(private readonly tui: { requestRender(): void }, private readonly theme: DashboardTheme, private readonly getStore: () => HealthStore | undefined, private readonly onClose: () => void, private readonly getHeight: () => number = () => 30, private readonly onFetch?: DashboardFetchHandler) {
+    this.model = this.readModel();
+  }
+  private readModel(): FullDashboardModel {
+    const store = this.getStore();
+    return store ? buildFullDashboardModel(store) : { metrics: [], typedItems: [], typedItemCount: 0, coverage: { statuses: [], daysConsidered: 0, daysWithValues: 0, missingIntervals: 0, missingTruncated: false }, dates: [], sources: [], origins: [], contracts: [], documentCount: 0, itemCount: 0, availableCount: 0, chartableCount: 0, unavailableCount: 0 };
+  }
+  private renderSoon(): void { if (!this.disposed) this.tui.requestRender(); }
+  private selectVisible(position: number): void {
+    const indexes = visibleMetricIndexes(this.model, this.state);
+    if (indexes.length) this.state.selected = indexes[Math.max(0, Math.min(position, indexes.length - 1))]!;
+    delete this.state.cursor; this.state.pointOffset = 0;
+  }
+  private moveMetric(delta: number): void {
+    const indexes = visibleMetricIndexes(this.model, this.state), current = Math.max(0, indexes.indexOf(this.state.selected));
+    this.selectVisible(current + delta);
+  }
+  private selectDomain(domain: DashboardDomain | "All"): void {
+    this.state.domain = domain; this.state.screen = "overview"; delete this.state.searchQuery; this.normalizeSelection();
+  }
+  private normalizeSelection(): void {
+    const indexes = visibleMetricIndexes(this.model, this.state);
+    if (indexes.length && !indexes.includes(this.state.selected)) this.state.selected = indexes[0]!;
+    else if (!indexes.length) this.state.selected = 0;
+    delete this.state.cursor; this.state.pointOffset = 0;
+  }
+  private async startFetch(days: 7 | 30 | 90): Promise<void> {
+    if (!this.onFetch || this.state.fetching) { this.state.fetchMenu = false; this.state.fetchStatus = "Fetch unavailable: no dashboard source configured"; this.renderSoon(); return; }
+    const discovered = [...new Set(this.model.metrics.filter(metric => metricHasAvailableEvidence(metric) && metric.points.some(point => point.numericExpected)).map(metric => metric.id))], ids = (discovered.length ? discovered : DEFAULT_TREND_METRICS).slice(0, 512);
+    this.fetchController = new AbortController();
+    const selectedKey = this.model.metrics[this.state.selected]?.key;
+    this.state.fetchMenu = false; this.state.fetching = true; this.state.fetchStatus = `Fetching the last ${days} days…`; this.renderSoon();
+    try {
+      await this.onFetch(days, ids, this.fetchController.signal);
+      this.model = this.readModel();
+      const retained = selectedKey ? this.model.metrics.findIndex(metric => metric.key === selectedKey) : -1;
+      this.state.selected = retained >= 0 ? retained : 0; delete this.state.cursor; this.state.pointOffset = 0;
+      this.state.fetchStatus = `Fetched ${days} days • ${this.model.documentCount} cached response${this.model.documentCount === 1 ? "" : "s"}`;
+      this.normalizeSelection();
+    } catch (error) {
+      const message = (error instanceof Error ? error.message : String(error)).replace(/[\r\n\t\0-\x1f\x7f]/g, " ");
+      const cancelled = this.fetchController.signal.aborted;
+      this.state.fetchStatus = cancelled ? "Fetch cancelled" : `Fetch failed: ${message}`;
+      this.state.fetchMenu = !cancelled;
+    } finally { this.state.fetching = false; this.fetchController = undefined; this.renderSoon(); }
+  }
+  handleInput(data: string): void {
+    const pressed = (...keys: KeyId[]) => keys.some(key => matchesKey(data, key));
+    if (pressed("ctrl+c")) { this.fetchController?.abort(); this.onClose(); return; }
+    if (this.state.help) {
+      if (pressed("q", "shift+q")) { this.onClose(); return; }
+      if (pressed("escape", "?")) delete this.state.help;
+      this.renderSoon(); return;
+    }
+    if (this.state.searchEditing) {
+      if (pressed("escape", "return")) { delete this.state.searchEditing; this.normalizeSelection(); }
+      else if (pressed("ctrl+u")) { delete this.state.searchQuery; this.normalizeSelection(); }
+      else if (pressed("backspace", "delete")) { this.state.searchQuery = (this.state.searchQuery ?? "").slice(0, -1); if (!this.state.searchQuery) delete this.state.searchQuery; this.normalizeSelection(); }
+      else {
+        const printable = printableInput(data);
+        if (printable) { this.state.searchQuery = truncateToWidth(`${this.state.searchQuery ?? ""}${printable}`, 64, ""); this.normalizeSelection(); }
+      }
+      this.renderSoon(); return;
+    }
+    if (this.state.fetchMenu) {
+      if (pressed("escape", "q", "shift+q", "f", "shift+f")) this.state.fetchMenu = false;
+      else if (pressed("1")) void this.startFetch(7);
+      else if (pressed("2")) void this.startFetch(30);
+      else if (pressed("3")) void this.startFetch(90);
+      this.renderSoon(); return;
+    }
+    if (this.state.fetching) { if (pressed("escape", "q", "shift+q")) { this.fetchController?.abort(); this.state.fetchStatus = "Cancelling fetch…"; this.renderSoon(); } return; }
+    if (pressed("escape", "q", "shift+q")) { this.onClose(); return; }
+    if (pressed("?")) this.state.help = true;
+    else if (pressed("/")) { this.state.domain = "All"; this.state.searchEditing = true; this.normalizeSelection(); }
+    else if (pressed("ctrl+u") && this.state.searchQuery) { delete this.state.searchQuery; this.normalizeSelection(); }
+    else if (pressed("f", "shift+f") || pressed("return") && !this.model.documentCount) { this.state.fetchMenu = true; delete this.state.fetchStatus; }
+    else if (pressed("1")) this.selectDomain("All");
+    else if (pressed("2")) this.selectDomain("Activity");
+    else if (pressed("3")) this.selectDomain("Sleep");
+    else if (pressed("4")) this.selectDomain("Heart");
+    else if (pressed("5")) this.selectDomain("Mobility");
+    else if (pressed("6")) this.selectDomain("Recovery");
+    else if (pressed("7")) this.selectDomain("Body");
+    else if (pressed("8")) this.selectDomain("Other");
+    else if (pressed("up", "k", "shift+k")) { if (this.state.screen === "records") this.state.recordOffset = Math.max(0, this.state.recordOffset - 1); else this.moveMetric(-1); }
+    else if (pressed("down", "j", "shift+j")) { if (this.state.screen === "records") this.state.recordOffset = Math.min(Math.max(0, this.model.typedItems.length - 1), this.state.recordOffset + 1); else this.moveMetric(1); }
+    else if (pressed("home")) { if (this.state.screen === "records") this.state.recordOffset = 0; else this.selectVisible(0); }
+    else if (pressed("end")) { if (this.state.screen === "records") this.state.recordOffset = Math.max(0, this.model.typedItems.length - 1); else this.selectVisible(visibleMetricIndexes(this.model, this.state).length - 1); }
+    else if (pressed("left")) { const metric = this.model.metrics[this.state.selected], count = metric ? selectedPoints(metric, this.state).filter(pointObserved).length : 0; this.state.cursor = Math.max(0, (this.state.cursor ?? Math.max(0, count - 1)) - 1); }
+    else if (pressed("right")) { const metric = this.model.metrics[this.state.selected], count = metric ? selectedPoints(metric, this.state).filter(pointObserved).length : 0; this.state.cursor = Math.min(Math.max(0, count - 1), (this.state.cursor ?? Math.max(0, count - 1)) + 1); }
+    else if (pressed("tab")) this.state.screen = this.state.screen === "overview" ? "metric" : this.state.screen === "metric" ? "records" : this.state.screen === "records" ? "coverage" : "overview";
+    else if (pressed("o", "shift+o")) this.state.screen = "overview";
+    else if (pressed("d", "shift+d", "return")) this.state.screen = "metric";
+    else if (pressed("t", "shift+t")) this.state.screen = "records";
+    else if (pressed("c", "shift+c")) this.state.screen = "coverage";
+    else if (pressed("v", "shift+v")) { const current = this.state.chartMode ?? "auto"; this.state.chartMode = current === "auto" ? "bar" : current === "bar" ? "line" : "auto"; this.state.screen = "metric"; }
+    else if (pressed("a", "shift+a")) { this.state.availableOnly = !(this.state.availableOnly !== false); this.normalizeSelection(); }
+    else if (pressed("g", "shift+g")) {
+      const domains: Array<DashboardDomain | "All"> = ["All", ...DASHBOARD_DOMAINS], start = domains.indexOf(this.state.domain ?? "All");
+      for (let offset = 1; offset <= domains.length; offset++) { this.state.domain = domains[(start + offset) % domains.length]!; if (visibleMetricIndexes(this.model, this.state).length) break; }
+      this.normalizeSelection();
+    } else if (pressed("w", "shift+w")) { const windows = [7, 30, 90, 3650], index = windows.indexOf(this.state.pointWindow); this.state.pointWindow = windows[(index + 1) % windows.length]!; this.state.pointOffset = 0; delete this.state.cursor; }
+    else if (pressed("[")) { this.state.pointOffset += Math.max(1, Math.floor(this.state.pointWindow / 2)); delete this.state.cursor; }
+    else if (pressed("]")) { this.state.pointOffset = Math.max(0, this.state.pointOffset - Math.max(1, Math.floor(this.state.pointWindow / 2))); delete this.state.cursor; }
+    else if (pressed("+", "=", "shift+=")) { this.state.pointWindow = Math.max(1, Math.floor(this.state.pointWindow / 2)); delete this.state.cursor; }
+    else if (pressed("-", "_", "shift+-")) { this.state.pointWindow = Math.min(3650, this.state.pointWindow * 2); delete this.state.cursor; }
+    else if (pressed("r", "shift+r")) { this.model = this.readModel(); this.normalizeSelection(); }
+    this.renderSoon();
+  }
+  render(width: number): string[] { return renderFullDashboard(this.model, this.state, width, this.theme, this.getHeight()); }
+  invalidate(): void {}
+  dispose(): void { this.disposed = true; this.fetchController?.abort(); }
+}

--- a/packages/pi-healthmd-dashboard/src/exact.ts
+++ b/packages/pi-healthmd-dashboard/src/exact.ts
@@ -1,0 +1,56 @@
+import { boundedJson, truncateUtf8 } from "./json.js";
+import type { JsonValue } from "./model.js";
+
+export interface DecodedExactNumber {
+  representation: "binary64" | "signed_integer" | "unsigned_integer";
+  exactText: string;
+  chartValue?: number;
+  safeForChart: boolean;
+}
+
+export function decodeBinary64(bits: string): DecodedExactNumber {
+  if (!/^[0-9a-f]{16}$/.test(bits)) throw new Error(`Invalid binary64 bits: ${bits}`);
+  const value = Buffer.from(bits, "hex").readDoubleBE(0);
+  if (!Number.isFinite(value)) throw new Error(`Non-finite binary64 is forbidden: ${bits}`);
+  const exactText = Object.is(value, -0) ? "-0" : value.toString();
+  return { representation: "binary64", exactText, chartValue: value, safeForChart: true };
+}
+
+export function decodeExactNumber(value: JsonValue): DecodedExactNumber | undefined {
+  if (!value || Array.isArray(value) || typeof value !== "object") return undefined;
+  const representation = value.representation;
+  if (representation === "binary64") {
+    if (typeof value.bits !== "string") throw new Error("binary64 exact number requires bits");
+    return decodeBinary64(value.bits);
+  }
+  if (representation === "signed_integer" || representation === "unsigned_integer") {
+    if (typeof value.decimal !== "string") throw new Error(`${representation} exact number requires decimal`);
+    if (value.decimal.length > 40) throw new Error("Exact integer exceeds 40 characters");
+    const pattern = representation === "signed_integer" ? /^(?:0|-?[1-9][0-9]*)$/ : /^(?:0|[1-9][0-9]*)$/;
+    if (!pattern.test(value.decimal)) throw new Error(`Invalid ${representation}: ${value.decimal}`);
+    const integer = BigInt(value.decimal);
+    const safe = integer >= BigInt(Number.MIN_SAFE_INTEGER) && integer <= BigInt(Number.MAX_SAFE_INTEGER);
+    return { representation, exactText: value.decimal, ...(safe ? { chartValue: Number(integer) } : {}), safeForChart: safe };
+  }
+  return undefined;
+}
+
+export function displayValue(value: JsonValue, maxBytes = 2_000): string {
+  try {
+    const exact = decodeExactNumber(value);
+    if (exact) return exact.exactText;
+  } catch { /* Invalid exact values remain safely displayable and are reported by validation. */ }
+  if (typeof value === "string") return truncateUtf8(value, maxBytes, "…[value truncated]");
+  if (typeof value === "number") return Object.is(value, -0) ? "-0" : String(value);
+  if (typeof value === "bigint" || typeof value === "boolean" || value === null) return String(value);
+  return boundedJson(value, maxBytes);
+}
+
+export function numericValue(value: JsonValue): number | undefined {
+  try {
+    const exact = decodeExactNumber(value);
+    if (exact) return exact.chartValue;
+  } catch { return undefined; }
+  if (typeof value === "bigint") return value >= BigInt(Number.MIN_SAFE_INTEGER) && value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : undefined;
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}

--- a/packages/pi-healthmd-dashboard/src/extension.ts
+++ b/packages/pi-healthmd-dashboard/src/extension.ts
@@ -1,0 +1,239 @@
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { StringEnum } from "@earendil-works/pi-ai";
+import { Type } from "typebox";
+import { configuredCacheDirectory, forgetCacheDirectory, loadCachedEvidence, persistFetchedEvidence, rememberCacheDirectory, type PersistedCacheReceipt } from "./cache.js";
+import { FullDashboardComponent } from "./dashboard.js";
+import { boundedJson, truncateUtf8, utf8ByteLength } from "./json.js";
+import { canonicalRoot, loadHealthData, loadHealthDataText, requireApprovedPath, storeSummary, type InMemoryJsonInput } from "./loader.js";
+import type { HealthStore, QueryOptions, ViewState } from "./model.js";
+import { initialView } from "./model.js";
+import { formatEvidence, queryStore } from "./query.js";
+import { renderDashboard } from "./render.js";
+import { fetchHealthMd, HEALTHMD_READ_OPERATIONS, type HealthMdFetchOptions, type HealthMdReadOperation, type HealthMdSourceConfig } from "./source.js";
+import { updateView, type ViewAction } from "./view.js";
+
+const WIDGET_KEY = "healthmd-dashboard";
+const MAX_TOOL_BYTES = 45_000;
+const GUIDELINES = [
+  "Tool evidence enters model context and may be retained in Pi session/JSON output; load or fetch only data the user intends to disclose to the model.",
+  "healthmd_fetch may contact a paired foreground iPhone through the configured Health.md CLI or read-only MCP stdio server; use explicit bounded dates and metrics whenever possible.",
+  "Never invent equivalence between platform/provider facts; preserve semantic ID, statistic, unit, platform, provider, provenance, capture status, and coverage.",
+  "WHOOP HRV RMSSD remains provider data and must never be merged into HealthKit SDNN or Health Connect RMSSD metrics.",
+  "Do not make medical diagnoses. Describe only bounded evidence loaded from approved roots or explicitly fetched through the configured read-only Health.md source.",
+  "healthmd.health_data v9 unified-cross-platform-v1 is proposed/experimental reader support, not evidence of a shipped writer.",
+];
+
+export interface DashboardController {
+  getStore(): HealthStore | undefined;
+  getView(): ViewState;
+  approvedRoots(): readonly string[];
+  approveAndLoad(paths: string[]): Promise<HealthStore>;
+  loadApproved(paths: string[]): Promise<HealthStore>;
+  loadFetched(input: InMemoryJsonInput): HealthStore;
+  loadFetchedMany(inputs: InMemoryJsonInput[]): HealthStore;
+  replaceStore(store: HealthStore): HealthStore;
+  query(options: QueryOptions): object;
+  view(action: ViewAction, options?: Omit<Parameters<typeof updateView>[1], "action">): ViewState;
+  reset(): void;
+}
+
+function textResult(value: unknown) {
+  const text = typeof value === "string" ? truncateUtf8(value, MAX_TOOL_BYTES, "\n…[tool output truncated]") : boundedJson(value, MAX_TOOL_BYTES);
+  return { content: [{ type: "text" as const, text }], details: { bounded: true, chars: text.length, bytes: utf8ByteLength(text) } };
+}
+
+export function createController(onChange: () => void = () => {}, initiallyVisible = true): DashboardController {
+  let store: HealthStore | undefined;
+  const resetView = (): ViewState => ({ ...initialView(), visible: initiallyVisible });
+  let view = resetView();
+  const roots = new Set<string>();
+  const performLoad = async (paths: string[], confinementRoots: readonly string[]) => { store = await loadHealthData(paths, {}, confinementRoots); onChange(); return store; };
+  return {
+    getStore: () => store, getView: () => view, approvedRoots: () => [...roots],
+    async approveAndLoad(paths) { const canonical = await Promise.all(paths.map(canonicalRoot)); canonical.forEach(root => roots.add(root)); return performLoad(canonical, canonical); },
+    async loadApproved(paths) { const canonical = await Promise.all(paths.map(path => requireApprovedPath(path, [...roots]))); return performLoad(canonical, [...roots]); },
+    loadFetched(input) { store = loadHealthDataText([input]); onChange(); return store; },
+    loadFetchedMany(inputs) { store = loadHealthDataText(inputs); onChange(); return store; },
+    replaceStore(nextStore) { store = nextStore; onChange(); return store; },
+    query(options) { if (!store) throw new Error("No Health.md evidence loaded. Use /healthmd load or healthmd_fetch first."); return formatEvidence(queryStore(store, options)); },
+    view(action, options = {}) { view = updateView(view, { action, ...options }); onChange(); return view; },
+    reset() { store = undefined; view = resetView(); roots.clear(); onChange(); },
+  };
+}
+
+export default function healthmdDashboardExtension(pi: ExtensionAPI): void {
+  let lastContext: ExtensionContext | undefined;
+  const refresh = () => {
+    if (!lastContext?.hasUI || lastContext.mode !== "tui") return;
+    const controllerView = controller.getView();
+    if (!controllerView.visible) lastContext.ui.setWidget(WIDGET_KEY, undefined);
+    else lastContext.ui.setWidget(WIDGET_KEY, (_tui, _theme) => ({ render: (width: number) => renderDashboard(controller.getStore(), controllerView, width), invalidate() {} }), { placement: "aboveEditor" });
+  };
+  const controller = createController(refresh, false);
+  let cacheDirectory: string | undefined;
+  let lastFetchedInput: InMemoryJsonInput | undefined;
+  pi.registerFlag("healthmd-data", { type: "string", description: "Approve and load a Health.md JSON root read-only at startup" });
+  pi.registerFlag("healthmd-cache-dir", { type: "string", description: "Persist validated fetched evidence and restore it across Pi reloads" });
+  pi.registerFlag("healthmd-cli-path", { type: "string", description: "Health.md CLI executable (default: healthmd on PATH)" });
+  pi.registerFlag("healthmd-mcp-path", { type: "string", description: "Standalone Health.md MCP stdio helper; omit to use healthmd mcp serve-read-only" });
+  pi.registerFlag("healthmd-fetch-transport", { type: "string", description: "Default fetched-data transport: mcp (default) or cli" });
+  pi.registerFlag("healthmd-device", { type: "string", description: "Explicit paired Health.md device UUID for the portable CLI" });
+  pi.registerFlag("healthmd-port", { type: "string", description: "Explicit Health.md direct Manual IP port" });
+
+  const flagString = (name: string): string | undefined => { const value = pi.getFlag(name); return typeof value === "string" && value.trim() ? value.trim() : undefined; };
+  const sourceConfig = (): HealthMdSourceConfig => {
+    const portText = flagString("healthmd-port") ?? process.env.HEALTHMD_CLI_PORT;
+    const transport = flagString("healthmd-fetch-transport") ?? process.env.HEALTHMD_FETCH_TRANSPORT;
+    let defaultTransport: "cli" | "mcp" | undefined;
+    if (transport === "cli" || transport === "mcp") defaultTransport = transport;
+    else if (transport) throw new Error("HEALTHMD fetch transport must be cli or mcp");
+    const mcpExecutable = flagString("healthmd-mcp-path") ?? process.env.HEALTHMD_MCP_PATH;
+    const deviceId = flagString("healthmd-device") ?? process.env.HEALTHMD_DEVICE_ID;
+    return {
+      cliExecutable: flagString("healthmd-cli-path") ?? process.env.HEALTHMD_CLI_PATH ?? "healthmd",
+      ...(mcpExecutable ? { mcpExecutable } : {}), ...(deviceId ? { deviceId } : {}),
+      ...(portText ? { port: Number(portText) } : {}),
+      ...(defaultTransport ? { defaultTransport } : {}),
+    };
+  };
+  const fetchAndLoad = async (options: HealthMdFetchOptions, signal?: AbortSignal) => {
+    const fetched = await fetchHealthMd(sourceConfig(), options, signal);
+    const input: InMemoryJsonInput = { path: fetched.syntheticPath, text: fetched.text, origin: fetched.transport === "cli" ? "healthmd-cli" : "healthmd-mcp", operation: fetched.operation };
+    let nextStore = loadHealthDataText([input]);
+    let cache: PersistedCacheReceipt | undefined;
+    if (cacheDirectory) {
+      cache = await persistFetchedEvidence(cacheDirectory, { text: input.text, origin: input.origin as "healthmd-cli" | "healthmd-mcp", operation: fetched.operation });
+      const cached = await loadCachedEvidence(cacheDirectory);
+      if (cached.length) nextStore = loadHealthDataText(cached);
+    }
+    const store = controller.replaceStore(nextStore);
+    lastFetchedInput = input;
+    return { fetched, store, cache };
+  };
+
+  pi.registerTool({
+    name: "healthmd_load", label: "Load approved Health.md JSON",
+    description: "Load JSON only at/below roots approved by --healthmd-data, HEALTHMD_DATA_PATH, or user-authored /healthmd load. No confirmation is requested.",
+    promptSnippet: "Load read-only Health.md JSON from an already approved realpath root.", promptGuidelines: GUIDELINES,
+    parameters: Type.Object({ paths: Type.Array(Type.String({ minLength: 1 }), { minItems: 1, maxItems: 32 }) }),
+    async execute(_id, params, _signal, _update, ctx) {
+      lastContext = ctx;
+      const store = await controller.loadApproved(params.paths);
+      const documents = store.documents.slice(0, 100).map(({ value: _value, contractErrors, ...document }) => ({ ...document, contractErrors: contractErrors.slice(0, 10) }));
+      return textResult({ summary: storeSummary(store), disclosure: "Loaded evidence enters model context and Pi session/JSON output.", warnings: store.warnings.slice(0, 100), references: store.references.slice(0, 100), documentCount: store.documents.length, documents, omittedDocuments: store.documents.length - documents.length });
+    },
+  });
+
+  pi.registerTool({
+    name: "healthmd_fetch", label: "Fetch Health.md evidence",
+    description: "Run one fixed read-only typed Health.md operation through the configured CLI or MCP stdio server, then replace the in-memory dashboard store with its bounded canonical JSON response. MCP uses serve-read-only and no transport fallback occurs.",
+    promptSnippet: "Fetch bounded typed evidence from a paired foreground iPhone through explicit Health.md CLI/MCP configuration.", promptGuidelines: GUIDELINES,
+    parameters: Type.Object({
+      operation: StringEnum(HEALTHMD_READ_OPERATIONS),
+      arguments: Type.Object({}, { additionalProperties: true }),
+      transport: Type.Optional(StringEnum(["mcp", "cli"] as const)),
+      timeoutSeconds: Type.Optional(Type.Integer({ minimum: 1, maximum: 3_600 })),
+    }),
+    async execute(_id, params, signal, _update, ctx) {
+      lastContext = ctx;
+      const { fetched, store, cache } = await fetchAndLoad({ operation: params.operation, arguments: params.arguments as HealthMdFetchOptions["arguments"], ...(params.transport ? { transport: params.transport } : {}), ...(params.timeoutSeconds ? { timeoutSeconds: params.timeoutSeconds } : {}) }, signal);
+      const document = store.documents[0];
+      return textResult({
+        summary: storeSummary(store), operation: fetched.operation, transport: fetched.transport, fetchedBytes: fetched.bytes,
+        contract: document ? { kind: document.contractKind, valid: document.contractValid, schema: document.schema, schemaVersion: document.schemaVersion, origin: document.origin } : undefined,
+        warnings: store.warnings, ...(cache ? { cache: { directory: cache.directory, file: cache.file, digest: cache.digest } } : {}), disclosure: cache ? "Fetched evidence is held in memory and persisted in the explicitly configured Health.md cache directory." : "Fetched evidence is held in memory for healthmd_query/healthmd_view and may enter model context or Pi session output.",
+      });
+    },
+  });
+
+  pi.registerTool({
+    name: "healthmd_query", label: "Query Health.md evidence", description: "Query loaded or fetched contracts by semantic metric, generic JSON path, or text. Returns strictly bounded model-visible evidence.",
+    promptSnippet: "Query bounded evidence across every loaded Health.md JSON path.", promptGuidelines: GUIDELINES,
+    parameters: Type.Object({ path: Type.Optional(Type.String()), search: Type.Optional(Type.String()), metric: Type.Optional(Type.String()), limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 100 })), offset: Type.Optional(Type.Integer({ minimum: 0 })) }),
+    async execute(_id, params, _signal, _update, ctx) { lastContext = ctx; return textResult(controller.query(params)); },
+  });
+
+  pi.registerTool({
+    name: "healthmd_view", label: "Control Health.md dashboard", description: "Show/hide and control the compact persistent dashboard.",
+    promptSnippet: "Control the dashboard without confirmation.", promptGuidelines: GUIDELINES,
+    parameters: Type.Object({
+      action: StringEnum(["show", "hide", "select", "focus", "mode", "date_window", "zoom_in", "zoom_out", "pan_left", "pan_right", "reset"] as const),
+      target: Type.Optional(Type.String()), targetKind: Type.Optional(StringEnum(["metric", "path", "search"] as const)),
+      mode: Type.Optional(StringEnum(["chart", "table"] as const)), startDate: Type.Optional(Type.String()), endDate: Type.Optional(Type.String()),
+    }),
+    async execute(_id, params, _signal, _update, ctx) { lastContext = ctx; const { action, ...options } = params; return textResult(controller.view(action, options)); },
+  });
+
+  const localDate = (date: Date): string => `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+  const guidedFetch = async (days: 7 | 30 | 90, metricIds: string[], signal?: AbortSignal): Promise<void> => {
+    const end = new Date(), start = new Date(end.getFullYear(), end.getMonth(), end.getDate() - days + 1);
+    const argumentsValue: HealthMdFetchOptions["arguments"] = {
+      all_pages: true,
+      dates: { type: "exact", range: { start_date: localDate(start), end_date: localDate(end) } },
+      metrics: metricIds.length ? { type: "explicit", metric_ids: metricIds } : { type: "all_available" },
+      detail_level: "summary",
+    };
+    await fetchAndLoad({ operation: "healthmd_metric_chart", arguments: argumentsValue, timeoutSeconds: 300 }, signal);
+  };
+  const openFullDashboard = async (ctx: ExtensionCommandContext) => {
+    if (ctx.mode !== "tui") { if (ctx.hasUI) ctx.ui.notify("The full Health.md dashboard requires interactive TUI mode", "error"); return; }
+    let dashboardHeight = 30;
+    await ctx.ui.custom<void>((tui, theme, _keybindings, done) => new FullDashboardComponent(tui, theme, controller.getStore, () => done(), () => dashboardHeight, (days, metricIds, signal) => guidedFetch(days, metricIds, ctx.signal ? AbortSignal.any([ctx.signal, signal]) : signal)), {
+      overlay: true,
+      overlayOptions: { width: "96%", maxHeight: "95%", anchor: "center", margin: 1, visible: (_terminalWidth, terminalHeight) => { dashboardHeight = Math.max(1, Math.floor((terminalHeight - 2) * 0.95)); return true; } },
+    });
+  };
+
+  pi.registerCommand("healthmd", {
+    description: "Health.md dashboard: dashboard/load/fetch/cache/show/hide/reset/status",
+    async handler(args, ctx) {
+      lastContext = ctx;
+      const trimmed = args.trim();
+      const separator = trimmed.search(/\s/);
+      const command = (separator === -1 ? trimmed : trimmed.slice(0, separator)) || "status";
+      const argument = separator === -1 ? "" : trimmed.slice(separator).trim();
+      try {
+        if (command === "load") { if (!argument) throw new Error("Usage: /healthmd load <file-or-directory>"); const store = await controller.approveAndLoad([argument]); if (ctx.hasUI) ctx.ui.notify(storeSummary(store), "info"); }
+        else if (command === "fetch") {
+          const operationSeparator = argument.search(/\s/);
+          if (operationSeparator < 1) throw new Error("Usage: /healthmd fetch <operation> <JSON-object>");
+          const operation = argument.slice(0, operationSeparator);
+          if (!(HEALTHMD_READ_OPERATIONS as readonly string[]).includes(operation)) throw new Error(`Unsupported read-only Health.md operation: ${operation}`);
+          const parsed = JSON.parse(argument.slice(operationSeparator).trim()) as unknown;
+          if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Health.md query arguments must be one JSON object");
+          const { store } = await fetchAndLoad({ operation: operation as HealthMdReadOperation, arguments: parsed as HealthMdFetchOptions["arguments"] }, ctx.signal);
+          if (ctx.hasUI) ctx.ui.notify(storeSummary(store), "info");
+        }
+        else if (command === "dashboard") await openFullDashboard(ctx);
+        else if (command === "cache") {
+          if (!argument) throw new Error("Usage: /healthmd cache <directory|off>");
+          if (argument === "off") { await forgetCacheDirectory(); cacheDirectory = undefined; if (ctx.hasUI) ctx.ui.notify("Health.md persistent cache disabled; existing cached files were retained", "info"); }
+          else {
+            cacheDirectory = await rememberCacheDirectory(argument);
+            if (lastFetchedInput) await persistFetchedEvidence(cacheDirectory, { text: lastFetchedInput.text, origin: lastFetchedInput.origin as "healthmd-cli" | "healthmd-mcp", operation: lastFetchedInput.operation ?? "unknown" });
+            else { const cached = await loadCachedEvidence(cacheDirectory); if (cached.length) controller.loadFetchedMany(cached); }
+            if (ctx.hasUI) ctx.ui.notify(`Health.md persistent cache: ${cacheDirectory}`, "info");
+          }
+        }
+        else if (command === "show" || command === "hide") controller.view(command);
+        else if (command === "reset") controller.reset();
+        else if (command === "status") { if (ctx.hasUI) ctx.ui.notify(`${controller.getStore() ? storeSummary(controller.getStore()!) : "No Health.md evidence loaded"}; cache ${cacheDirectory ?? "disabled"}`, "info"); }
+        else throw new Error("Usage: /healthmd dashboard|load|fetch|cache|show|hide|reset|status");
+      } catch (error) {
+        if (ctx.hasUI) ctx.ui.notify(error instanceof Error ? error.message : String(error), "error");
+        else throw error;
+      }
+    },
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    lastContext = ctx; refresh();
+    const explicitCache = flagString("healthmd-cache-dir") ?? process.env.HEALTHMD_CACHE_DIR;
+    try {
+      cacheDirectory = await configuredCacheDirectory(explicitCache);
+      if (cacheDirectory) { const cached = await loadCachedEvidence(cacheDirectory); if (cached.length) { controller.loadFetchedMany(cached); if (ctx.hasUI) ctx.ui.notify(`Restored ${cached.length} cached Health.md response${cached.length === 1 ? "" : "s"}`, "info"); } }
+    } catch (error) { if (ctx.hasUI) ctx.ui.notify(`Health.md cache restore failed: ${error instanceof Error ? error.message : String(error)}`, "error"); else throw error; }
+    const startup = pi.getFlag("healthmd-data") || process.env.HEALTHMD_DATA_PATH;
+    if (typeof startup === "string" && startup.trim()) try { await controller.approveAndLoad([startup]); if (ctx.hasUI) ctx.ui.notify(storeSummary(controller.getStore()!), "info"); } catch (error) { if (ctx.hasUI) ctx.ui.notify(`Health.md startup load failed: ${error instanceof Error ? error.message : String(error)}`, "error"); else throw error; }
+  });
+}

--- a/packages/pi-healthmd-dashboard/src/json.ts
+++ b/packages/pi-healthmd-dashboard/src/json.ts
@@ -1,0 +1,81 @@
+import { parse } from "lossless-json";
+import type { JsonValue } from "./model.js";
+
+const MAX_NUMBER_TOKEN_CHARS = 1024;
+
+export class JsonNumberToken {
+  constructor(readonly token: string) {}
+}
+
+export function parseJsonNumberTokens(text: string): unknown {
+  return parse(text, null, token => {
+    if (token.length > MAX_NUMBER_TOKEN_CHARS) throw new Error(`JSON number token exceeds ${MAX_NUMBER_TOKEN_CHARS} characters`);
+    return new JsonNumberToken(token);
+  });
+}
+
+export function parseJsonLossless(text: string): JsonValue {
+  return parse(text, null, token => {
+    if (token.length > MAX_NUMBER_TOKEN_CHARS) throw new Error(`JSON number token exceeds ${MAX_NUMBER_TOKEN_CHARS} characters`);
+    if (/[.eE]/.test(token)) {
+      const number = Number(token);
+      if (!Number.isFinite(number)) throw new Error("JSON number is outside the finite binary64 range");
+      return number;
+    }
+    if (token === "-0") return -0;
+    const integer = BigInt(token);
+    return integer >= BigInt(Number.MIN_SAFE_INTEGER) && integer <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(integer) : integer;
+  }) as JsonValue;
+}
+
+export function jsonStringify(value: unknown, space?: number): string {
+  return JSON.stringify(value, (_key, item) => typeof item === "bigint" ? item.toString() : item, space) ?? "null";
+}
+
+export function utf8ByteLength(text: string): number { return Buffer.byteLength(text, "utf8"); }
+
+export function truncateUtf8(text: string, maxBytes: number, suffix = "…[truncated]"): string {
+  if (maxBytes <= 0) return "";
+  if (utf8ByteLength(text) <= maxBytes) return text;
+  const suffixBytes = utf8ByteLength(suffix);
+  if (suffixBytes >= maxBytes) return Buffer.from(suffix).subarray(0, maxBytes).toString("utf8").replace(/\uFFFD$/u, "");
+  const buffer = Buffer.from(text);
+  let end = maxBytes - suffixBytes;
+  while (end > 0 && (buffer[end]! & 0xc0) === 0x80) end--;
+  return `${buffer.subarray(0, end).toString("utf8")}${suffix}`;
+}
+
+interface PreviewState { nodes: number; maxNodes: number; maxDepth: number; maxStringChars: number }
+function preview(value: unknown, state: PreviewState, depth: number): unknown {
+  if (state.nodes++ >= state.maxNodes) return "…[node limit]";
+  if (typeof value === "string") return value.length <= state.maxStringChars ? value : `${value.slice(0, state.maxStringChars)}…[string truncated]`;
+  if (typeof value === "bigint") return value.toString();
+  if (value === null || typeof value === "number" || typeof value === "boolean" || value === undefined) return value;
+  if (depth >= state.maxDepth) return Array.isArray(value) ? `[array ${value.length} items]` : "{object depth limit}";
+  if (Array.isArray(value)) {
+    const output: unknown[] = [];
+    for (let index = 0; index < value.length && state.nodes < state.maxNodes; index++) output.push(preview(value[index], state, depth + 1));
+    if (output.length < value.length) output.push(`…[${value.length - output.length} items omitted]`);
+    return output;
+  }
+  if (typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const key in value as Record<string, unknown>) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+      if (state.nodes >= state.maxNodes) { output["…"] = "[properties omitted]"; break; }
+      output[key.length <= state.maxStringChars ? key : `${key.slice(0, state.maxStringChars)}…`] = preview((value as Record<string, unknown>)[key], state, depth + 1);
+    }
+    return output;
+  }
+  return String(value);
+}
+
+export function boundedJson(value: unknown, maxBytes: number): string {
+  const state: PreviewState = {
+    nodes: 0,
+    maxNodes: Math.max(8, Math.min(1_024, Math.floor(maxBytes / 16))),
+    maxDepth: 12,
+    maxStringChars: Math.max(16, Math.min(256, Math.floor(maxBytes / 32))),
+  };
+  return truncateUtf8(jsonStringify(preview(value, state, 0)), maxBytes);
+}

--- a/packages/pi-healthmd-dashboard/src/loader.ts
+++ b/packages/pi-healthmd-dashboard/src/loader.ts
@@ -1,0 +1,328 @@
+import { createHash } from "node:crypto";
+import { constants } from "node:fs";
+import { lstat, open, opendir, realpath } from "node:fs/promises";
+import { basename, isAbsolute, relative, resolve, sep } from "node:path";
+import { classifyContract, extractContext } from "./contracts.js";
+import { jsonStringify, parseJsonLossless, parseJsonNumberTokens, utf8ByteLength } from "./json.js";
+import type { DocumentOrigin, HealthStore, IndexEntry, JsonValue, LoadLimits, LoadedDocument, ReferenceResolution } from "./model.js";
+import { DEFAULT_LIMITS } from "./model.js";
+
+type Obj = { [key: string]: JsonValue };
+const object = (value: JsonValue): value is Obj => value !== null && typeof value === "object" && !Array.isArray(value);
+type OpenHandle = Awaited<ReturnType<typeof open>>;
+
+async function verifyOpenIdentity(handle: OpenHandle, path: string, expectedCanonical: string) {
+  const opened = await handle.stat();
+  const currentCanonical = await realpath(path);
+  const current = await lstat(path);
+  if (current.isSymbolicLink() || currentCanonical !== expectedCanonical || opened.dev !== current.dev || opened.ino !== current.ino) {
+    throw new Error(`Path identity changed during read-only open: ${path}`);
+  }
+  return opened;
+}
+
+export async function canonicalRoot(path: string): Promise<string> {
+  const input = resolve(path);
+  if ((await lstat(input)).isSymbolicLink()) throw new Error(`Symbolic-link inputs are not followed: ${path}`);
+  const canonical = await realpath(input);
+  const handle = await open(input, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try { await verifyOpenIdentity(handle, input, canonical); }
+  finally { await handle.close(); }
+  return canonical;
+}
+
+export function isAtOrBelow(path: string, root: string): boolean {
+  const rel = relative(root, path);
+  return rel === "" || (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel));
+}
+
+function requireConfinement(path: string, roots: readonly string[], displayPath = path): void {
+  if (roots.length > 0 && !roots.some(root => isAtOrBelow(path, root))) throw new Error(`${displayPath} is outside approved Health.md roots`);
+}
+
+export async function requireApprovedPath(path: string, approvedRoots: readonly string[]): Promise<string> {
+  if (approvedRoots.length === 0) throw new Error("No approved Health.md roots. Approve one with --healthmd-data, HEALTHMD_DATA_PATH, or /healthmd load <path>.");
+  const canonical = await canonicalRoot(path);
+  if (!approvedRoots.some(root => isAtOrBelow(canonical, root))) throw new Error(`${path} is outside approved Health.md roots; approve it with /healthmd load <path>`);
+  return canonical;
+}
+
+interface TraversalCounter { entries: number }
+async function collectJsonFiles(input: string, limits: LoadLimits, traversal: TraversalCounter, confinementRoots: readonly string[]): Promise<string[]> {
+  const root = await canonicalRoot(input);
+  requireConfinement(root, confinementRoots, input);
+  const rootHandle = await open(root, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  let rootStat: import("node:fs").Stats;
+  try { rootStat = await verifyOpenIdentity(rootHandle, root, root); }
+  finally { await rootHandle.close(); }
+  if (rootStat.isFile()) {
+    if (!root.toLowerCase().endsWith(".json")) throw new Error(`Explicit file is not JSON: ${input}`);
+    return [root];
+  }
+  if (!rootStat.isDirectory()) throw new Error(`Input is neither a file nor directory: ${input}`);
+  const output: string[] = [];
+  const pending = [root];
+  while (pending.length) {
+    const directory = pending.pop()!;
+    const directoryStat = await lstat(directory);
+    if (directoryStat.isSymbolicLink()) throw new Error(`Symbolic-link directories are not followed: ${directory}`);
+    const canonicalDirectory = await realpath(directory);
+    if (!isAtOrBelow(canonicalDirectory, root)) throw new Error(`Directory identity escaped the selected root: ${directory}`);
+    requireConfinement(canonicalDirectory, confinementRoots, directory);
+    const handle = await opendir(canonicalDirectory);
+    try {
+      for await (const child of handle) {
+        traversal.entries++;
+        if (traversal.entries > limits.maxDirectoryEntries) throw new Error(`Directory entry count exceeds limit ${limits.maxDirectoryEntries}`);
+        if (child.isSymbolicLink()) continue;
+        const candidate = resolve(canonicalDirectory, child.name);
+        if (child.isDirectory()) pending.push(candidate);
+        else if (child.isFile() && child.name.toLowerCase().endsWith(".json")) {
+          const canonical = await realpath(candidate);
+          if (!isAtOrBelow(canonical, root)) throw new Error(`File identity escaped the selected root: ${candidate}`);
+          requireConfinement(canonical, confinementRoots, candidate);
+          output.push(canonical);
+          if (output.length > limits.maxFiles) throw new Error(`JSON file count exceeds limit ${limits.maxFiles}`);
+        }
+      }
+    } finally { await handle.close().catch(() => {}); }
+  }
+  return output.sort();
+}
+
+async function readBoundedFile(file: string, maxBytes: number, confinementRoots: readonly string[]): Promise<Buffer> {
+  requireConfinement(file, confinementRoots);
+  const handle = await open(file, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const stat = await verifyOpenIdentity(handle, file, file);
+    if (!stat.isFile()) throw new Error(`${file} is not a regular file`);
+    if (stat.size > maxBytes) throw new Error(`${file} exceeds per-file byte limit ${maxBytes}`);
+    const chunks: Buffer[] = [];
+    let total = 0;
+    while (true) {
+      const chunk = Buffer.allocUnsafe(Math.min(64 * 1024, maxBytes + 1 - total));
+      const { bytesRead } = await handle.read(chunk, 0, chunk.length, null);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      if (total > maxBytes) throw new Error(`${file} exceeds per-file byte limit ${maxBytes}`);
+      chunks.push(chunk.subarray(0, bytesRead));
+    }
+    return Buffer.concat(chunks, total);
+  } finally { await handle.close(); }
+}
+
+function assertJsonDepth(text: string, maxDepth: number): void {
+  let depth = 0, inString = false, escaped = false;
+  for (const character of text) {
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (character === "\\") escaped = true;
+      else if (character === "\"") inString = false;
+      continue;
+    }
+    if (character === "\"") inString = true;
+    else if (character === "{" || character === "[") {
+      depth++;
+      if (depth > maxDepth + 1) throw new Error(`JSON depth exceeds limit ${maxDepth}`);
+    } else if (character === "}" || character === "]") depth--;
+  }
+}
+
+function childPath(parent: string, key: string | number, maxBytes: number): string {
+  const parentBytes = utf8ByteLength(parent);
+  let path: string;
+  if (typeof key === "number") path = `${parent}[${key}]`;
+  else {
+    if (parentBytes + utf8ByteLength(key) + 4 > maxBytes) throw new Error(`JSON path exceeds per-path byte limit ${maxBytes}`);
+    path = /^[A-Za-z_$][A-Za-z0-9_$-]*$/.test(key) ? `${parent}.${key}` : `${parent}[${jsonStringify(key)}]`;
+  }
+  if (utf8ByteLength(path) > maxBytes) throw new Error(`JSON path exceeds per-path byte limit ${maxBytes}`);
+  return path;
+}
+
+interface IndexCounters { leaves: number; nodes: number; pathBytes: number }
+function reservePath(path: string, counters: IndexCounters, limits: LoadLimits): string {
+  counters.pathBytes += utf8ByteLength(path);
+  if (counters.pathBytes > limits.maxIndexedPathBytes) throw new Error(`Indexed JSON paths exceed total byte limit ${limits.maxIndexedPathBytes}`);
+  return path;
+}
+
+type Context = Partial<Pick<IndexEntry, "ownerDate" | "recordTimestamp" | "unit" | "statistic" | "semanticId" | "provenance" | "platform" | "provider" | "source" | "captureStatus">>;
+function mergeContext(parent: Context, value: JsonValue, path: string, document: LoadedDocument): Context {
+  const local = object(value) ? extractContext(value) : {};
+  const provider = path.match(/(?:^|\.)providers\.([^.[]+)/)?.[1] ?? (path.match(/^\$\.whoop(?:\.|$)/) ? "whoop" : undefined);
+  const platform = path.match(/(?:^|\.)platform\.([^.[]+)/)?.[1];
+  const ownerDate = local.ownerDate ?? parent.ownerDate ?? document.ownerDate;
+  const recordTimestamp = local.recordTimestamp ?? parent.recordTimestamp;
+  const unit = local.unit ?? parent.unit, statistic = local.statistic ?? parent.statistic, semanticId = local.semanticId ?? parent.semanticId;
+  const provenance = local.provenance ?? parent.provenance, resolvedPlatform = platform ?? local.platform ?? parent.platform ?? document.platform;
+  const resolvedProvider = provider ?? local.provider ?? parent.provider, source = local.source ?? parent.source;
+  const captureStatus = local.captureStatus ?? parent.captureStatus ?? document.captureStatus;
+  return {
+    ...(ownerDate ? { ownerDate } : {}), ...(recordTimestamp ? { recordTimestamp } : {}), ...(unit ? { unit } : {}),
+    ...(statistic ? { statistic } : {}), ...(semanticId ? { semanticId } : {}), ...(provenance ? { provenance } : {}),
+    ...(resolvedPlatform ? { platform: resolvedPlatform } : {}), ...(resolvedProvider ? { provider: resolvedProvider } : {}),
+    ...(source ? { source } : {}), ...(captureStatus ? { captureStatus } : {}),
+  };
+}
+
+function indexDocument(document: LoadedDocument, counters: IndexCounters, limits: LoadLimits): IndexEntry[] {
+  const entries: IndexEntry[] = [];
+  const stack: Array<{ value: JsonValue; path: string; depth: number; context: Context }> = [{ value: document.value, path: reservePath("$", counters, limits), depth: 0, context: {} }];
+  while (stack.length) {
+    const item = stack.pop()!;
+    if (item.depth > limits.maxDepth) throw new Error(`JSON depth exceeds limit ${limits.maxDepth}`);
+    counters.nodes++;
+    if (counters.nodes > limits.maxNodes) throw new Error(`JSON node count exceeds limit ${limits.maxNodes}`);
+    const kind: IndexEntry["kind"] = Array.isArray(item.value) ? "array" : object(item.value) ? "object" : "scalar";
+    const context = mergeContext(item.context, item.value, item.path, document);
+    const date = context.recordTimestamp ?? context.ownerDate;
+    entries.push({ documentId: document.id, file: document.path, path: item.path, value: item.value, kind, contractKind: document.contractKind, ...(document.schema ? { schema: document.schema } : {}), ...(document.schemaVersion !== undefined ? { schemaVersion: document.schemaVersion } : {}), contractValid: document.contractValid, contractErrors: document.contractErrors, origin: document.origin, ...(document.operation ? { operation: document.operation } : {}), ...context, ...(date ? { date } : {}) });
+    if (kind === "scalar") {
+      counters.leaves++;
+      if (counters.leaves > limits.maxLeaves) throw new Error(`JSON leaf count exceeds limit ${limits.maxLeaves}`);
+    } else if (Array.isArray(item.value)) {
+      for (let index = item.value.length - 1; index >= 0; index--) {
+        const path = reservePath(childPath(item.path, index, limits.maxPathBytes), counters, limits);
+        stack.push({ value: item.value[index]!, path, depth: item.depth + 1, context });
+      }
+    } else if (object(item.value)) {
+      const children = Object.entries(item.value);
+      for (let index = children.length - 1; index >= 0; index--) {
+        const [key, value] = children[index]!;
+        const path = reservePath(childPath(item.path, key, limits.maxPathBytes), counters, limits);
+        stack.push({ value, path, depth: item.depth + 1, context });
+      }
+    }
+  }
+  return entries;
+}
+
+function findReferences(document: LoadedDocument, limits: LoadLimits, referenceCount: { value: number }): Omit<ReferenceResolution, "status" | "detail">[] {
+  const found: Omit<ReferenceResolution, "status" | "detail">[] = [];
+  const stack: Array<{ value: JsonValue; path: string }> = [{ value: document.value, path: "$" }];
+  while (stack.length) {
+    const { value, path } = stack.pop()!;
+    if (Array.isArray(value)) {
+      for (let index = value.length - 1; index >= 0; index--) stack.push({ value: value[index]!, path: childPath(path, index, limits.maxPathBytes) });
+      continue;
+    }
+    if (!object(value)) continue;
+    const schemaVersion = typeof value.schema_version === "number" || typeof value.schema_version === "string" || typeof value.schema_version === "bigint" ? value.schema_version : undefined;
+    if (typeof value.schema === "string" && schemaVersion !== undefined && typeof value.sha256 === "string" && /^[0-9a-f]{64}$/.test(value.sha256)) {
+      referenceCount.value++;
+      if (referenceCount.value > limits.maxReferences) throw new Error(`Contract reference count exceeds limit ${limits.maxReferences}`);
+      found.push({ documentId: document.id, path, schema: value.schema, schemaVersion, sha256: value.sha256, ...(typeof value.byte_count === "number" ? { expectedBytes: value.byte_count } : {}) });
+    }
+    for (const [key, child] of Object.entries(value)) stack.push({ value: child, path: childPath(path, key, limits.maxPathBytes) });
+  }
+  return found;
+}
+
+function resolveReferences(documents: LoadedDocument[], limits: LoadLimits): ReferenceResolution[] {
+  const referenceCount = { value: 0 };
+  const references = documents.flatMap(document => findReferences(document, limits, referenceCount));
+  return references.map(reference => {
+    const digest = documents.find(candidate => candidate.sha256 === reference.sha256);
+    if (digest) {
+      if (reference.expectedBytes !== undefined && digest.bytes !== reference.expectedBytes) return { ...reference, status: "byte_count_mismatch", resolvedDocumentId: digest.id, detail: `Digest matched ${basename(digest.path)}, but bytes ${digest.bytes} != expected ${reference.expectedBytes}` };
+      if (digest.schema !== reference.schema || String(digest.schemaVersion) !== String(reference.schemaVersion)) return { ...reference, status: "digest_mismatch", resolvedDocumentId: digest.id, detail: "Digest matched loaded bytes, but contract identity did not" };
+      return { ...reference, status: "resolved", resolvedDocumentId: digest.id, detail: `Matched exact loaded bytes in ${basename(digest.path)}` };
+    }
+    const identity = documents.find(candidate => candidate.schema === reference.schema && String(candidate.schemaVersion) === String(reference.schemaVersion));
+    if (identity) return { ...reference, status: "digest_mismatch", resolvedDocumentId: identity.id, detail: "Loaded contract identity has a different SHA-256" };
+    return { ...reference, status: "unresolved", detail: "No matching companion bytes were explicitly loaded" };
+  });
+}
+
+interface BufferedJsonInput {
+  path: string;
+  bytes: Buffer;
+  origin: DocumentOrigin;
+  operation?: string;
+}
+
+export interface InMemoryJsonInput {
+  path: string;
+  text: string;
+  origin: Exclude<DocumentOrigin, "file">;
+  operation: string;
+}
+
+function buildStore(inputs: BufferedJsonInput[], limits: LoadLimits): HealthStore {
+  if (inputs.length > limits.maxFiles) throw new Error(`JSON document count exceeds limit ${limits.maxFiles}`);
+  const documents: LoadedDocument[] = [];
+  const warnings: string[] = [];
+  let totalBytes = 0;
+  for (const input of inputs) {
+    if (input.bytes.byteLength > limits.maxFileBytes) throw new Error(`${input.path} exceeds per-document byte limit ${limits.maxFileBytes}`);
+    totalBytes += input.bytes.byteLength;
+    if (totalBytes > limits.maxTotalBytes) throw new Error(`Loaded JSON exceeds total byte limit ${limits.maxTotalBytes}`);
+    let value: JsonValue;
+    const text = input.bytes.toString("utf8");
+    try {
+      assertJsonDepth(text, limits.maxDepth);
+      value = parseJsonLossless(text);
+    } catch (error) {
+      if (error instanceof Error && /JSON depth exceeds/.test(error.message)) throw error;
+      warnings.push(`${basename(input.path)}: invalid JSON (${error instanceof Error ? error.message : String(error)})`);
+      continue;
+    }
+    const queryIdentity = object(value) && (value.schema === "healthmd.query_response" || value.schema === "healthmd.mcp_query_pages");
+    const classification = classifyContract(value, queryIdentity ? parseJsonNumberTokens(text) : undefined);
+    const contractErrors = classification.errors.map(error => error.slice(0, 512));
+    if (contractErrors.length) warnings.push(...contractErrors.slice(0, 20).map(error => `${basename(input.path)}: ${error}`));
+    documents.push({
+      id: `doc-${documents.length + 1}`, path: input.path, origin: input.origin,
+      ...(input.operation ? { operation: input.operation } : {}), bytes: input.bytes.byteLength,
+      sha256: createHash("sha256").update(input.bytes).digest("hex"), value,
+      contractKind: classification.kind, contractValid: classification.valid, contractErrors,
+      experimentalV9: classification.experimentalV9,
+      ...(classification.schema ? { schema: classification.schema } : {}),
+      ...(classification.schemaVersion !== undefined ? { schemaVersion: classification.schemaVersion } : {}),
+      ...(classification.profile ? { profile: classification.profile } : {}),
+      ...(classification.ownerDate ? { ownerDate: classification.ownerDate } : {}),
+      ...(classification.platform ? { platform: classification.platform } : {}),
+      ...(classification.captureStatus ? { captureStatus: classification.captureStatus } : {}),
+    });
+  }
+  const counters: IndexCounters = { leaves: 0, nodes: 0, pathBytes: 0 };
+  const entries = documents.flatMap(document => indexDocument(document, counters, limits));
+  return { documents, entries, references: resolveReferences(documents, limits), warnings: warnings.slice(0, 100), limits };
+}
+
+export function loadHealthDataText(inputs: InMemoryJsonInput[], overrides: Partial<LoadLimits> = {}): HealthStore {
+  if (inputs.length === 0) throw new Error("At least one fetched Health.md JSON document is required");
+  const limits = { ...DEFAULT_LIMITS, ...overrides };
+  return buildStore(inputs.map(input => ({ ...input, bytes: Buffer.from(input.text, "utf8") })), limits);
+}
+
+export async function loadHealthData(inputs: string[], overrides: Partial<LoadLimits> = {}, confinementRoots: readonly string[] = []): Promise<HealthStore> {
+  if (inputs.length === 0) throw new Error("At least one explicit local file or directory is required");
+  const limits = { ...DEFAULT_LIMITS, ...overrides };
+  const allFiles = new Set<string>();
+  const traversal = { entries: 0 };
+  for (const input of inputs) {
+    for (const file of await collectJsonFiles(input, limits, traversal, confinementRoots)) {
+      allFiles.add(file);
+      if (allFiles.size > limits.maxFiles) throw new Error(`JSON file count exceeds limit ${limits.maxFiles}`);
+    }
+  }
+  const buffered: BufferedJsonInput[] = [];
+  let totalBytes = 0;
+  for (const file of [...allFiles].sort()) {
+    const bytes = await readBoundedFile(file, limits.maxFileBytes, confinementRoots);
+    totalBytes += bytes.byteLength;
+    if (totalBytes > limits.maxTotalBytes) throw new Error(`Loaded JSON exceeds total byte limit ${limits.maxTotalBytes}`);
+    buffered.push({ path: file, bytes, origin: "file" });
+  }
+  return buildStore(buffered, limits);
+}
+
+export function storeSummary(store: HealthStore): string {
+  const proposed = store.documents.filter(document => document.experimentalV9).length;
+  const contracts = new Set(store.documents.map(document => `${document.contractKind}:${document.schema ?? "unknown"}@${document.schemaVersion ?? "?"}`));
+  const origins = new Set(store.documents.map(document => document.origin));
+  const refs = store.references.reduce<Record<string, number>>((counts, reference) => ({ ...counts, [reference.status]: (counts[reference.status] ?? 0) + 1 }), {});
+  return `${store.documents.length} documents; ${store.entries.length} indexed paths; origins ${[...origins].join(", ") || "none"}; contracts ${[...contracts].join(", ") || "none"}; valid proposed v9 readers ${proposed}; references ${jsonStringify(refs)}`;
+}

--- a/packages/pi-healthmd-dashboard/src/model.ts
+++ b/packages/pi-healthmd-dashboard/src/model.ts
@@ -1,0 +1,139 @@
+export type JsonScalar = string | number | bigint | boolean | null;
+export type JsonValue = JsonScalar | JsonValue[] | { [key: string]: JsonValue };
+
+export type ContractKind =
+  | "unified_v9" | "apple_health_data" | "android_frozen_v4" | "android_analytical_v5"
+  | "android_unversioned" | "healthkit_archive" | "android_raw_snapshot" | "android_raw_manifest"
+  | "android_merge_reference" | "android_raw_reference" | "whoop_typed_daily" | "external_provider_daily"
+  | "rollup" | "api_envelope" | "raw_envelope" | "query_response" | "mcp_query_pages"
+  | "generic_healthmd" | "generic_json";
+
+export type DocumentOrigin = "file" | "healthmd-cli" | "healthmd-mcp";
+
+export interface LoadedDocument {
+  id: string;
+  path: string;
+  origin: DocumentOrigin;
+  operation?: string;
+  bytes: number;
+  sha256: string;
+  schema?: string;
+  schemaVersion?: string | number | bigint;
+  profile?: string;
+  ownerDate?: string;
+  platform?: string;
+  captureStatus?: string;
+  contractKind: ContractKind;
+  contractValid: boolean;
+  contractErrors: string[];
+  experimentalV9: boolean;
+  value: JsonValue;
+}
+
+export interface IndexEntry {
+  documentId: string;
+  file: string;
+  path: string;
+  value: JsonValue;
+  kind: "scalar" | "object" | "array";
+  contractKind: ContractKind;
+  schema?: string;
+  schemaVersion?: string | number | bigint;
+  contractValid: boolean;
+  contractErrors: string[];
+  date?: string;
+  ownerDate?: string;
+  recordTimestamp?: string;
+  unit?: string;
+  statistic?: string;
+  semanticId?: string;
+  provenance?: JsonValue;
+  platform?: string;
+  provider?: string;
+  source?: string;
+  origin: DocumentOrigin;
+  operation?: string;
+  captureStatus?: string;
+}
+
+export interface ReferenceResolution {
+  documentId: string;
+  path: string;
+  schema: string;
+  schemaVersion: string | number | bigint;
+  sha256: string;
+  expectedBytes?: number;
+  status: "resolved" | "unresolved" | "digest_mismatch" | "byte_count_mismatch";
+  resolvedDocumentId?: string;
+  detail: string;
+}
+
+export interface HealthStore {
+  documents: LoadedDocument[];
+  entries: IndexEntry[];
+  references: ReferenceResolution[];
+  warnings: string[];
+  limits: LoadLimits;
+}
+
+export interface LoadLimits {
+  maxFiles: number;
+  maxDirectoryEntries: number;
+  maxFileBytes: number;
+  maxTotalBytes: number;
+  maxLeaves: number;
+  maxNodes: number;
+  maxDepth: number;
+  maxPathBytes: number;
+  maxIndexedPathBytes: number;
+  maxReferences: number;
+}
+
+export const DEFAULT_LIMITS: LoadLimits = {
+  maxFiles: 256,
+  maxDirectoryEntries: 100_000,
+  maxFileBytes: 32 * 1024 * 1024,
+  maxTotalBytes: 128 * 1024 * 1024,
+  maxLeaves: 500_000,
+  maxNodes: 1_000_000,
+  maxDepth: 256,
+  maxPathBytes: 4_096,
+  maxIndexedPathBytes: 64 * 1024 * 1024,
+  maxReferences: 10_000,
+};
+
+export interface QueryOptions {
+  path?: string;
+  search?: string;
+  metric?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface QueryResult {
+  matches: IndexEntry[];
+  totalMatches: number;
+  truncated: boolean;
+  evidenceChars: number;
+  evidenceBytes: number;
+}
+
+export type ViewMode = "chart" | "table";
+export interface ViewState {
+  visible: boolean;
+  target?: string;
+  targetKind: "metric" | "path" | "search";
+  mode: ViewMode;
+  startDate?: string;
+  endDate?: string;
+  offset: number;
+  windowSize: number;
+}
+
+export const initialView = (): ViewState => ({
+  visible: true,
+  targetKind: "metric",
+  mode: "table",
+  offset: 0,
+  windowSize: 30,
+});

--- a/packages/pi-healthmd-dashboard/src/query-contract.ts
+++ b/packages/pi-healthmd-dashboard/src/query-contract.ts
@@ -1,0 +1,199 @@
+import { JsonNumberToken } from "./json.js";
+import type { JsonValue } from "./model.js";
+
+type JsonObject = { [key: string]: JsonValue };
+const object = (value: JsonValue | undefined): value is JsonObject => value !== null && typeof value === "object" && !Array.isArray(value);
+const keys = (value: JsonValue | undefined, allowed: readonly string[], required: readonly string[] = allowed): JsonObject | undefined => {
+  if (!object(value) || Object.keys(value).some(key => !allowed.includes(key)) || required.some(key => !(key in value))) return undefined;
+  return value;
+};
+const string = (value: JsonValue | undefined): value is string => typeof value === "string";
+const nonempty = (value: JsonValue | undefined): value is string => string(value) && value.length > 0;
+const I64_MIN = -(1n << 63n), I64_MAX = (1n << 63n) - 1n, U64_MAX = (1n << 64n) - 1n;
+const finite = (value: JsonValue | undefined): boolean => typeof value === "number" && Number.isFinite(value) || typeof value === "bigint" && value >= I64_MIN && value <= U64_MAX;
+const integerValue = (value: JsonValue | undefined): bigint | undefined => typeof value === "bigint" ? value : typeof value === "number" && Number.isSafeInteger(value) ? BigInt(value) : undefined;
+const integer = (value: JsonValue | undefined): boolean => { const integer = integerValue(value); return integer !== undefined && integer >= I64_MIN && integer <= I64_MAX; };
+const unsigned = (value: JsonValue | undefined): boolean => { const integer = integerValue(value); return integer !== undefined && integer >= 0n && integer <= U64_MAX; };
+const integerEquals = (value: JsonValue | undefined, expected: number): boolean => integerValue(value) === BigInt(expected);
+const array = (value: JsonValue | undefined, validator: (item: JsonValue) => boolean, maximum?: number): value is JsonValue[] => Array.isArray(value) && (maximum === undefined || value.length <= maximum) && value.every(validator);
+const strings = (value: JsonValue | undefined): value is string[] => array(value, nonempty);
+const absentOr = (value: JsonValue | undefined, validator: (item: JsonValue) => boolean): boolean => value === undefined || validator(value);
+const nullableOr = (value: JsonValue | undefined, validator: (item: JsonValue) => boolean): boolean => value === undefined || value === null || validator(value);
+const nullableString = (value: JsonValue | undefined): boolean => value === undefined || value === null || string(value);
+
+const STATUSES = new Set(["available", "complete_empty", "partial", "failed", "unsupported", "skipped", "cancelled", "not_requested", "legacy_unavailable", "redacted", "not_synchronized"]);
+const status = (value: JsonValue | undefined): boolean => string(value) && STATUSES.has(value);
+const dateRange = (value: JsonValue): boolean => {
+  const item = keys(value, ["start_date", "end_date"]);
+  return Boolean(item && nonempty(item.start_date) && nonempty(item.end_date));
+};
+const source = (value: JsonValue): boolean => {
+  const item = keys(value, ["schema", "schema_version", "digest"]);
+  return Boolean(item && nonempty(item.schema) && unsigned(item.schema_version) && string(item.digest) && /^[0-9a-fA-F]{64}$/.test(item.digest));
+};
+const limitation = (value: JsonValue): boolean => {
+  const item = keys(value, ["code", "message"]);
+  return Boolean(item && nonempty(item.code) && item.code.length <= 128 && nonempty(item.message) && item.message.length <= 512);
+};
+const locator = (value: JsonValue): boolean => {
+  if (!object(value) || !string(value.type)) return false;
+  const detail = value.type === "summary_key" ? "key" : value.type === "canonical_uuid" ? "uuid" : ["external_identity", "query_manifest", "partial_failure"].includes(value.type) ? "identifier" : value.type === "warning" ? "code" : undefined;
+  if (!detail) return false;
+  const item = keys(value, ["type", "owner_date", detail]);
+  return Boolean(item && nonempty(item.owner_date) && nonempty(item[detail]));
+};
+const evidenceReference = (value: JsonValue): boolean => {
+  const item = keys(value, ["evidence_id", "locator", "source", "source_id", "provider_id"], ["evidence_id", "locator", "source", "source_id"]);
+  return Boolean(item && nonempty(item.evidence_id) && nonempty(item.source_id) && absentOr(item.provider_id, nonempty) && item.locator !== undefined && locator(item.locator) && item.source !== undefined && source(item.source));
+};
+const missingInterval = (value: JsonValue): boolean => {
+  const item = keys(value, ["range", "status", "reason"], ["range", "status"]);
+  return Boolean(item && item.range !== undefined && dateRange(item.range) && status(item.status) && absentOr(item.reason, string));
+};
+const coverage = (value: JsonValue | undefined): boolean => {
+  const item = keys(value, ["requested_range", "available_range", "status", "days_considered", "days_with_values", "missing", "missing_interval_count", "missing_truncated"], ["status", "days_considered", "days_with_values", "missing"]);
+  const daysConsidered = item && integerValue(item.days_considered), daysWithValues = item && integerValue(item.days_with_values);
+  if (!item || !status(item.status) || !unsigned(item.days_considered) || !unsigned(item.days_with_values) || daysConsidered === undefined || daysWithValues === undefined || daysWithValues > daysConsidered) return false;
+  return array(item.missing, missingInterval, 64) && nullableOr(item.requested_range, dateRange) && nullableOr(item.available_range, dateRange) && absentOr(item.missing_interval_count, unsigned) && (item.missing_truncated === undefined || typeof item.missing_truncated === "boolean");
+};
+
+function queryValue(value: JsonValue, depth = 0): boolean {
+  if (depth > 64 || !object(value) || !nonempty(value.type)) return false;
+  let valid = false;
+  if (value.type === "quantity") valid = finite(value.value) && nonempty(value.unit);
+  else if (value.type === "duration") valid = finite(value.seconds);
+  else if (value.type === "count") valid = integer(value.value);
+  else if (["string", "timestamp", "date"].includes(value.type)) valid = string(value.value);
+  else if (value.type === "boolean") valid = typeof value.value === "boolean";
+  else if (value.type === "category") valid = nonempty(value.identifier) && absentOr(value.display, string) && absentOr(value.raw_value, integer);
+  else if (value.type === "array") valid = array(value.value, item => queryValue(item, depth + 1));
+  else valid = true;
+  if (!valid) return false;
+  const allowed = value.type === "quantity" ? ["type", "value", "unit"] : value.type === "duration" ? ["type", "seconds"] : value.type === "category" ? ["type", "identifier", "display", "raw_value"] : ["type", "value"];
+  return Object.keys(value).every(key => allowed.includes(key));
+}
+
+const metricItem = (value: JsonValue): boolean => {
+  const allowed = ["metric_id", "display_name", "owner_date", "value", "status", "evidence", "limitations"];
+  const item = keys(value, allowed, ["metric_id", "display_name", "owner_date", "status", "evidence", "limitations"]);
+  return Boolean(item && nonempty(item.metric_id) && nonempty(item.display_name) && nonempty(item.owner_date) && status(item.status) && nullableOr(item.value, queryValue) && array(item.evidence, evidenceReference) && array(item.limitations, limitation, 64));
+};
+const aggregation = (value: JsonValue): boolean => {
+  const item = keys(value, ["metric_id", "kind", "expected_unit"], ["metric_id", "kind"]);
+  return Boolean(item && nonempty(item.metric_id) && string(item.kind) && ["sum", "average", "minimum", "maximum", "latest", "count", "duration_sum"].includes(item.kind) && absentOr(item.expected_unit, string));
+};
+const comparisonItem = (value: JsonValue): boolean => {
+  const item = keys(value, ["metric_id", "aggregation", "first_range", "second_range", "first_value", "second_value", "absolute_change", "percent_change", "direction", "coverage", "evidence", "limitations"], ["metric_id", "aggregation", "first_range", "second_range", "direction", "coverage", "evidence", "limitations"]);
+  return Boolean(item && nonempty(item.metric_id) && item.aggregation !== undefined && aggregation(item.aggregation) && item.first_range !== undefined && dateRange(item.first_range) && item.second_range !== undefined && dateRange(item.second_range) && string(item.direction) && ["increased", "decreased", "unchanged", "not_comparable"].includes(item.direction) && coverage(item.coverage) && nullableOr(item.first_value, queryValue) && nullableOr(item.second_value, queryValue) && nullableOr(item.absolute_change, queryValue) && nullableOr(item.percent_change, finite) && array(item.evidence, evidenceReference) && array(item.limitations, limitation, 64));
+};
+const workout = (value: JsonValue): boolean => {
+  const allowed = ["workout_id", "activity", "start", "end", "details", "evidence_ids"];
+  const item = keys(value, allowed);
+  return Boolean(item && nonempty(item.workout_id) && nonempty(item.activity) && nonempty(item.start) && nonempty(item.end) && object(item.details) && Object.values(item.details).every(detail => queryValue(detail)) && strings(item.evidence_ids));
+};
+const sleepPhysiology = (value: JsonValue): boolean => {
+  const item = keys(value, ["metric_id", "status", "sample_count", "first_sample_at", "last_sample_at", "observed_owner_dates", "evidence"], ["metric_id", "status", "sample_count", "observed_owner_dates", "evidence"]);
+  return Boolean(item && nonempty(item.metric_id) && status(item.status) && unsigned(item.sample_count) && nullableString(item.first_sample_at) && nullableString(item.last_sample_at) && strings(item.observed_owner_dates) && array(item.evidence, evidenceReference));
+};
+const sleepWindow = (value: JsonValue): boolean => {
+  const item = keys(value, ["start_offset_seconds", "duration_seconds"], ["duration_seconds"]);
+  return Boolean(item && absentOr(item.start_offset_seconds, finite) && finite(item.duration_seconds));
+};
+const sleepSession = (value: JsonValue): boolean => {
+  const allowed = ["session_id", "owner_date", "calendar_dates", "classification", "completeness", "start", "end", "local_start", "local_end", "calendar_timezone", "analysis_start", "analysis_end", "requested_window", "elapsed_duration_seconds", "observed_duration_seconds", "untracked_duration_seconds", "asleep_duration_seconds", "awake_duration_seconds", "stage_durations_seconds", "physiology", "evidence", "limitations"];
+  const item = keys(value, allowed, allowed.filter(key => key !== "requested_window"));
+  if (!item || !["session_id", "owner_date", "start", "end", "local_start", "local_end", "calendar_timezone", "analysis_start", "analysis_end"].every(key => nonempty(item[key]))) return false;
+  if (!string(item.classification) || !["overnight", "nap", "sleep"].includes(item.classification) || !string(item.completeness) || !["complete", "partial", "truncated_at_start", "truncated_at_end", "truncated_at_both", "aggregated", "outside_session"].includes(item.completeness)) return false;
+  if (!strings(item.calendar_dates) || !["elapsed_duration_seconds", "observed_duration_seconds", "untracked_duration_seconds", "asleep_duration_seconds", "awake_duration_seconds"].every(key => finite(item[key]))) return false;
+  return object(item.stage_durations_seconds) && Object.values(item.stage_durations_seconds).every(finite) && nullableOr(item.requested_window, sleepWindow) && array(item.physiology, sleepPhysiology) && array(item.evidence, evidenceReference) && array(item.limitations, limitation, 64);
+};
+const alignmentItem = (value: JsonValue): boolean => {
+  const item = keys(value, ["alignment_id", "workout", "preceding_sleep", "following_sleep", "seconds_from_preceding_sleep", "seconds_until_following_sleep", "physiology_sample_count", "status", "evidence", "limitations"], ["alignment_id", "workout", "physiology_sample_count", "status", "evidence", "limitations"]);
+  return Boolean(item && nonempty(item.alignment_id) && item.workout !== undefined && workout(item.workout) && unsigned(item.physiology_sample_count) && string(item.status) && ["complete", "partial", "unavailable"].includes(item.status) && nullableOr(item.preceding_sleep, sleepSession) && nullableOr(item.following_sleep, sleepSession) && nullableOr(item.seconds_from_preceding_sleep, finite) && nullableOr(item.seconds_until_following_sleep, finite) && array(item.evidence, evidenceReference) && array(item.limitations, limitation, 64));
+};
+const contextEvidence = (value: JsonValue): boolean => {
+  const item = keys(value, ["reference", "value", "note", "metric_ids"], ["reference", "metric_ids"]);
+  return Boolean(item && item.reference !== undefined && evidenceReference(item.reference) && strings(item.metric_ids) && nullableOr(item.value, queryValue) && absentOr(item.note, string));
+};
+const queryItem = (value: JsonValue): boolean => {
+  if (!object(value) || !string(value.type)) return false;
+  const validator = value.type === "metric" ? metricItem : value.type === "comparison" ? comparisonItem : value.type === "workout" ? workout : value.type === "sleep_session" ? sleepSession : value.type === "workout_sleep_alignment" ? alignmentItem : value.type === "evidence" ? contextEvidence : undefined;
+  return Boolean(validator && Object.keys(value).length === 2 && value[value.type] !== undefined && validator(value[value.type]!));
+};
+const packetMetadata = (value: JsonValue): boolean => {
+  const item = keys(value, ["generated_at", "producer"]);
+  return Boolean(item && nonempty(item.generated_at) && nonempty(item.producer));
+};
+const packetFact = (value: JsonValue): boolean => {
+  const item = keys(value, ["fact_id", "label", "owner_date", "value", "evidence"], ["fact_id", "label", "value", "evidence"]);
+  return Boolean(item && nonempty(item.fact_id) && nonempty(item.label) && absentOr(item.owner_date, string) && item.value !== undefined && queryValue(item.value) && array(item.evidence, evidenceReference));
+};
+function packetFactCount(value: JsonValue, itemsEmpty: boolean): number | undefined {
+  const item = keys(value, ["schema", "schema_version", "packet_id", "kind", "range", "facts", "coverage", "sources", "limitations", "metadata"]);
+  if (!itemsEmpty || !item || item.schema !== "healthmd.evidence_packet" || item.schema_version !== 1 || !nonempty(item.packet_id) || !string(item.kind) || !["daily_wellness", "training", "doctor_visit"].includes(item.kind)) return undefined;
+  if (!nullableOr(item.range, dateRange) || !coverage(item.coverage) || !array(item.sources, source, 64) || !array(item.limitations, limitation, 64) || item.metadata === undefined || !packetMetadata(item.metadata) || !array(item.facts, packetFact)) return undefined;
+  return item.facts.length;
+}
+
+function validatePage(value: JsonValue, label: string, maximumItems: number): string[] {
+  const allowed = ["schema", "schema_version", "items", "packet", "coverage", "sources", "evidence", "next_cursor", "limitations", "metadata"];
+  const item = keys(value, allowed, ["schema", "schema_version", "items", "coverage", "sources", "evidence", "limitations"]);
+  if (!item || item.schema !== "healthmd.query_response" || item.schema_version !== 1) return [`${label} must be a structurally canonical healthmd.query_response/1`];
+  if (!array(item.items, queryItem) || !coverage(item.coverage) || !array(item.sources, source, 64) || !array(item.evidence, evidenceReference) || !array(item.limitations, limitation, 64) || !nullableString(item.next_cursor) || !nullableOr(item.metadata, object)) return [`${label} has invalid canonical fields`];
+  const facts = item.packet === undefined || item.packet === null ? 0 : packetFactCount(item.packet, item.items.length === 0);
+  if (facts === undefined || item.items.length + facts > maximumItems) return [`${label} exceeds canonical item bounds or contains an invalid evidence packet`];
+  return [];
+}
+
+const UNSIGNED_INTEGER_FIELDS = new Set(["schema_version", "days_considered", "days_with_values", "missing_interval_count", "sample_count", "physiology_sample_count", "page_count", "item_count", "packet_fact_count"]);
+function validateIntegerTokens(value: unknown): string[] {
+  const errors: string[] = [];
+  const stack: Array<{ value: unknown; parent?: Record<string, unknown>; key?: string }> = [{ value }];
+  while (stack.length) {
+    const item = stack.pop()!;
+    if (item.value instanceof JsonNumberToken) {
+      const integerField = item.key && (UNSIGNED_INTEGER_FIELDS.has(item.key) || item.key === "raw_value" || item.key === "value" && item.parent?.type === "count");
+      if (!integerField) continue;
+      if (!/^-?(?:0|[1-9]\d*)$/.test(item.value.token)) { errors.push(`Canonical integer field ${item.key} used a non-integer JSON token`); continue; }
+      const integer = BigInt(item.value.token);
+      const unsignedField = item.key !== "raw_value" && !(item.key === "value" && item.parent?.type === "count");
+      if (unsignedField ? integer < 0n || integer > U64_MAX : integer < I64_MIN || integer > I64_MAX) errors.push(`Canonical integer field ${item.key} is out of range`);
+      continue;
+    }
+    if (Array.isArray(item.value)) {
+      for (const child of item.value) stack.push({ value: child });
+    } else if (item.value !== null && typeof item.value === "object") {
+      const parent = item.value as Record<string, unknown>;
+      for (const [key, child] of Object.entries(parent)) stack.push({ value: child, parent, key });
+    }
+  }
+  return [...new Set(errors)].slice(0, 100);
+}
+
+/** Validate the canonical typed query receipts returned by both Health.md CLI and MCP adapters. */
+export function validateQueryContract(value: JsonValue, maximumItems = 1_000, exactTokens?: unknown, initialCursor?: string): string[] {
+  if (!Number.isSafeInteger(maximumItems) || maximumItems < 1 || maximumItems > 1_000) return ["Health.md query item bound is invalid"];
+  const tokenErrors = exactTokens === undefined ? [] : validateIntegerTokens(exactTokens);
+  if (!object(value)) return [...tokenErrors, "Health.md typed query returned a non-object JSON result"];
+  if (value.schema === "healthmd.query_response") return [...new Set([...tokenErrors, ...validatePage(value, "Health.md query response", maximumItems)])].slice(0, 100);
+  const top = keys(value, ["schema", "schema_version", "pages", "receipt"]);
+  if (!top || top.schema !== "healthmd.mcp_query_pages" || top.schema_version !== 1 || !Array.isArray(top.pages) || top.pages.length === 0 || top.pages.length > 4_096 || !object(top.receipt)) return [...tokenErrors, "Health.md typed query did not return a canonical healthmd.query_response/1 or healthmd.mcp_query_pages/1"];
+  const errors = [...tokenErrors, ...top.pages.flatMap((page, index) => validatePage(page, `Health.md query page ${index + 1}`, maximumItems))];
+  const receipt = keys(top.receipt, ["page_count", "item_count", "packet_fact_count", "traversal_complete", "next_cursor", "limit_reason"]);
+  const itemCount = top.pages.reduce<number>((count, page) => count + (object(page) && Array.isArray(page.items) ? page.items.length : 0), 0);
+  const factCount = top.pages.reduce<number>((count, page) => {
+    if (!object(page) || !Array.isArray(page.items) || page.packet === undefined || page.packet === null) return count;
+    return count + (packetFactCount(page.packet, page.items.length === 0) ?? 0);
+  }, 0);
+  if (!receipt || !integerEquals(receipt.page_count, top.pages.length) || !integerEquals(receipt.item_count, itemCount) || !integerEquals(receipt.packet_fact_count, factCount) || typeof receipt.traversal_complete !== "boolean" || !nullableString(receipt.next_cursor) || !nullableString(receipt.limit_reason)) errors.push("Health.md multipage receipt is inconsistent");
+  else {
+    const cursors = top.pages.map(page => object(page) ? page.next_cursor : undefined);
+    const intermediate = cursors.slice(0, -1), returnedCursors = cursors.filter(nonempty);
+    if (intermediate.some(cursor => !nonempty(cursor)) || new Set(returnedCursors).size !== returnedCursors.length || initialCursor !== undefined && returnedCursors.includes(initialCursor)) errors.push("Health.md multipage cursor chain is invalid");
+    const lastCursor = cursors.at(-1);
+    if (receipt.traversal_complete) {
+      if (receipt.next_cursor !== null || receipt.limit_reason !== null || !(lastCursor === null || lastCursor === undefined)) errors.push("Health.md completed traversal receipt is inconsistent");
+    } else if (!nonempty(receipt.next_cursor) || !string(receipt.limit_reason) || !["maximum_pages", "maximum_aggregate_bytes"].includes(receipt.limit_reason) || receipt.limit_reason === "maximum_pages" && top.pages.length !== 4_096 || lastCursor !== receipt.next_cursor) errors.push("Health.md limited traversal receipt is inconsistent");
+  }
+  return [...new Set(errors)].slice(0, 100);
+}

--- a/packages/pi-healthmd-dashboard/src/query.ts
+++ b/packages/pi-healthmd-dashboard/src/query.ts
@@ -1,0 +1,76 @@
+import { displayValue } from "./exact.js";
+import { boundedJson, jsonStringify, truncateUtf8, utf8ByteLength } from "./json.js";
+import type { HealthStore, IndexEntry, JsonValue, QueryOptions, QueryResult } from "./model.js";
+
+const MAX_RESULTS = 100;
+export const MAX_EVIDENCE_BYTES = 24_000;
+/** @deprecated Use MAX_EVIDENCE_BYTES; retained for API compatibility. */
+export const MAX_EVIDENCE_CHARS = MAX_EVIDENCE_BYTES;
+const MAX_VALUE_BYTES = 2_000;
+const MAX_PROVENANCE_BYTES = 2_000;
+
+function searchable(entry: IndexEntry): string {
+  const scalarValue = entry.kind === "scalar" ? displayValue(entry.value, 512) : "";
+  return [entry.path, entry.documentId, entry.file, entry.date, entry.ownerDate, entry.recordTimestamp, entry.unit, entry.statistic, entry.semanticId, entry.platform, entry.provider, entry.source, entry.origin, entry.operation, entry.contractKind, entry.schema, entry.schemaVersion, scalarValue].filter(value => value !== undefined && value !== null && value !== "").join(" ").toLowerCase();
+}
+
+export function matchingEntries(store: HealthStore, options: QueryOptions): IndexEntry[] {
+  const needle = options.search?.toLowerCase();
+  return store.entries.filter(entry => {
+    if (options.path && !entry.path.toLowerCase().includes(options.path.toLowerCase())) return false;
+    if (needle && !searchable(entry).includes(needle)) return false;
+    if (options.metric && entry.semanticId !== options.metric) return false;
+    return true;
+  });
+}
+
+export function queryStore(store: HealthStore, options: QueryOptions): QueryResult {
+  const requestedLimit = Math.max(1, Math.min(options.limit ?? 25, MAX_RESULTS));
+  const offset = Math.max(0, options.offset ?? 0);
+  const candidates = matchingEntries(store, options);
+  const matches = candidates.slice(offset, offset + requestedLimit);
+  return { matches, totalMatches: candidates.length, truncated: offset + matches.length < candidates.length, evidenceChars: 0, evidenceBytes: 0 };
+}
+
+function boundedText(text: string, maximum: number): string {
+  return truncateUtf8(text.replace(/[\r\n\t]/g, " "), maximum, "…[value omitted]");
+}
+function boundedValue(entry: IndexEntry): string { return boundedText(displayValue(entry.value, MAX_VALUE_BYTES), MAX_VALUE_BYTES); }
+function boundedProvenance(value: JsonValue): string { return boundedJson(value, MAX_PROVENANCE_BYTES); }
+
+function evidenceRow(entry: IndexEntry): object {
+  return {
+    document: entry.documentId, file: entry.file, path: entry.path, value: boundedValue(entry), kind: entry.kind,
+    contractKind: entry.contractKind, ...(entry.schema ? { schema: entry.schema } : {}), ...(entry.schemaVersion !== undefined ? { schemaVersion: String(entry.schemaVersion) } : {}), contractValid: entry.contractValid,
+    ...(entry.contractErrors.length ? { contractErrors: entry.contractErrors.slice(0, 5) } : {}),
+    ...(entry.date ? { date: entry.date } : {}), ...(entry.ownerDate ? { ownerDate: entry.ownerDate } : {}),
+    ...(entry.recordTimestamp ? { recordTimestamp: entry.recordTimestamp } : {}), ...(entry.unit ? { unit: entry.unit } : {}),
+    ...(entry.statistic ? { statistic: entry.statistic } : {}), ...(entry.semanticId ? { semanticId: entry.semanticId } : {}),
+    ...(entry.platform ? { platform: entry.platform } : {}), ...(entry.provider ? { provider: entry.provider } : {}),
+    ...(entry.source ? { source: entry.source } : {}), origin: entry.origin, ...(entry.operation ? { operation: entry.operation } : {}),
+    ...(entry.captureStatus ? { captureStatus: entry.captureStatus } : {}), ...(entry.provenance ? { provenance: boundedProvenance(entry.provenance) } : {}),
+  };
+}
+
+export function formatEvidence(result: QueryResult): object {
+  const evidence: object[] = [];
+  let omittedForSize = 0;
+  for (const entry of result.matches) {
+    let row = evidenceRow(entry);
+    let candidate = { totalMatches: result.totalMatches, returned: evidence.length + 1, truncated: true, omittedForSize, evidence: [...evidence, row] };
+    if (utf8ByteLength(jsonStringify(candidate)) > MAX_EVIDENCE_BYTES) {
+      if (evidence.length === 0) {
+        row = { document: entry.documentId, path: boundedText(entry.path, 512), value: "[value omitted: evidence row exceeded output bound]", contractKind: entry.contractKind, contractValid: entry.contractValid };
+        candidate = { ...candidate, evidence: [row] };
+        if (utf8ByteLength(jsonStringify(candidate)) <= MAX_EVIDENCE_BYTES) evidence.push(row);
+      }
+      omittedForSize = result.matches.length - evidence.length;
+      break;
+    }
+    evidence.push(row);
+  }
+  const output = { totalMatches: result.totalMatches, returned: evidence.length, truncated: result.truncated || omittedForSize > 0, omittedForSize, evidence };
+  result.evidenceChars = jsonStringify(output).length;
+  result.evidenceBytes = utf8ByteLength(jsonStringify(output));
+  return output;
+}

--- a/packages/pi-healthmd-dashboard/src/render.ts
+++ b/packages/pi-healthmd-dashboard/src/render.ts
@@ -1,0 +1,92 @@
+import stringWidth from "string-width";
+import { displayValue, numericValue } from "./exact.js";
+import type { HealthStore, IndexEntry, ViewState } from "./model.js";
+import { matchingEntries } from "./query.js";
+
+export function visibleWidth(text: string): number { return stringWidth(text); }
+export function truncateWidth(text: string, width: number): string {
+  if (width <= 0) return "";
+  if (visibleWidth(text) <= width) return text;
+  if (width === 1) return "…";
+  let output = "";
+  for (const character of text) { if (visibleWidth(output + character) > width - 1) break; output += character; }
+  return `${output}…`;
+}
+function padWidth(text: string, width: number): string { const truncated = truncateWidth(text, width); return `${truncated}${" ".repeat(Math.max(0, width - visibleWidth(truncated)))}`; }
+function fit(lines: string[], width: number): string[] { return lines.map(line => truncateWidth(line.replace(/[\r\n\t]/g, " "), Math.max(0, width))); }
+
+export function selectedEntries(store: HealthStore, view: ViewState): IndexEntry[] {
+  const candidates = !view.target ? store.entries.filter(entry => entry.semanticId && isNumericCandidate(entry) && (entry.path.endsWith(".number") || /\.value\.(?:value|seconds)$/.test(entry.path))) : matchingEntries(store, {
+    ...(view.targetKind === "metric" ? { metric: view.target } : {}), ...(view.targetKind === "path" ? { path: view.target } : {}), ...(view.targetKind === "search" ? { search: view.target } : {}),
+  });
+  const filtered = candidates.filter(entry => {
+    const filterDate = entry.ownerDate ?? entry.date;
+    return (!view.startDate || !filterDate || filterDate >= view.startDate) && (!view.endDate || !filterDate || filterDate <= view.endDate);
+  });
+  filtered.sort((a, b) => (a.date ?? "").localeCompare(b.date ?? "") || a.documentId.localeCompare(b.documentId) || a.path.localeCompare(b.path));
+  const maxOffset = Math.max(0, filtered.length - view.windowSize);
+  const start = Math.max(0, Math.min(view.offset, maxOffset));
+  return filtered.slice(start, start + view.windowSize);
+}
+
+function table(entries: IndexEntry[], width: number): string[] {
+  if (entries.length === 0) return ["No matching loaded evidence."];
+  if (width < 16) return entries.map(entry => truncateWidth(displayValue(entry.value), width));
+  const dateWidth = Math.min(20, Math.max(6, Math.floor(width * 0.22)));
+  const valueWidth = Math.min(28, Math.max(5, Math.floor(width * 0.25)));
+  const pathWidth = Math.max(1, width - dateWidth - valueWidth - 6);
+  return [`${padWidth("DATE", dateWidth)} | ${padWidth("PATH", pathWidth)} | VALUE`, ...entries.map(entry => `${padWidth(entry.date ?? "—", dateWidth)} | ${padWidth(entry.path, pathWidth)} | ${truncateWidth(displayValue(entry.value), valueWidth)}`)];
+}
+
+function seriesIdentity(entry: IndexEntry): string {
+  const pathIdentity = entry.semanticId ?? entry.path.replace(/\[\d+\]/g, "[]");
+  return [pathIdentity, entry.contractKind, entry.schema ?? "", String(entry.schemaVersion ?? ""), entry.unit ?? "", entry.statistic ?? "", entry.provider ?? "", entry.platform ?? "", entry.source ?? "", entry.origin].join("\0");
+}
+function isNumericCandidate(entry: IndexEntry): boolean {
+  if (typeof entry.value === "number" || typeof entry.value === "bigint") return true;
+  return entry.value !== null && typeof entry.value === "object" && !Array.isArray(entry.value) && ["binary64", "signed_integer", "unsigned_integer"].includes(String(entry.value.representation));
+}
+function chart(entries: IndexEntry[], width: number, structuredTarget: boolean): { lines?: string[]; reason?: string } {
+  if (structuredTarget && entries.some(entry => entry.kind !== "scalar")) return { reason: "structured values" };
+  const candidates = entries.filter(entry => {
+    if (!isNumericCandidate(entry) || /(?:^|\.|\[)(?:evidence|provenance|sources|coverage|limitations)(?:\.|\[|$)/.test(entry.path)) return false;
+    return entry.origin === "file" || !entry.semanticId || /\.metric\.value\.(?:value|seconds)$/.test(entry.path);
+  });
+  if (candidates.length === 0) return { reason: "non-numeric/unsafe exact values" };
+  const decoded = candidates.map(entry => ({ entry, value: numericValue(entry.value) }));
+  if (decoded.some(point => point.value === undefined)) return { reason: "non-numeric/unsafe exact values" };
+  const points = decoded as Array<{ entry: IndexEntry; value: number }>;
+  if (new Set(points.map(point => seriesIdentity(point.entry))).size > 1) return { reason: "mixed contract/schema/path/unit/statistic/provider/platform/source/origin series" };
+  const values = points.map(point => point.value);
+  const minimum = Math.min(...values), maximum = Math.max(...values);
+  const scale = Math.max(1, Math.abs(minimum), Math.abs(maximum));
+  const scaledMinimum = minimum / scale, scaledMaximum = maximum / scale;
+  const barWidth = Math.max(1, Math.min(40, width - 14));
+  return { lines: points.map(point => {
+    const ratio = maximum === minimum ? 1 : (point.value / scale - scaledMinimum) / (scaledMaximum - scaledMinimum);
+    const bars = Math.max(1, Math.round(Math.max(0, Math.min(1, ratio)) * barWidth));
+    const labelWidth = Math.max(1, Math.min(18, width - barWidth - 2));
+    const shown = Object.is(point.value, -0) ? "-0" : String(point.value);
+    return `${padWidth(point.entry.date ?? point.entry.documentId, labelWidth)} ${"█".repeat(bars)} ${shown}${point.entry.unit ? ` ${point.entry.unit}` : ""}`;
+  }) };
+}
+
+export function renderDashboard(store: HealthStore | undefined, view: ViewState, width: number): string[] {
+  if (!view.visible || width <= 0) return [];
+  if (!store) return fit(["Health.md — no data", "/healthmd load <path>"], width);
+  const entries = selectedEntries(store, view);
+  const chartResult = view.mode === "chart" ? chart(entries, width, view.targetKind === "path") : {};
+  const dates = store.entries.map(entry => entry.ownerDate ?? entry.date).filter((date): date is string => Boolean(date)).sort();
+  const sources = [...new Set(store.documents.map(document => [document.origin, document.operation, document.platform, document.contractKind].filter(Boolean).join("/")))];
+  const refs = store.references.reduce<Record<string, number>>((acc, ref) => ({ ...acc, [ref.status]: (acc[ref.status] ?? 0) + 1 }), {});
+  const lines = [
+    store.documents.some(document => document.experimentalV9) ? "EXPERIMENTAL proposed v9 reader — Health.md" : "Health.md dashboard",
+    `${view.targetKind}:${view.target ?? "overview"} • ${view.mode} • ${entries.length} shown`,
+    `Coverage: ${store.documents.length} files • ${dates[0] ?? "—"}..${dates.at(-1) ?? "—"}`,
+    `Source: ${sources.join(",") || "unknown"} • capture ${[...new Set(store.documents.map(d => d.captureStatus).filter(Boolean))].join(",") || "unknown"}`,
+    `References ${Object.entries(refs).map(([key, count]) => `${key}:${count}`).join(",") || "none"}`,
+    ...(view.mode === "chart" && chartResult.reason ? [`Chart split/refused: ${chartResult.reason}; table fallback.`] : []),
+    ...(chartResult.lines ?? table(entries, width)),
+  ];
+  return fit(lines.slice(0, 10), width);
+}

--- a/packages/pi-healthmd-dashboard/src/schemas.ts
+++ b/packages/pi-healthmd-dashboard/src/schemas.ts
@@ -1,0 +1,48 @@
+import { Ajv2020, type ErrorObject, type ValidateFunction } from "ajv/dist/2020.js";
+import providerSectionsSchema from "../schemas/provider-sections-v1.schema.json" with { type: "json" };
+import unifiedV9Schema from "../schemas/unified-health-data-v9.schema.json" with { type: "json" };
+import type { JsonValue } from "./model.js";
+
+function validDateParts(year: number, month: number, day: number): boolean {
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return year >= 1 && month >= 1 && month <= 12 && day >= 1 && day <= days[month - 1]!;
+}
+
+const ajv = new Ajv2020({ allErrors: true, strict: false, validateFormats: true });
+ajv.addFormat("date", {
+  type: "string",
+  validate(value: string) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    return Boolean(match && validDateParts(Number(match[1]), Number(match[2]), Number(match[3])));
+  },
+});
+ajv.addFormat("date-time", {
+  type: "string",
+  validate(value: string) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d+)?Z$/.exec(value);
+    return Boolean(match && validDateParts(Number(match[1]), Number(match[2]), Number(match[3])) && Number(match[4]) <= 23 && Number(match[5]) <= 59 && Number(match[6]) <= 59);
+  },
+});
+
+const validateUnifiedV9 = ajv.compile(unifiedV9Schema) as ValidateFunction<JsonValue>;
+const validateProviderSections = ajv.compile(providerSectionsSchema) as ValidateFunction<JsonValue>;
+
+function describe(error: ErrorObject): string {
+  const path = error.instancePath || "$";
+  if (error.keyword === "required") return `${path}: missing required property ${String(error.params.missingProperty)}`;
+  if (error.keyword === "additionalProperties") return `${path}: unknown property ${String(error.params.additionalProperty)}`;
+  return `${path}: ${error.message ?? error.keyword}`;
+}
+
+function errors(validate: ValidateFunction<JsonValue>, value: JsonValue): string[] {
+  return validate(value) ? [] : (validate.errors ?? []).slice(0, 100).map(describe);
+}
+
+export function validateUnifiedV9Schema(value: JsonValue): string[] {
+  return errors(validateUnifiedV9, value);
+}
+
+export function validateProviderSectionsSchema(value: JsonValue): string[] {
+  return errors(validateProviderSections, value);
+}

--- a/packages/pi-healthmd-dashboard/src/source.ts
+++ b/packages/pi-healthmd-dashboard/src/source.ts
@@ -1,0 +1,335 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+import { jsonStringify, parseJsonLossless, parseJsonNumberTokens, truncateUtf8, utf8ByteLength } from "./json.js";
+import type { JsonValue } from "./model.js";
+import { validateQueryContract } from "./query-contract.js";
+
+export const HEALTHMD_QUERY_OPERATIONS = [
+  "healthmd_metric_chart",
+  "healthmd_sleep_sessions",
+  "healthmd_training_alignment",
+  "healthmd_workouts",
+  "healthmd_coverage",
+  "healthmd_compare_periods",
+  "healthmd_training_evidence",
+  "healthmd_query",
+  "healthmd_evidence_packet",
+] as const;
+
+export const HEALTHMD_READ_OPERATIONS = [
+  "healthmd_status", "healthmd_doctor", "healthmd_capabilities", "healthmd_metrics",
+  ...HEALTHMD_QUERY_OPERATIONS,
+] as const;
+
+export type HealthMdQueryOperation = typeof HEALTHMD_QUERY_OPERATIONS[number];
+export type HealthMdReadOperation = typeof HEALTHMD_READ_OPERATIONS[number];
+export type HealthMdFetchTransport = "cli" | "mcp";
+
+export interface HealthMdSourceConfig {
+  cliExecutable?: string;
+  /** Standalone stdio helper, such as the Mac app's healthmd-mcp. Omit to use `healthmd mcp serve-read-only`. */
+  mcpExecutable?: string;
+  deviceId?: string;
+  port?: number;
+  defaultTransport?: HealthMdFetchTransport;
+  maxOutputBytes?: number;
+}
+
+export interface HealthMdFetchOptions {
+  operation: HealthMdReadOperation;
+  arguments: { [key: string]: JsonValue };
+  transport?: HealthMdFetchTransport;
+  timeoutSeconds?: number;
+}
+
+export interface HealthMdFetchResult {
+  operation: HealthMdReadOperation;
+  transport: HealthMdFetchTransport;
+  text: string;
+  bytes: number;
+  syntheticPath: string;
+}
+
+const DEFAULT_MAX_OUTPUT_BYTES = 32 * 1024 * 1024;
+const MAX_ARGUMENT_BYTES = 2 * 1024 * 1024;
+const MAX_DIAGNOSTIC_BYTES = 1_024;
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SOURCE_ENVIRONMENT_KEYS = [
+  "PATH", "HOME", "USERPROFILE", "LOCALAPPDATA", "APPDATA", "XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_RUNTIME_DIR",
+  "DBUS_SESSION_BUS_ADDRESS", "HEALTHMD_CLI_DATA_DIR", "HEALTHMD_MCP_BASE_URL", "TMPDIR", "TEMP", "TMP",
+  "SystemRoot", "WINDIR", "PATHEXT", "LANG", "LC_ALL",
+] as const;
+
+function sourceEnvironment(): NodeJS.ProcessEnv {
+  const environment: NodeJS.ProcessEnv = { NO_COLOR: "1" };
+  for (const key of SOURCE_ENVIRONMENT_KEYS) if (process.env[key] !== undefined) environment[key] = process.env[key];
+  return environment;
+}
+
+function signalProcessTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  try {
+    if (process.platform !== "win32" && child.pid) process.kill(-child.pid, signal);
+    else child.kill(signal);
+  } catch { child.kill(signal); }
+}
+
+function terminateProcessTree(child: ChildProcess): void {
+  signalProcessTree(child, "SIGTERM");
+  const escalation = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) signalProcessTree(child, "SIGKILL");
+  }, 250);
+  escalation.unref();
+}
+
+function validateExecutable(value: string, label: string): string {
+  const executable = value.trim();
+  if (!executable || executable.length > 4_096 || executable.includes("\0")) throw new Error(`${label} is invalid`);
+  return executable;
+}
+
+function validatedConfig(config: HealthMdSourceConfig): Required<Pick<HealthMdSourceConfig, "cliExecutable" | "defaultTransport" | "maxOutputBytes">> & HealthMdSourceConfig {
+  const cliExecutable = validateExecutable(config.cliExecutable ?? "healthmd", "Health.md CLI executable");
+  const defaultTransport = config.defaultTransport ?? "mcp";
+  if (defaultTransport !== "cli" && defaultTransport !== "mcp") throw new Error("Health.md fetch transport must be cli or mcp");
+  const maxOutputBytes = config.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  if (!Number.isSafeInteger(maxOutputBytes) || maxOutputBytes < 1 || maxOutputBytes > 128 * 1024 * 1024) throw new Error("Health.md fetch output limit is invalid");
+  if (config.deviceId && !UUID.test(config.deviceId)) throw new Error("Health.md device ID must be a UUID");
+  if (config.port !== undefined && (!Number.isInteger(config.port) || config.port < 1 || config.port > 65_535)) throw new Error("Health.md direct port must be between 1 and 65535");
+  return { ...config, cliExecutable, defaultTransport, maxOutputBytes, ...(config.mcpExecutable ? { mcpExecutable: validateExecutable(config.mcpExecutable, "Health.md MCP executable") } : {}) };
+}
+
+function queryOperation(value: string): value is HealthMdQueryOperation {
+  return (HEALTHMD_QUERY_OPERATIONS as readonly string[]).includes(value);
+}
+function readOperation(value: string): value is HealthMdReadOperation {
+  return (HEALTHMD_READ_OPERATIONS as readonly string[]).includes(value);
+}
+
+function validateArguments(value: { [key: string]: JsonValue }): void {
+  const seen = new WeakSet<object>();
+  const stack: Array<{ value: JsonValue; depth: number }> = [{ value, depth: 0 }];
+  let nodes = 0;
+  while (stack.length) {
+    const item = stack.pop()!;
+    if (++nodes > 100_000) throw new Error("Health.md query arguments exceed the node limit");
+    if (item.depth > 128) throw new Error("Health.md query arguments exceed the depth limit");
+    if (typeof item.value === "number" && !Number.isFinite(item.value)) throw new Error("Health.md query arguments contain a non-finite number");
+    if (typeof item.value === "bigint") throw new Error("Health.md query arguments cannot contain bigint values");
+    if (item.value === null || typeof item.value !== "object") continue;
+    if (seen.has(item.value)) throw new Error("Health.md query arguments contain a cycle");
+    seen.add(item.value);
+    const children = Array.isArray(item.value) ? item.value : Object.values(item.value);
+    for (const child of children) stack.push({ value: child, depth: item.depth + 1 });
+  }
+  if (utf8ByteLength(jsonStringify(value)) > MAX_ARGUMENT_BYTES) throw new Error(`Health.md query arguments exceed ${MAX_ARGUMENT_BYTES} bytes`);
+}
+
+function globalArguments(config: HealthMdSourceConfig): string[] {
+  return [
+    ...(config.deviceId ? ["--device", config.deviceId] : []),
+    ...(config.port !== undefined ? ["--port", String(config.port)] : []),
+  ];
+}
+
+function diagnostic(value: unknown): string {
+  return truncateUtf8(String(value ?? "").replace(/[\r\n\t\0-\x1f\x7f]/g, " "), MAX_DIAGNOSTIC_BYTES);
+}
+
+function errorFromPayload(text: string): string | undefined {
+  try {
+    const value = parseJsonLossless(text);
+    if (value === null || typeof value !== "object" || Array.isArray(value)) return undefined;
+    const code = typeof value.error === "string" ? value.error : typeof value.code === "string" ? value.code : undefined;
+    const message = typeof value.message === "string" ? value.message : undefined;
+    return [code, message].filter(Boolean).map(diagnostic).join(": ") || undefined;
+  } catch { return undefined; }
+}
+
+interface ProcessOutput { code: number | null; stdout: string; stderr: string }
+async function collectProcess(command: string, args: string[], timeoutSeconds: number, maxOutputBytes: number, signal?: AbortSignal): Promise<ProcessOutput> {
+  if (signal?.aborted) throw new Error("Health.md fetch cancelled");
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { shell: false, detached: process.platform !== "win32", stdio: ["ignore", "pipe", "pipe"], env: sourceEnvironment() });
+    const stdout: Buffer[] = [], stderr: Buffer[] = [];
+    let stdoutBytes = 0, stderrBytes = 0, settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      signal?.removeEventListener("abort", cancel);
+    };
+    const stop = (error: Error) => {
+      if (settled) return;
+      settled = true; cleanup(); terminateProcessTree(child); reject(error);
+    };
+    const cancel = () => stop(new Error("Health.md fetch cancelled"));
+    signal?.addEventListener("abort", cancel, { once: true });
+    timer = setTimeout(() => stop(new Error(`Health.md fetch timed out after ${timeoutSeconds} seconds`)), timeoutSeconds * 1_000 + 500);
+    child.stdout.on("data", (chunk: Buffer) => {
+      if (settled) return;
+      stdoutBytes += chunk.byteLength;
+      if (stdoutBytes > maxOutputBytes) { stop(new Error(`Health.md output exceeds ${maxOutputBytes} bytes`)); return; }
+      stdout.push(chunk);
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      if (settled || stderrBytes >= MAX_DIAGNOSTIC_BYTES) return;
+      const retained = chunk.subarray(0, MAX_DIAGNOSTIC_BYTES - stderrBytes);
+      stderr.push(retained); stderrBytes += retained.byteLength;
+    });
+    child.on("error", error => stop(new Error(`Unable to start Health.md executable: ${diagnostic(error.message)}`)));
+    child.on("close", code => {
+      if (settled) return;
+      settled = true; cleanup();
+      resolve({ code, stdout: Buffer.concat(stdout, stdoutBytes).toString("utf8"), stderr: Buffer.concat(stderr, stderrBytes).toString("utf8") });
+    });
+  });
+}
+
+async function fetchViaCli(config: ReturnType<typeof validatedConfig>, operation: HealthMdQueryOperation, argumentsValue: { [key: string]: JsonValue }, timeoutSeconds: number, signal?: AbortSignal): Promise<string> {
+  const output = await collectProcess(config.cliExecutable, [
+    ...globalArguments(config), "query", operation, "--arguments", jsonStringify(argumentsValue), "--timeout", String(timeoutSeconds),
+  ], timeoutSeconds, config.maxOutputBytes, signal);
+  const text = output.stdout.trim();
+  if (output.code !== 0) throw new Error(`Health.md CLI query failed${errorFromPayload(text) ? `: ${errorFromPayload(text)}` : ` with exit code ${output.code ?? "unknown"}`}`);
+  if (!text) throw new Error("Health.md CLI returned no JSON");
+  const parsed = parseJsonLossless(text);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Health.md CLI returned a non-object JSON result");
+  return text;
+}
+
+function mcpPayloadText(result: unknown): string {
+  if (result === null || typeof result !== "object" || Array.isArray(result)) throw new Error("Health.md MCP returned an invalid tool result");
+  const object = result as Record<string, unknown>;
+  const content = Array.isArray(object.content) ? object.content : [];
+  const text = content.find(item => item !== null && typeof item === "object" && !Array.isArray(item) && (item as Record<string, unknown>).type === "text");
+  const payload = text && typeof (text as Record<string, unknown>).text === "string" ? (text as Record<string, unknown>).text as string : undefined;
+  if (!payload) throw new Error("Health.md MCP returned no authoritative JSON text");
+  if (object.isError === true) throw new Error(`Health.md MCP query failed${errorFromPayload(payload) ? `: ${errorFromPayload(payload)}` : ""}`);
+  const parsed = parseJsonLossless(payload);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Health.md MCP returned a non-object JSON result");
+  return payload;
+}
+
+type JsonObject = { [key: string]: JsonValue };
+function jsonObject(value: JsonValue | undefined): value is JsonObject { return value !== null && typeof value === "object" && !Array.isArray(value); }
+
+function requestedPage(operation: HealthMdReadOperation, argumentsValue: JsonObject): JsonObject | undefined {
+  const request = operation === "healthmd_query" || operation === "healthmd_evidence_packet" ? argumentsValue.request : argumentsValue;
+  return jsonObject(request) && jsonObject(request.page) ? request.page : undefined;
+}
+function requestedPageMaximum(operation: HealthMdReadOperation, argumentsValue: JsonObject): number {
+  const page = requestedPage(operation, argumentsValue);
+  if (page?.max_items === undefined) return 250;
+  if (typeof page.max_items !== "number" || !Number.isSafeInteger(page.max_items) || page.max_items < 1 || page.max_items > 1_000) throw new Error("Health.md page.max_items must be an integer between 1 and 1000");
+  return page.max_items;
+}
+
+function validateFetchedPayload(operation: HealthMdReadOperation, argumentsValue: JsonObject, text: string): void {
+  const value = parseJsonLossless(text);
+  if (!jsonObject(value)) throw new Error("Health.md returned a non-object JSON result");
+  if (queryOperation(operation)) {
+    const allPages = argumentsValue.all_pages === true;
+    if (allPages !== (value.schema === "healthmd.mcp_query_pages")) throw new Error("Health.md query response shape disagrees with the requested all_pages mode");
+    const page = requestedPage(operation, argumentsValue);
+    const initialCursor = page && typeof page.cursor === "string" ? page.cursor : undefined;
+    const errors = validateQueryContract(value, requestedPageMaximum(operation, argumentsValue), parseJsonNumberTokens(text), initialCursor);
+    if (errors.length) throw new Error(errors[0]);
+    return;
+  }
+  const expectedSchemas: Partial<Record<HealthMdReadOperation, readonly string[]>> = {
+    healthmd_doctor: ["healthmd.direct_readiness", "healthmd.local_readiness"],
+    healthmd_capabilities: ["healthmd.mcp_capabilities", "healthmd.local_capabilities"],
+    healthmd_metrics: ["healthmd.metric_catalog"],
+  };
+  const expected = expectedSchemas[operation];
+  if (expected && (!expected.includes(String(value.schema)) || value.schema_version !== 1)) throw new Error(`${operation} returned an unsupported contract identity`);
+  if (operation === "healthmd_metrics" && !Array.isArray(value.metrics)) throw new Error("healthmd_metrics returned an invalid catalog");
+}
+
+async function fetchViaMcp(config: ReturnType<typeof validatedConfig>, operation: HealthMdReadOperation, argumentsValue: { [key: string]: JsonValue }, timeoutSeconds: number, signal?: AbortSignal): Promise<string> {
+  if (signal?.aborted) throw new Error("Health.md fetch cancelled");
+  const standalone = config.mcpExecutable;
+  if (standalone && (config.deviceId || config.port !== undefined)) throw new Error("A standalone Health.md MCP helper cannot accept portable CLI device/port selection");
+  const command = standalone ?? config.cliExecutable;
+  const args = standalone ? [] : [...globalArguments(config), "mcp", "serve-read-only", "--timeout-seconds", String(timeoutSeconds)];
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { shell: false, detached: process.platform !== "win32", stdio: ["pipe", "pipe", "pipe"], env: sourceEnvironment() });
+    let buffer = "", outputBytes = 0, stderr = "", settled = false, initialized = false;
+    const decoder = new StringDecoder("utf8");
+    let timer: NodeJS.Timeout | undefined;
+    const cleanup = () => {
+      if (timer) clearTimeout(timer);
+      signal?.removeEventListener("abort", cancel);
+    };
+    const finish = (error?: Error, value?: string) => {
+      if (settled) return;
+      settled = true; cleanup(); child.stdin.end(); terminateProcessTree(child);
+      if (error) reject(error); else resolve(value!);
+    };
+    const cancel = () => {
+      try { child.stdin.write(`${jsonStringify({ jsonrpc: "2.0", method: "notifications/cancelled", params: { requestId: 2, reason: "cancelled" } })}\n`); } catch {}
+      finish(new Error("Health.md fetch cancelled"));
+    };
+    signal?.addEventListener("abort", cancel, { once: true });
+    timer = setTimeout(() => finish(new Error(`Health.md fetch timed out after ${timeoutSeconds} seconds`)), timeoutSeconds * 1_000 + 500);
+    child.stderr.on("data", chunk => { if (utf8ByteLength(stderr) < MAX_DIAGNOSTIC_BYTES) stderr += Buffer.from(chunk).subarray(0, MAX_DIAGNOSTIC_BYTES - utf8ByteLength(stderr)).toString("utf8"); });
+    child.stdin.on("error", error => { if (!settled) finish(new Error(`Health.md MCP stdin failed: ${diagnostic(error.message)}`)); });
+    child.on("error", error => finish(new Error(`Unable to start Health.md MCP executable: ${diagnostic(error.message)}`)));
+    child.on("close", code => { if (!settled) finish(new Error(`Health.md MCP exited before replying (code ${code ?? "unknown"}${stderr ? `; ${diagnostic(stderr)}` : ""})`)); });
+    child.stdout.on("data", chunk => {
+      outputBytes += Buffer.byteLength(chunk);
+      if (outputBytes > config.maxOutputBytes) { finish(new Error(`Health.md MCP output exceeds ${config.maxOutputBytes} bytes`)); return; }
+      buffer += decoder.write(chunk);
+      while (!settled) {
+        const newline = buffer.indexOf("\n");
+        if (newline < 0) break;
+        const line = buffer.slice(0, newline).replace(/\r$/, "");
+        buffer = buffer.slice(newline + 1);
+        if (!line) continue;
+        let response: Record<string, unknown>;
+        try { response = JSON.parse(line) as Record<string, unknown>; }
+        catch { finish(new Error("Health.md MCP returned invalid JSON-RPC")); return; }
+        if (response.id !== 1 && response.id !== 2) continue;
+        if (response.jsonrpc !== "2.0") { finish(new Error("Health.md MCP returned an invalid JSON-RPC version")); return; }
+        if (response.error) {
+          const error = response.error as Record<string, unknown>;
+          finish(new Error(`Health.md MCP ${response.id === 1 ? "initialization" : "query"} failed: ${diagnostic(error.message ?? error.code ?? "unknown error")}`));
+          return;
+        }
+        if (response.id === 1) {
+          if (initialized) { finish(new Error("Health.md MCP returned duplicate initialization responses")); return; }
+          const result = response.result as Record<string, unknown> | undefined;
+          if (!result || result.protocolVersion !== "2025-11-25") { finish(new Error("Health.md MCP negotiated an unexpected protocol version")); return; }
+          initialized = true;
+          child.stdin.write(`${jsonStringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} })}\n`);
+          child.stdin.write(`${jsonStringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: operation, arguments: argumentsValue } })}\n`);
+        } else {
+          if (!initialized) { finish(new Error("Health.md MCP replied before initialization completed")); return; }
+          try { finish(undefined, mcpPayloadText(response.result)); }
+          catch (error) { finish(error instanceof Error ? error : new Error(String(error))); }
+        }
+      }
+    });
+    child.once("spawn", () => child.stdin.write(`${jsonStringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "pi-healthmd-dashboard", version: "0.1.0" } } })}\n`));
+  });
+}
+
+export async function fetchHealthMd(configValue: HealthMdSourceConfig, options: HealthMdFetchOptions, signal?: AbortSignal): Promise<HealthMdFetchResult> {
+  const config = validatedConfig(configValue);
+  if (!readOperation(options.operation)) throw new Error(`Unsupported read-only Health.md operation: ${String(options.operation)}`);
+  if (options.arguments === null || typeof options.arguments !== "object" || Array.isArray(options.arguments)) throw new Error("Health.md query arguments must be one JSON object");
+  validateArguments(options.arguments);
+  const timeoutSeconds = options.timeoutSeconds ?? 1_200;
+  if (!Number.isInteger(timeoutSeconds) || timeoutSeconds < 1 || timeoutSeconds > 3_600) throw new Error("Health.md query timeout must be between 1 and 3600 seconds");
+  const transport = options.transport ?? config.defaultTransport;
+  if (transport !== "cli" && transport !== "mcp") throw new Error("Health.md fetch transport must be cli or mcp");
+  let text: string;
+  if (transport === "cli") {
+    if (!queryOperation(options.operation)) throw new Error(`${options.operation} requires the MCP transport; no transport fallback was attempted`);
+    text = await fetchViaCli(config, options.operation, options.arguments, timeoutSeconds, signal);
+  } else {
+    text = await fetchViaMcp(config, options.operation, options.arguments, timeoutSeconds, signal);
+  }
+  validateFetchedPayload(options.operation, options.arguments, text);
+  if (utf8ByteLength(text) > config.maxOutputBytes) throw new Error(`Health.md result exceeds ${config.maxOutputBytes} bytes`);
+  return { operation: options.operation, transport, text, bytes: utf8ByteLength(text), syntheticPath: `${transport === "cli" ? "healthmd-cli" : "healthmd-mcp"}://${options.operation}` };
+}

--- a/packages/pi-healthmd-dashboard/src/view.ts
+++ b/packages/pi-healthmd-dashboard/src/view.ts
@@ -1,0 +1,40 @@
+import { initialView, type ViewState } from "./model.js";
+
+export type ViewAction = "show" | "hide" | "select" | "focus" | "mode" | "date_window" | "zoom_in" | "zoom_out" | "pan_left" | "pan_right" | "reset";
+
+export interface ViewUpdate {
+  action: ViewAction;
+  target?: string;
+  targetKind?: "metric" | "path" | "search";
+  mode?: "chart" | "table";
+  startDate?: string;
+  endDate?: string;
+}
+
+export function updateView(current: ViewState, update: ViewUpdate): ViewState {
+  if (update.action === "reset") return { ...initialView(), visible: current.visible };
+  const next = { ...current };
+  if (update.action === "show") next.visible = true;
+  if (update.action === "hide") next.visible = false;
+  if (update.action === "select" || update.action === "focus") {
+    if (!update.target) throw new Error(`${update.action} requires target`);
+    next.target = update.target;
+    next.targetKind = update.targetKind ?? "metric";
+    next.offset = 0;
+  }
+  if (update.action === "mode") {
+    if (!update.mode) throw new Error("mode action requires chart or table");
+    next.mode = update.mode;
+  }
+  if (update.action === "date_window") {
+    if (!update.startDate || !update.endDate) throw new Error("date_window requires startDate and endDate");
+    if (update.startDate > update.endDate) throw new Error("startDate must not follow endDate");
+    next.startDate = update.startDate;
+    next.endDate = update.endDate;
+  }
+  if (update.action === "zoom_in") next.windowSize = Math.max(1, Math.floor(next.windowSize / 2));
+  if (update.action === "zoom_out") next.windowSize = Math.min(3650, next.windowSize * 2);
+  if (update.action === "pan_left") next.offset = Math.max(0, next.offset - Math.max(1, Math.floor(next.windowSize / 2)));
+  if (update.action === "pan_right") next.offset = Math.max(0, next.offset + Math.max(1, Math.floor(next.windowSize / 2)));
+  return next;
+}

--- a/packages/pi-healthmd-dashboard/test/adapters-exact.test.ts
+++ b/packages/pi-healthmd-dashboard/test/adapters-exact.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { classifyContract } from "../src/contracts.js";
+import { decodeExactNumber, displayValue } from "../src/exact.js";
+import { jsonStringify, parseJsonLossless } from "../src/json.js";
+import { loadHealthData } from "../src/loader.js";
+
+const repo = resolve(import.meta.dirname, "../../..");
+const evidence: Array<[string, string]> = [
+  ["apps/apple/docs/reference/generated/core/provider-day.json", "apple_health_data"],
+  ["apps/apple/docs/reference/generated/core/canonical-archive.json", "healthkit_archive"],
+  ["apps/apple/docs/reference/generated/automation/api-export-v2-provider-sidecar.json", "api_envelope"],
+  ["apps/apple/docs/reference/generated/automation/raw-result-complete.json", "raw_envelope"],
+  ["apps/apple/docs/reference/generated/automation/agent-query-response.json", "query_response"],
+  ["apps/apple/docs/reference/generated/cli/strict-raw-complete-response.json", "raw_envelope"],
+  ["apps/apple/docs/reference/generated/rollups/weekly.json", "rollup"],
+  ["apps/android/docs/export-contract/samples/android-full-day-granular.json", "android_unversioned"],
+  ["apps/android/app/src/test/resources/raw-export/v1/minimal-snapshot.json", "android_raw_snapshot"],
+  ["apps/android/app/src/test/resources/raw-export/v1/medical-exact-fhir-record.json", "generic_json"],
+  ["packages/contracts/proposals/provider-sections-v1/fixtures/whoop-complete.providers.json", "whoop_typed_daily"],
+];
+for (const [path, kind] of evidence) test(`classifies actual ${kind} evidence`, async () => {
+  const store = await loadHealthData([join(repo, path)]);
+  assert.equal(store.documents[0]?.contractKind, kind);
+  assert.ok(store.entries.length > 0);
+  if (path.includes("medical-exact-fhir")) assert.ok(store.entries.some(entry => entry.path.includes("fhir")));
+});
+
+test("pure adapter recognizes remaining explicit identities without inferring equivalence", () => {
+  for (const schemaVersion of [5, 6, 7, 8]) assert.equal(classifyContract({ schema: "healthmd.health_data", schema_version: schemaVersion }).kind, "apple_health_data");
+  assert.equal(classifyContract({ schema: "healthmd.health_data", schema_version: 4 }).kind, "android_frozen_v4");
+  assert.equal(classifyContract({ type: "health-data", schemaProfile: "android-analytical-v5", schemaVersion: 5 }).kind, "android_analytical_v5");
+  assert.equal(classifyContract({ profileVersion: 5, schemaVersion: 5, payload: {} }).kind, "generic_json");
+  assert.equal(classifyContract({ schema: "healthmd.external_provider_daily", schema_version: 1 }).kind, "external_provider_daily");
+  assert.equal(classifyContract({ schema: "healthmd.android_merge_provenance", schema_version: 1 }).kind, "android_merge_reference");
+  assert.equal(classifyContract({ schema: "healthmd.raw_record", schema_version: 1 }).kind, "android_raw_reference");
+  assert.equal(classifyContract({ header: { schema: "healthmd.raw-changes", version: 1 }, events: [], issues: [], manifest: {} }).kind, "android_raw_reference");
+  assert.equal(classifyContract({ schema: "healthmd.raw-snapshot.manifest", version: 1 }).kind, "android_raw_manifest");
+  assert.equal(classifyContract({ schema: "healthmd.unknown", schema_version: 1 }).kind, "generic_healthmd");
+});
+
+test("Android v5 signature metadata remains generically readable without masquerading as a daily export", async () => {
+  const store = await loadHealthData([join(repo, "apps/android/app/src/test/resources/export-contract/signatures/exporter_signature_android_analytical_v5.json")]);
+  assert.equal(store.documents[0]?.contractKind, "generic_json");
+  assert.ok(store.entries.some(entry => entry.path.endsWith("metricDiscriminators.schemaProfile") && entry.value === "android-analytical-v5"));
+});
+
+test("actual nested Android raw identity is retained", async () => {
+  const store = await loadHealthData([join(repo, "apps/android/app/src/test/resources/raw-export/v1/minimal-snapshot.json")]);
+  assert.equal(store.documents[0]?.schema, "healthmd.raw-snapshot");
+  assert.equal(store.documents[0]?.schemaVersion, 1);
+});
+
+test("packaged schema snapshots remain byte-identical to canonical contracts", async () => {
+  for (const [packaged, canonical] of [
+    ["schemas/unified-health-data-v9.schema.json", "packages/contracts/proposals/unified-health-data-v9/unified-health-data-v9.schema.json"],
+    ["schemas/provider-sections-v1.schema.json", "packages/contracts/proposals/provider-sections-v1/provider-sections-v1.schema.json"],
+  ] as const) assert.deepEqual(await readFile(join(repo, "packages/pi-healthmd-dashboard", packaged)), await readFile(join(repo, canonical)));
+});
+
+test("lossless parser preserves actual source-fidelity integer tokens", async () => {
+  const store = await loadHealthData([join(repo, "apps/apple/docs/reference/generated/core/canonical-archive.json")]);
+  const large = store.entries.find(entry => entry.path.endsWith("metadata.unsigned_integer.value"));
+  assert.equal(large?.value, 18446744073709551615n);
+  assert.match(jsonStringify(large), /18446744073709551615/);
+  const parsed = parseJsonLossless('{"n":18446744073709551615,"negativeZero":-0}') as { n: bigint; negativeZero: number };
+  assert.equal(parsed.n, 18446744073709551615n);
+  assert.equal(Object.is(parsed.negativeZero, -0), true);
+  assert.throws(() => parseJsonLossless(`{"n":${"1".repeat(1025)}}`), /number token exceeds/);
+  assert.throws(() => parseJsonLossless('{"n":1e9999}'), /finite binary64/);
+});
+
+test("exact number representations preserve -0, subnormal, extremes, and safely reject invalid values", () => {
+  assert.equal(decodeExactNumber({ representation: "binary64", bits: "8000000000000000" })?.exactText, "-0");
+  assert.equal(decodeExactNumber({ representation: "binary64", bits: "0000000000000001" })?.chartValue, 5e-324);
+  assert.equal(decodeExactNumber({ representation: "binary64", bits: "7fefffffffffffff" })?.chartValue, Number.MAX_VALUE);
+  assert.throws(() => decodeExactNumber({ representation: "binary64", bits: "7ff0000000000000" }), /Non-finite/);
+  assert.throws(() => decodeExactNumber({ representation: "unsigned_integer", decimal: "-1" }), /Invalid/);
+  assert.throws(() => decodeExactNumber({ representation: "signed_integer", decimal: "1".repeat(41) }), /40/);
+  assert.doesNotThrow(() => displayValue({ representation: "unsigned_integer", decimal: "-1" }));
+});
+
+test("recognized invalid typed query response remains indexed and marked invalid", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-query-invalid-"));
+  const file = join(dir, "invalid-query.json");
+  await writeFile(file, JSON.stringify({ schema: "healthmd.query_response", schema_version: 2, items: "bad" }));
+  const store = await loadHealthData([file]);
+  assert.equal(store.documents[0]?.contractKind, "query_response");
+  assert.equal(store.documents[0]?.contractValid, false);
+  assert.ok(store.warnings.some(warning => /healthmd\.query_response\/1/.test(warning)));
+});
+
+test("file-loaded query contracts retain exact integer token validation", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-query-token-"));
+  const file = join(dir, "decimal-version.json");
+  const canonical = await readFile(join(repo, "apps/apple/docs/reference/generated/automation/agent-query-response.json"), "utf8");
+  await writeFile(file, canonical.replace('"schema_version":1', '"schema_version":1.0'));
+  const store = await loadHealthData([file]);
+  assert.equal(store.documents[0]?.contractKind, "query_response");
+  assert.equal(store.documents[0]?.contractValid, false);
+  assert.ok(store.warnings.some(warning => /non-integer JSON token/.test(warning)));
+});
+
+test("recognized invalid v9 remains indexed and boundedly warned", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-v9-invalid-"));
+  const file = join(dir, "invalid.json");
+  await writeFile(file, JSON.stringify({ schema: "healthmd.health_data", schema_version: 9, profile: "wrong", unknown: true }));
+  const store = await loadHealthData([file]);
+  assert.equal(store.documents[0]?.contractKind, "unified_v9");
+  assert.equal(store.documents[0]?.experimentalV9, false);
+  assert.equal(store.documents[0]?.contractValid, false);
+  assert.ok(store.entries.length > 0);
+  assert.ok(store.warnings.length > 0 && store.warnings.length <= 100);
+});
+
+test("v9 validation rejects malformed resource, platform, and metric semantic invariants", () => {
+  const base = {
+    schema: "healthmd.health_data", schema_version: 9, profile: "unified-cross-platform-v1", owner_date: "2026-01-01",
+    calendar: { identifier: "gregorian", time_zone: "UTC", interval_start: "2026-01-01T00:00:00Z", interval_end: "2026-01-02T00:00:00Z", assignment_rule: "record_start_in_half_open_day_interval" },
+    source: { platform: "apple", source_profile: "apple_health_data_v8" },
+    capture: { status: "complete", resources: [{ source: "apple_health", resource: "steps", status: "complete", record_count: 1 }] },
+    metrics: [{ semantic_id: "steps", statistic: "sum", value: { value_type: "number", number: { representation: "unsigned_integer", decimal: "1" }, unit: "count" }, provenance: [{ source: "apple_health", source_semantic_id: "steps" }] }],
+    platform: { apple: { schema: "healthmd.platform.apple_daily", schema_version: 1, source_schema_version: 8 } },
+  };
+  const metric = base.metrics[0]!;
+  assert.equal(classifyContract(base).valid, true);
+  assert.equal(classifyContract({ ...base, platform: { apple: { schema: "wrong", schema_version: 1 } } }).valid, false);
+  assert.equal(classifyContract({ ...base, capture: { status: "complete", resources: [{ status: "complete" }] } }).valid, false);
+  assert.equal(classifyContract({ ...base, metrics: [{ statistic: "sum", value: { value_type: "number", number: { representation: "unsigned_integer", decimal: "-1" } }, provenance: [] }] }).valid, false);
+  assert.equal(classifyContract({ ...base, owner_date: "not-a-date" }).valid, false);
+  assert.equal(classifyContract({ ...base, source: { ...base.source, unexpected: true } }).valid, false);
+  assert.equal(classifyContract({ ...base, providers: { whoop: { schema: "healthmd.provider.whoop_daily", schema_version: 1 } } }).valid, false);
+  assert.equal(classifyContract({ ...base, metrics: [{ ...metric, value: { value_type: "unknown" } }] }).valid, false);
+  assert.equal(classifyContract({ ...base, metrics: [{ ...metric, provenance: [{ source: "health_connect", source_semantic_id: "steps" }] }] }).valid, false);
+  assert.equal(classifyContract({ ...base, metrics: [{ ...metric, provenance: [{ source: "apple_health", source_semantic_id: "not_steps", source_statistic: "sum" }] }] }).valid, false);
+  assert.equal(classifyContract({ ...base, metrics: [{ ...metric, provenance: [{ source: "apple_health", source_semantic_id: "steps", source_statistic: "latest" }] }] }).valid, false);
+  assert.equal(classifyContract({ ...base, metrics: [{ ...metric, semantic_id: "arbitrary_metric" }], capture: { status: "complete", resources: [{ source: "apple_health", resource: "arbitrary_metric", status: "complete", record_count: 1 }] } }).valid, false);
+  assert.equal(classifyContract({ ...base, metrics: [{ ...metric, semantic_id: "heart_rate_variability_rmssd", statistic: "latest", value: { ...metric.value, unit: "millisecond" } }], capture: { status: "complete", resources: [{ source: "apple_health", resource: "heart_rate_variability_rmssd", status: "complete", record_count: 1 }] } }).valid, false);
+});

--- a/packages/pi-healthmd-dashboard/test/cache.test.ts
+++ b/packages/pi-healthmd-dashboard/test/cache.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { chmod, mkdir, mkdtemp, readFile, stat, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { configuredCacheDirectory, loadCachedEvidence, persistFetchedEvidence, rememberCacheDirectory } from "../src/cache.js";
+import { loadHealthDataText } from "../src/loader.js";
+
+const fixture = resolve(import.meta.dirname, "../../../apps/apple/docs/reference/generated/automation/agent-query-response.json");
+
+test("content-addressed cache remembers, verifies, and restores exact fetched evidence", async () => {
+  const root = await mkdtemp(join(tmpdir(), "healthmd-cache-"));
+  const cache = join(root, "evidence"), config = join(root, "config");
+  const previous = process.env.XDG_CONFIG_HOME;
+  process.env.XDG_CONFIG_HOME = config;
+  try {
+    const directory = await rememberCacheDirectory(cache);
+    assert.equal(await configuredCacheDirectory(), directory);
+    const text = await readFile(fixture, "utf8");
+    const receipt = await persistFetchedEvidence(directory, { text, origin: "healthmd-mcp", operation: "healthmd_metric_chart" });
+    assert.equal(receipt.entries, 1);
+    assert.equal((await stat(receipt.file)).mode & 0o777, 0o600);
+    await chmod(receipt.file, 0o644);
+    await persistFetchedEvidence(directory, { text, origin: "healthmd-mcp", operation: "healthmd_metric_chart" });
+    assert.equal((await stat(receipt.file)).mode & 0o777, 0o600);
+    const secondText = `${text}\n`;
+    await Promise.all([
+      persistFetchedEvidence(directory, { text, origin: "healthmd-mcp", operation: "healthmd_metric_chart" }),
+      persistFetchedEvidence(directory, { text: secondText, origin: "healthmd-cli", operation: "healthmd_training_evidence" }),
+    ]);
+    const inputs = await loadCachedEvidence(directory);
+    assert.equal(inputs.length, 2);
+    assert.ok(inputs.some(input => input.text === text && input.origin === "healthmd-mcp" && input.operation === "healthmd_metric_chart"));
+    assert.ok(inputs.some(input => input.text === secondText && input.origin === "healthmd-cli" && input.operation === "healthmd_training_evidence"));
+    const store = loadHealthDataText(inputs);
+    assert.ok(store.documents.every(document => document.contractKind === "query_response"));
+    assert.ok(store.documents.some(document => document.operation === "healthmd_metric_chart"));
+    await writeFile(receipt.file, `${text} `);
+    await chmod(receipt.file, 0o600);
+    await assert.rejects(loadCachedEvidence(directory), /size mismatch|digest mismatch/);
+  } finally {
+    if (previous === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = previous;
+  }
+});
+
+test("cache rejects a symlinked objects directory", async () => {
+  const root = await mkdtemp(join(tmpdir(), "healthmd-cache-symlink-"));
+  const cache = join(root, "cache"), outside = join(root, "outside");
+  await mkdir(cache, { mode: 0o700 });
+  await mkdir(outside, { mode: 0o700 });
+  await symlink(outside, join(cache, "objects"));
+  await assert.rejects(rememberCacheDirectory(cache), /objects path escapes/);
+});

--- a/packages/pi-healthmd-dashboard/test/contracts.test.ts
+++ b/packages/pi-healthmd-dashboard/test/contracts.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { decodeExactNumber } from "../src/exact.js";
+import { loadHealthData } from "../src/loader.js";
+import { formatEvidence, queryStore } from "../src/query.js";
+
+const repo = resolve(import.meta.dirname, "../../..");
+const fixtureDir = join(repo, "packages/contracts/proposals/unified-health-data-v9/fixtures");
+const fixtures = ["android-minimal.json", "android-not-requested.json", "apple-minimal.json", "apple-partial.json", "apple-whoop.json"];
+
+for (const fixture of fixtures) {
+  test(`loads and indexes canonical proposed v9 fixture ${fixture}`, async () => {
+    const store = await loadHealthData([join(fixtureDir, fixture)]);
+    assert.equal(store.documents.length, 1);
+    assert.equal(store.documents[0]?.experimentalV9, true);
+    assert.equal(store.documents[0]?.profile, "unified-cross-platform-v1");
+    assert.ok(store.entries.some(entry => entry.path === "$.capture.status"));
+    assert.ok(store.entries.some(entry => entry.path === "$.source.platform"));
+  });
+}
+
+test("canonical fixtures preserve exact values, capture, platform, provenance, explicit zero, and provider identity", async () => {
+  const store = await loadHealthData(fixtures.map(file => join(fixtureDir, file)));
+  const steps = queryStore(store, { metric: "steps", path: ".number", limit: 100 });
+  assert.ok(steps.matches.some(entry => JSON.stringify(entry.value).includes('"decimal":"1234"')));
+  const hrv = queryStore(store, { metric: "heart_rate_variability_rmssd", path: ".number", limit: 20 });
+  assert.equal(decodeExactNumber(hrv.matches[0]!.value)?.chartValue, 48);
+  assert.equal(hrv.matches[0]?.unit, "millisecond");
+  assert.equal(hrv.matches[0]?.statistic, "latest");
+  assert.ok(hrv.matches[0]?.provenance);
+  assert.ok(store.entries.some(entry => entry.path.includes("providers.whoop.recoveries[0].hrv_rmssd_ms") && entry.provider === "whoop"));
+  assert.ok(store.entries.some(entry => entry.path.endsWith("capture.resources[0].record_count") && entry.value === 0));
+  assert.ok(store.entries.some(entry => entry.value === "not_requested"));
+  assert.ok(store.entries.some(entry => entry.value === "partial"));
+  assert.deepEqual(new Set(store.documents.map(document => document.platform)), new Set(["apple", "android"]));
+});
+
+test("exact integers outside safe chart range retain exact text", () => {
+  const decoded = decodeExactNumber({ representation: "unsigned_integer", decimal: "18446744073709551615" });
+  assert.equal(decoded?.exactText, "18446744073709551615");
+  assert.equal(decoded?.safeForChart, false);
+  assert.equal(decoded?.chartValue, undefined);
+});
+
+test("indexes an actual source-fidelity HealthKit contract and sensitive generic paths", async () => {
+  const archive = join(repo, "apps/apple/docs/reference/generated/core/canonical-archive.json");
+  const store = await loadHealthData([archive]);
+  assert.equal(store.documents[0]?.schema, "healthmd.healthkit_records");
+  for (const search of ["state_of_mind", "medication", "clinical", "workout_route"]) {
+    const result = queryStore(store, { search, limit: 10 });
+    assert.ok(result.totalMatches > 0, `expected ${search}`);
+  }
+  assert.ok(queryStore(store, { path: "$.records", search: "latitude", limit: 10 }).totalMatches > 0);
+});
+
+test("resolves matching digest references and reports mismatch/unresolved honestly", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-dashboard-"));
+  const companion = Buffer.from(JSON.stringify({ schema: "healthmd.healthkit_records", schema_version: 1, records: [] }));
+  const digest = createHash("sha256").update(companion).digest("hex");
+  await writeFile(join(directory, "companion.json"), companion);
+  await writeFile(join(directory, "v9.json"), JSON.stringify({
+    schema: "healthmd.health_data", schema_version: 9, profile: "unified-cross-platform-v1",
+    platform: { apple: { healthkit_record_archive: { schema: "healthmd.healthkit_records", schema_version: 1, sha256: digest, byte_count: companion.byteLength } } },
+  }));
+  let store = await loadHealthData([directory]);
+  assert.equal(store.references[0]?.status, "resolved");
+  const v9 = JSON.parse(await readFile(join(directory, "v9.json"), "utf8"));
+  v9.platform.apple.healthkit_record_archive.byte_count++;
+  await writeFile(join(directory, "v9.json"), JSON.stringify(v9));
+  store = await loadHealthData([directory]);
+  assert.equal(store.references[0]?.status, "byte_count_mismatch");
+  v9.platform.apple.healthkit_record_archive.sha256 = "0".repeat(64);
+  await writeFile(join(directory, "v9.json"), JSON.stringify(v9));
+  store = await loadHealthData([directory]);
+  assert.equal(store.references[0]?.status, "digest_mismatch");
+  store = await loadHealthData([join(directory, "v9.json")]);
+  assert.equal(store.references[0]?.status, "unresolved");
+});
+
+test("resolves an exact Android raw-snapshot companion without normalizing contract identity", async () => {
+  const raw = join(repo, "apps/android/app/src/test/resources/raw-export/v1/minimal-snapshot.json");
+  const bytes = await readFile(raw);
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-raw-reference-"));
+  const reference = join(directory, "reference.json");
+  await writeFile(reference, JSON.stringify({ companion: { schema: "healthmd.raw-snapshot", schema_version: 1, sha256: createHash("sha256").update(bytes).digest("hex") } }));
+  let store = await loadHealthData([raw, reference]);
+  assert.equal(store.references[0]?.status, "resolved");
+  await writeFile(reference, JSON.stringify({ companion: { schema: "healthmd.raw_snapshot", schema_version: 1, sha256: createHash("sha256").update(bytes).digest("hex") } }));
+  store = await loadHealthData([raw, reference]);
+  assert.equal(store.references[0]?.status, "digest_mismatch");
+});
+
+test("enforces file, per-file, total-byte, and leaf bounds", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-bounds-"));
+  await writeFile(join(directory, "a.json"), JSON.stringify({ a: 1, b: 2 }));
+  await writeFile(join(directory, "b.json"), JSON.stringify({ c: 3 }));
+  await assert.rejects(loadHealthData([directory], { maxFiles: 1 }), /file count/);
+  await assert.rejects(loadHealthData([join(directory, "a.json")], { maxFileBytes: 2 }), /per-file/);
+  await assert.rejects(loadHealthData([directory], { maxTotalBytes: 5 }), /total byte/);
+  await assert.rejects(loadHealthData([join(directory, "a.json")], { maxLeaves: 1 }), /leaf count/);
+  const longPath = join(directory, "long-path.json");
+  await writeFile(longPath, JSON.stringify({ ["x".repeat(100)]: 1 }));
+  await assert.rejects(loadHealthData([longPath], { maxPathBytes: 32 }), /per-path byte limit/);
+  const manyPaths = join(directory, "many-paths.json");
+  await writeFile(manyPaths, JSON.stringify({ values: Array.from({ length: 20 }, (_, index) => index) }));
+  await assert.rejects(loadHealthData([manyPaths], { maxIndexedPathBytes: 64 }), /paths exceed total byte limit/);
+  const references = join(directory, "references.json");
+  await writeFile(references, JSON.stringify({ refs: [0, 1].map(index => ({ schema: "healthmd.test", schema_version: 1, sha256: String(index).repeat(64) })) }));
+  await assert.rejects(loadHealthData([references], { maxReferences: 1 }), /reference count/);
+});
+
+test("generic query reaches sensitive, platform, and provider paths without filtering domains", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-domains-"));
+  const file = join(directory, "contracts.json");
+  await writeFile(file, JSON.stringify({
+    mood: { state_of_mind: "calm" }, medications: [{ name: "synthetic" }], clinical: { record: "synthetic" },
+    reproductive: { cycle_day: 1 }, nutrition: { energy: 0 }, routes: [{ latitude: 0, longitude: 0 }],
+    platform: { android: { merge_provenance: "synthetic" } }, providers: { whoop: { hrv_rmssd_ms: 50 } },
+  }));
+  const store = await loadHealthData([file]);
+  for (const search of ["mood", "medications", "clinical", "reproductive", "nutrition", "routes", "platform.android", "providers.whoop"]) {
+    assert.ok(queryStore(store, { path: search, limit: 5 }).totalMatches > 0, `expected generic path ${search}`);
+  }
+});
+
+test("query output is bounded", async () => {
+  const store = await loadHealthData([join(fixtureDir, "apple-whoop.json")]);
+  const result = queryStore(store, { search: "whoop", limit: 10_000 });
+  assert.ok(result.matches.length <= 100);
+  formatEvidence(result);
+  assert.ok(result.evidenceBytes <= 24_000);
+  assert.equal(result.truncated, result.totalMatches > result.matches.length);
+});

--- a/packages/pi-healthmd-dashboard/test/extension.test.ts
+++ b/packages/pi-healthmd-dashboard/test/extension.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import healthmdDashboardExtension from "../src/extension.js";
+
+interface FakePi {
+  tools: Map<string, any>;
+  commands: Map<string, any>;
+  flags: Map<string, any>;
+  handlers: Map<string, any>;
+  registerTool(tool: any): void;
+  registerCommand(name: string, command: any): void;
+  registerFlag(name: string, flag: any): void;
+  getFlag(name: string): unknown;
+  on(event: string, handler: any): void;
+}
+
+function fakePi(flagValues: Record<string, unknown> = {}): FakePi {
+  const api: FakePi = {
+    tools: new Map(), commands: new Map(), flags: new Map(), handlers: new Map(),
+    registerTool(tool) { this.tools.set(tool.name, tool); },
+    registerCommand(name, command) { this.commands.set(name, command); },
+    registerFlag(name, flag) { this.flags.set(name, flag); },
+    getFlag(name) { return flagValues[name]; },
+    on(event, handler) { this.handlers.set(event, handler); },
+  };
+  return api;
+}
+
+test("registers tools, starts with the compact widget hidden, and synchronizes show/hide/reset", async () => {
+  const cache = await mkdtemp(join(tmpdir(), "healthmd-empty-cache-"));
+  const pi = fakePi({ "healthmd-cache-dir": cache });
+  healthmdDashboardExtension(pi as any);
+  assert.deepEqual([...pi.tools.keys()], ["healthmd_load", "healthmd_fetch", "healthmd_query", "healthmd_view"]);
+  assert.ok(pi.commands.has("healthmd"));
+  for (const flag of ["healthmd-data", "healthmd-cache-dir", "healthmd-cli-path", "healthmd-mcp-path", "healthmd-fetch-transport", "healthmd-device", "healthmd-port"]) assert.ok(pi.flags.has(flag));
+  const widgets: unknown[][] = [];
+  let dashboardLines: string[] = [], dashboardOptions: any;
+  const theme = { fg: (_color: string, text: string) => text, bg: (_color: string, text: string) => text, bold: (text: string) => text };
+  const ctx = { hasUI: true, mode: "tui", cwd: process.cwd(), ui: {
+    setWidget: (...args: unknown[]) => widgets.push(args), notify() {},
+    async custom(factory: any, options: any) { dashboardOptions = options; const component = factory({ requestRender() {} }, theme, {}, () => {}); dashboardLines = component.render(120); },
+  } };
+  await pi.handlers.get("session_start")({ type: "session_start", reason: "startup" }, ctx);
+  assert.equal(widgets.at(-1)?.[1], undefined);
+  await pi.commands.get("healthmd").handler("dashboard", ctx);
+  assert.match(dashboardLines.join("\n"), /Welcome to Health\.md/);
+  assert.match(dashboardLines.join("\n"), /30 days is recommended/);
+  assert.match(dashboardLines.join("\n"), /F fetch/);
+
+  const fixture = resolve(import.meta.dirname, "../../../packages/contracts/proposals/unified-health-data-v9/fixtures/apple-minimal.json");
+  await pi.commands.get("healthmd").handler(`load ${fixture}`, ctx);
+  assert.equal(widgets.at(-1)?.[1], undefined);
+  await pi.commands.get("healthmd").handler("dashboard", ctx);
+  assert.equal(dashboardOptions.overlay, true);
+  assert.match(dashboardLines.join("\n"), /interactive health evidence dashboard/);
+  assert.match(dashboardLines.join("\n"), /steps/i);
+
+  await pi.tools.get("healthmd_view").execute("show", { action: "show" }, undefined, undefined, ctx);
+  let shownFactory = widgets.at(-1)?.[1] as ((tui: unknown, theme: unknown) => { render(width: number): string[] });
+  assert.match(shownFactory({}, {}).render(80).join("\n"), /EXPERIMENTAL proposed v9 reader/);
+  assert.match(shownFactory({}, {}).render(80).join("\n"), /Coverage:/);
+  await pi.tools.get("healthmd_view").execute("hide", { action: "hide" }, undefined, undefined, ctx);
+  assert.equal(widgets.at(-1)?.[1], undefined);
+  await pi.tools.get("healthmd_view").execute("reset", { action: "reset" }, undefined, undefined, ctx);
+  assert.equal(widgets.at(-1)?.[1], undefined);
+  await pi.tools.get("healthmd_view").execute("show", { action: "show" }, undefined, undefined, ctx);
+  shownFactory = widgets.at(-1)?.[1] as ((tui: unknown, theme: unknown) => { render(width: number): string[] });
+  assert.match(shownFactory({}, {}).render(80).join("\n"), /Coverage:/);
+  await pi.commands.get("healthmd").handler("reset", ctx);
+  assert.equal(widgets.at(-1)?.[1], undefined);
+
+  for (const tool of pi.tools.values()) {
+    assert.ok(tool.promptGuidelines.some((line: string) => /diagnos/i.test(line)));
+    assert.ok(tool.promptGuidelines.some((line: string) => /WHOOP HRV/i.test(line)));
+  }
+});
+
+test("user-authored load command accepts an explicit path containing spaces", async () => {
+  const pi = fakePi();
+  healthmdDashboardExtension(pi as any);
+  const directory = await mkdtemp(join(tmpdir(), "healthmd path with spaces "));
+  const file = join(directory, "daily export.json");
+  await writeFile(file, JSON.stringify({ date: "2026-01-01", type: "health-data", steps: 1 }));
+  const notifications: string[] = [];
+  const ctx = { hasUI: true, mode: "tui", cwd: process.cwd(), ui: { setWidget() {}, notify(message: string) { notifications.push(message); } } };
+  await pi.commands.get("healthmd").handler(`load ${file}`, ctx);
+  assert.match(notifications.at(-1) ?? "", /1 documents/);
+});
+
+test("healthmd_fetch uses configured CLI and makes its response queryable in memory", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-extension-fetch-"));
+  const executable = join(directory, "healthmd");
+  const digest = "a".repeat(64);
+  const response = { schema: "healthmd.query_response", schema_version: 1, items: [{ type: "metric", metric: { metric_id: "steps", display_name: "Steps", owner_date: "2026-03-15", status: "available", value: { type: "count", value: 123 }, evidence: [{ evidence_id: "steps-evidence", locator: { type: "summary_key", owner_date: "2026-03-15", key: "steps" }, source_id: "apple_health", source: { schema: "healthmd.health_data", schema_version: 8, digest } }], limitations: [] } }], coverage: { status: "available", days_considered: 1, days_with_values: 1, missing: [] }, sources: [], evidence: [], limitations: [], next_cursor: null };
+  await writeFile(executable, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(JSON.stringify(response))});\n`);
+  await chmod(executable, 0o755);
+  const cache = join(directory, "cache");
+  const flags = { "healthmd-cli-path": executable, "healthmd-fetch-transport": "cli", "healthmd-cache-dir": cache };
+  const pi = fakePi(flags);
+  healthmdDashboardExtension(pi as any);
+  const ctx = { hasUI: false, mode: "print", cwd: process.cwd(), ui: { setWidget() { throw new Error("TUI used in print mode"); } } };
+  await pi.handlers.get("session_start")({ type: "session_start", reason: "startup" }, ctx);
+  const fetched = await pi.tools.get("healthmd_fetch").execute("fetch", { operation: "healthmd_metric_chart", arguments: { dates: { type: "all_available" }, metrics: { type: "explicit", metric_ids: ["steps"] } } }, undefined, undefined, ctx);
+  assert.match(fetched.content[0].text, /healthmd-cli/);
+  assert.match(fetched.content[0].text, /cache/);
+  const queried = await pi.tools.get("healthmd_query").execute("query", { metric: "steps", limit: 20 }, undefined, undefined, ctx);
+  assert.match(queried.content[0].text, /apple_health/);
+  assert.match(queried.content[0].text, /123/);
+
+  const manifestPath = join(cache, "healthmd-cache.json"), validManifest = await readFile(manifestPath, "utf8"), revised: any = structuredClone(response);
+  revised.items[0].metric.value.value = 999;
+  await writeFile(executable, `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(JSON.stringify(revised))});\n`);
+  await chmod(executable, 0o755);
+  await writeFile(manifestPath, "{invalid");
+  await assert.rejects(pi.tools.get("healthmd_fetch").execute("fetch-atomic", { operation: "healthmd_metric_chart", arguments: { dates: { type: "all_available" }, metrics: { type: "explicit", metric_ids: ["steps"] } } }, undefined, undefined, ctx));
+  const afterFailedCache = await pi.tools.get("healthmd_query").execute("query-atomic", { metric: "steps", limit: 20 }, undefined, undefined, ctx);
+  assert.match(afterFailedCache.content[0].text, /123/);
+  assert.doesNotMatch(afterFailedCache.content[0].text, /999/);
+  await writeFile(manifestPath, validManifest);
+
+  const restored = fakePi(flags);
+  healthmdDashboardExtension(restored as any);
+  await restored.handlers.get("session_start")({ type: "session_start", reason: "startup" }, ctx);
+  const restoredQuery = await restored.tools.get("healthmd_query").execute("query", { metric: "steps", limit: 20 }, undefined, undefined, ctx);
+  assert.match(restoredQuery.content[0].text, /123/);
+});
+
+test("headless slash-command fetch failures are not swallowed", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-extension-failed-fetch-"));
+  const executable = join(directory, "healthmd");
+  await writeFile(executable, `#!/usr/bin/env node\nprocess.stdout.write(JSON.stringify({error:"healthmd_unavailable",message:"No paired source."})); process.exitCode=1;\n`);
+  await chmod(executable, 0o755);
+  const pi = fakePi({ "healthmd-cli-path": executable, "healthmd-fetch-transport": "cli" });
+  healthmdDashboardExtension(pi as any);
+  const ctx = { hasUI: false, mode: "rpc", cwd: process.cwd(), ui: { setWidget() {} } };
+  await assert.rejects(pi.commands.get("healthmd").handler(`fetch healthmd_metric_chart {}`, ctx), /healthmd_unavailable: No paired source/);
+});
+
+test("extension implementation never invokes confirmation or custom-entry persistence", async () => {
+  const source = await readFile(resolve(import.meta.dirname, "../src/extension.ts"), "utf8");
+  assert.doesNotMatch(source, /\.confirm\s*\(/);
+  assert.doesNotMatch(source, /appendEntry|customType|sendMessage/);
+});
+
+test("tools load/query/view in print mode without touching TUI", async () => {
+  const pi = fakePi();
+  healthmdDashboardExtension(pi as any);
+  const fixture = resolve(import.meta.dirname, "../../../packages/contracts/proposals/unified-health-data-v9/fixtures/apple-minimal.json");
+  const ctx = { hasUI: false, mode: "print", cwd: process.cwd(), ui: { setWidget() { throw new Error("TUI used in print mode"); } } };
+  await pi.commands.get("healthmd").handler(`load ${fixture}`, ctx);
+  const loaded = await pi.tools.get("healthmd_load").execute("1", { paths: [fixture] }, undefined, undefined, ctx);
+  assert.match(loaded.content[0].text, /proposed v9 readers 1/);
+  assert.ok(Buffer.byteLength(loaded.content[0].text, "utf8") < 50_000);
+  assert.deepEqual(loaded.details, { bounded: true, chars: loaded.content[0].text.length, bytes: Buffer.byteLength(loaded.content[0].text, "utf8") });
+  const queried = await pi.tools.get("healthmd_query").execute("2", { metric: "steps", limit: 5 }, undefined, undefined, ctx);
+  assert.match(queried.content[0].text, /steps/);
+  const viewed = await pi.tools.get("healthmd_view").execute("3", { action: "select", target: "steps", targetKind: "metric" }, undefined, undefined, ctx);
+  assert.match(viewed.content[0].text, /steps/);
+});

--- a/packages/pi-healthmd-dashboard/test/full-dashboard.test.ts
+++ b/packages/pi-healthmd-dashboard/test/full-dashboard.test.ts
@@ -1,0 +1,336 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { visibleWidth } from "@earendil-works/pi-tui";
+import { buildFullDashboardModel, FullDashboardComponent, renderFullDashboard, type FullDashboardState } from "../src/dashboard.js";
+import { loadHealthData, loadHealthDataText } from "../src/loader.js";
+
+const fixture = resolve(import.meta.dirname, "../../../apps/apple/docs/reference/generated/automation/agent-query-response.json");
+const theme = {
+  fg: (_color: string, text: string) => text,
+  bg: (_color: string, text: string) => text,
+  bold: (text: string) => text,
+} as any;
+
+test("full dashboard builds semantic metric cards and width-safe visualizations from typed query evidence", async () => {
+  const store = await loadHealthData([fixture]);
+  const model = buildFullDashboardModel(store);
+  assert.equal(model.itemCount, 1);
+  assert.equal(model.metrics.length, 1);
+  assert.equal(model.availableCount, 1);
+  assert.equal(model.metrics[0]?.id, "steps");
+  assert.equal(model.metrics[0]?.name, "Steps");
+  assert.equal(model.metrics[0]?.points[0]?.value, 12_345);
+  const state: FullDashboardState = { screen: "overview", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 };
+  for (const width of [60, 100, 160]) {
+    const lines = renderFullDashboard(model, state, width, theme);
+    assert.ok(lines.length >= 28);
+    assert.ok(lines.every(line => visibleWidth(line) <= width), `line overflow at ${width}`);
+    const rendered = lines.join("\n");
+    assert.match(rendered, /interactive health evidence dashboard/);
+    assert.match(rendered, /Steps/);
+    assert.match(rendered, /12,345/);
+    assert.match(rendered, /Summary/);
+    assert.match(rendered, /1 observation/);
+    if (width >= 100) assert.match(rendered, /Trend setup · 1 dated day loaded/);
+  }
+  for (const [width, height] of [[1, 4], [8, 8], [19, 10], [60, 12], [100, 20]] as const) {
+    const lines = renderFullDashboard(model, state, width, theme, height);
+    assert.ok(lines.length <= height);
+    assert.ok(lines.every(line => visibleWidth(line) <= width), `responsive overflow at ${width}x${height}`);
+  }
+});
+
+test("full dashboard renders connected unit-aware trends instead of isolated dots", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-full-dashboard-trend-"));
+  const file = join(directory, "trend.json");
+  await writeFile(file, JSON.stringify({ metrics: [3600, 5400, 4500].map((value, index) => ({ owner_date: `2026-01-0${index + 1}`, semantic_id: "sleep_total", display_name: "Total Sleep", unit: "s", number: value })) }));
+  const model = buildFullDashboardModel(await loadHealthData([file]));
+  const state: FullDashboardState = { screen: "metric", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 };
+  const rendered = renderFullDashboard(model, state, 120, theme).join("\n");
+  assert.match(rendered, /Latest 1h 15m 0s/);
+  assert.match(rendered, /Observed average 1h 15m 0s/);
+  assert.match(rendered, /[\u2801-\u28ff]/);
+  assert.match(rendered, /2026-01-01.*2026-01-03/);
+  assert.match(rendered, /AUTO→LINE/);
+  assert.match(rendered, /Selected 2026-01-03/);
+  assert.doesNotMatch(rendered, /snapshot, not a trend/);
+  state.chartMode = "bar";
+  const bars = renderFullDashboard(model, state, 120, theme).join("\n");
+  assert.match(bars, /Relative bars for 3 visible observations/);
+  assert.match(bars, /2026-01-01.*█.*1h 0m 0s/);
+});
+
+test("summary provides period comparisons and identity-safe sleep/activity views", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-full-dashboard-summary-"));
+  const file = join(directory, "summary.json");
+  const steps = Array.from({ length: 14 }, (_, index) => ({ owner_date: `2026-01-${String(index + 1).padStart(2, "0")}`, semantic_id: "steps", display_name: "Steps", unit: "steps", number: index < 7 ? 100 : 110 }));
+  const stages = [["sleep_total", "Total Sleep", 14400], ["sleep_deep", "Deep Sleep", 3600], ["sleep_core", "Core Sleep", 7200], ["sleep_rem", "REM Sleep", 3600], ["sleep_awake", "Awake", 1800]].map(([semantic_id, display_name, number]) => ({ owner_date: "2026-01-14", semantic_id, display_name, unit: "s", number }));
+  await writeFile(file, JSON.stringify({ metrics: [...steps, ...stages] }));
+  const model = buildFullDashboardModel(await loadHealthData([file]));
+  const state: FullDashboardState = { screen: "overview", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 };
+  const rendered = renderFullDashboard(model, state, 160, theme, 38).join("\n");
+  assert.match(rendered, /↑ 10% vs prior 7d/);
+  assert.match(rendered, /Sleep composition · 2026-01-14/);
+  assert.match(rendered, /Deep 22%.*Core 44%.*REM 22%.*Awake 11%/);
+  assert.match(rendered, /Latest activity observations · independent identities/);
+  assert.match(rendered, /Steps.*2026-01-14.*source retained/);
+  const rem = model.metrics.find(metric => metric.id === "sleep_rem")!;
+  rem.comparisonIdentity = `${rem.comparisonIdentity}-incompatible`;
+  assert.doesNotMatch(renderFullDashboard(model, state, 160, theme, 38).join("\n"), /Sleep composition/);
+
+  const hoursFile = join(directory, "hours.json");
+  const hourStages = [["sleep_total", 8], ["sleep_deep", 2], ["sleep_core", 4], ["sleep_rem", 2], ["sleep_awake", 1]].map(([semantic_id, number]) => ({ owner_date: "2026-01-14", semantic_id, unit: "h", number }));
+  await writeFile(hoursFile, JSON.stringify({ metrics: hourStages }));
+  const hoursModel = buildFullDashboardModel(await loadHealthData([hoursFile]));
+  const hoursRendered = renderFullDashboard(hoursModel, state, 160, theme, 38).join("\n");
+  assert.match(hoursRendered, /Sleep composition.*[\s\S]*9 h/);
+  const pieRendered = renderFullDashboard(hoursModel, { ...state, domain: "Sleep" }, 160, theme, 38).join("\n");
+  assert.match(pieRendered, /Sleep composition/);
+  assert.match(pieRendered, /████|▓▓|▒▒|░░/);
+  assert.match(pieRendered, /█ Deep 22%.*▓ Core 44%.*▒ REM 22%.*░ Awake 11%/);
+  assert.doesNotMatch(hoursRendered, /9s/);
+  const constrained = renderFullDashboard(hoursModel, { ...state, domain: "Sleep" }, 160, theme, 20).join("\n");
+  assert.match(constrained, /█ Deep 22%.*▓ Core 44%.*▒ REM 22%.*░ Awake 11%/);
+  assert.doesNotMatch(constrained, /Total 9 h/);
+  const totalSeries = hoursModel.metrics.find(metric => metric.id === "sleep_total")!;
+  hoursModel.metrics.push({ ...totalSeries, key: "unsafe-summary", id: "unsafe", name: "Unsafe", domain: "Other", points: [{ date: "2026-01-14", display: "18446744073709551615", status: "available", numericExpected: true }] });
+  const unsafeBoundary = renderFullDashboard(hoursModel, { ...state, domain: "Sleep" }, 160, theme, 29).join("\n");
+  assert.match(unsafeBoundary, /█ Deep 22%.*▓ Core 44%.*▒ REM 22%.*░ Awake 11%/);
+  assert.doesNotMatch(unsafeBoundary, /Total 9 h/);
+  hoursModel.metrics.pop();
+  const deep = hoursModel.metrics.find(metric => metric.id === "sleep_deep")!, core = hoursModel.metrics.find(metric => metric.id === "sleep_core")!;
+  deep.points[0]!.value = 0; core.points[0]!.value = 6;
+  const zeroPie = renderFullDashboard(hoursModel, { ...state, domain: "Sleep" }, 160, theme, 38).join("\n");
+  assert.match(zeroPie, /█ Deep 0%/);
+  assert.doesNotMatch(zeroPie, /██/);
+  deep.points[0]!.value = -1;
+  assert.doesNotMatch(renderFullDashboard(hoursModel, state, 160, theme, 38).join("\n"), /Sleep composition/);
+  deep.points[0]!.value = 2; deep.points[0]!.status = "failed"; core.points[0]!.value = 4;
+  assert.doesNotMatch(renderFullDashboard(hoursModel, state, 160, theme, 38).join("\n"), /Sleep composition/);
+});
+
+test("sparse windows are not promoted to seven-day comparisons or trends", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-full-dashboard-sparse-"));
+  const file = join(directory, "sparse.json");
+  await writeFile(file, JSON.stringify({ metrics: [
+    { owner_date: "2026-01-01", semantic_id: "steps", display_name: "Steps", unit: "steps", number: 100 },
+    { owner_date: "2026-01-08", semantic_id: "steps", display_name: "Steps", unit: "steps", number: 110 },
+  ] }));
+  const model = buildFullDashboardModel(await loadHealthData([file]));
+  const state: FullDashboardState = { screen: "overview", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 };
+  const rendered = renderFullDashboard(model, state, 160, theme).join("\n");
+  assert.equal(model.chartableCount, 0);
+  assert.match(rendered, /2 disconnected observations/);
+  assert.match(rendered, /Insufficient coverage • now 1\/7 · prior 1\/7/);
+  assert.doesNotMatch(rendered, /% vs prior 7d/);
+  const sparseDetail = renderFullDashboard(model, { ...state, screen: "metric" }, 120, theme).join("\n");
+  assert.match(sparseDetail, /AUTO→BAR/);
+  assert.match(sparseDetail, /Relative bars for 2 visible observations/);
+
+  const invalidFile = join(directory, "invalid-date.json");
+  await writeFile(invalidFile, JSON.stringify({ metrics: [
+    { owner_date: "2026-01-01", semantic_id: "steps", unit: "steps", number: 100 },
+    { owner_date: "2026-01-02", semantic_id: "steps", unit: "steps", number: 110 },
+    { semantic_id: "steps", unit: "steps", number: 120 },
+  ] }));
+  const invalidModel = buildFullDashboardModel(await loadHealthData([invalidFile]));
+  assert.equal(invalidModel.chartableCount, 0);
+  const invalidDetail = renderFullDashboard(invalidModel, { ...state, screen: "metric" }, 120, theme).join("\n");
+  assert.match(invalidDetail, /Trend unavailable: series contains an undated or invalid-date observation/);
+
+  const mixedFile = join(directory, "mixed-window.json");
+  await writeFile(mixedFile, JSON.stringify({ metrics: ["01", "02", "10", "20"].map((day, index) => ({ owner_date: `2026-01-${day}`, semantic_id: "steps", unit: "steps", number: 100 + index })) }));
+  const mixedModel = buildFullDashboardModel(await loadHealthData([mixedFile]));
+  assert.equal(mixedModel.chartableCount, 1);
+  const disconnectedWindow = renderFullDashboard(mixedModel, { ...state, screen: "metric", pointWindow: 2 }, 120, theme).join("\n");
+  assert.match(disconnectedWindow, /AUTO→BAR/);
+  assert.match(disconnectedWindow, /Relative bars for 2 visible observations/);
+  const onePointWindow = renderFullDashboard(mixedModel, { ...state, screen: "metric", pointWindow: 1 }, 120, theme).join("\n");
+  assert.match(onePointWindow, /AUTO→SNAPSHOT/);
+});
+
+test("full dashboard handles mixed finite extremes and preserves non-observed statuses", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-full-dashboard-extremes-"));
+  const extremesFile = join(directory, "extremes.json");
+  await writeFile(extremesFile, JSON.stringify({ metrics: [
+    { owner_date: "2026-01-01", semantic_id: "x", unit: "count", number: -Number.MAX_VALUE },
+    { owner_date: "2026-01-02", semantic_id: "x", unit: "count", number: Number.MAX_VALUE },
+  ] }));
+  const extremes = buildFullDashboardModel(await loadHealthData([extremesFile]));
+  for (const chartMode of ["line", "bar"] as const) {
+    const lines = renderFullDashboard(extremes, { screen: "metric", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0, chartMode }, 120, theme);
+    assert.ok(lines.every(line => visibleWidth(line) <= 120));
+    const rendered = lines.join("\n");
+    assert.match(rendered, chartMode === "line" ? /Selected 2026-01-02/ : /Relative bars/);
+    assert.doesNotMatch(rendered, /NaN|Infinity/);
+  }
+
+  const statusResponse = { schema: "healthmd.query_response", schema_version: 1, items: [
+    { type: "metric", metric: { metric_id: "x", display_name: "X", owner_date: "2026-01-01", value: { type: "count", value: 100 }, status: "available", evidence: [], limitations: [] } },
+    { type: "metric", metric: { metric_id: "x", display_name: "X", owner_date: "2026-01-02", value: { type: "count", value: 999 }, status: "failed", evidence: [], limitations: [] } },
+  ], coverage: { status: "partial", days_considered: 2, days_with_values: 1, requested_range: { start_date: "2026-01-01", end_date: "2026-01-02" }, available_range: { start_date: "2026-01-01", end_date: "2026-01-01" }, missing: [{ range: { start_date: "2026-01-02", end_date: "2026-01-02" }, status: "failed", reason: "source_failed" }], missing_interval_count: 1, missing_truncated: false }, sources: [], evidence: [], limitations: [], next_cursor: null };
+  const statusModel = buildFullDashboardModel(loadHealthDataText([{ path: "healthmd-mcp://status", text: JSON.stringify(statusResponse), origin: "healthmd-mcp", operation: "healthmd_metric_chart" }]));
+  const statusRendered = renderFullDashboard(statusModel, { screen: "metric", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 }, 120, theme).join("\n");
+  assert.match(statusRendered, /Latest 999 count.*failed/);
+  assert.match(statusRendered, /healthmd\.query_response@1.*healthmd-mcp.*healthmd_metric_chart/);
+  assert.match(statusRendered, /Most recent observed 100 count.*2026-01-01/);
+  assert.doesNotMatch(statusRendered, /Average.*549/);
+  const statusOverview = renderFullDashboard(statusModel, { screen: "overview", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 }, 120, theme).join("\n");
+  assert.match(statusOverview, /Selected · Other.*999 count.*failed/);
+});
+
+test("newest fetched revision wins for the same identity and owner date", () => {
+  const response = (value: number) => ({ schema: "healthmd.query_response", schema_version: 1, items: [{ type: "metric", metric: { metric_id: "steps", display_name: "Steps", owner_date: "2026-01-01", value: { type: "count", value }, status: "available", evidence: [], limitations: [] } }], coverage: { status: "available", days_considered: 1, days_with_values: 1, requested_range: { start_date: "2026-01-01", end_date: "2026-01-01" }, available_range: { start_date: "2026-01-01", end_date: "2026-01-01" }, missing: [], missing_interval_count: 0, missing_truncated: false }, sources: [], evidence: [], limitations: [], next_cursor: null });
+  const model = buildFullDashboardModel(loadHealthDataText([
+    { path: "healthmd-cache://new", text: JSON.stringify(response(200)), origin: "healthmd-mcp", operation: "healthmd_metric_chart" },
+    { path: "healthmd-cache://old", text: JSON.stringify(response(100)), origin: "healthmd-mcp", operation: "healthmd_metric_chart" },
+  ]));
+  assert.equal(model.metrics[0]?.points.length, 1);
+  assert.equal(model.metrics[0]?.points[0]?.value, 200);
+});
+
+test("available and domain filters drive grouped metric navigation", async () => {
+  const store = await loadHealthData([fixture]);
+  const model = buildFullDashboardModel(store), base = model.metrics[0]!;
+  model.metrics.push({ ...base, key: "sleep-unavailable", id: "sleep_total", name: "Total Sleep", domain: "Sleep", statuses: ["unsupported"], points: [{ date: "2026-03-15", display: "—", status: "unsupported", numericExpected: false }] });
+  const state: FullDashboardState = { screen: "metric", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0, availableOnly: true, domain: "All" };
+  assert.doesNotMatch(renderFullDashboard(model, state, 120, theme).join("\n"), /Total Sleep/);
+  state.availableOnly = false;
+  assert.match(renderFullDashboard(model, state, 120, theme).join("\n"), /Total Sleep/);
+  state.domain = "Sleep";
+  state.selected = 1;
+  assert.match(renderFullDashboard(model, state, 120, theme).join("\n"), /Sleep · all \(1\)/);
+  state.screen = "overview";
+  const narrow = renderFullDashboard(model, state, 80, theme).join("\n");
+  assert.match(narrow, /navigation all \/ Sleep/);
+  assert.match(narrow, /Selected · Sleep.*Total Sleep/);
+  assert.doesNotMatch(narrow, /Latest activity observations/);
+});
+
+test("dashboard fetch menu launches bounded trend presets", async () => {
+  const store = await loadHealthData([fixture]);
+  let request: { days: number; ids: string[] } | undefined;
+  const component = new FullDashboardComponent({ requestRender() {} }, theme, () => store, () => {}, () => 30, async (days, ids) => { request = { days, ids }; });
+  component.handleInput("f");
+  assert.match(component.render(120).join("\n"), /Fetch trend data/);
+  component.handleInput("2");
+  await new Promise(resolve => setImmediate(resolve));
+  assert.deepEqual(request, { days: 30, ids: ["steps"] });
+  assert.match(component.render(120).join("\n"), /Fetched 30 days/);
+
+  let firstRunIds: string[] = [];
+  const empty = new FullDashboardComponent({ requestRender() {} }, theme, () => undefined, () => {}, () => 30, async (_days, ids) => { firstRunIds = ids; });
+  assert.match(empty.render(120).join("\n"), /Welcome to Health\.md/);
+  empty.handleInput("\r");
+  assert.match(empty.render(120).join("\n"), /Fetch trend data/);
+  empty.handleInput("\x1b");
+  empty.handleInput("f"); empty.handleInput("1");
+  await new Promise(resolve => setImmediate(resolve));
+  assert.ok(firstRunIds.includes("steps") && firstRunIds.includes("sleep_total") && firstRunIds.length <= 32);
+
+  const cancellable = new FullDashboardComponent({ requestRender() {} }, theme, () => store, () => {}, () => 30, async (_days, _ids, signal) => new Promise((_resolve, reject) => signal.addEventListener("abort", () => reject(new Error("cancelled")), { once: true })));
+  cancellable.handleInput("f"); cancellable.handleInput("1"); cancellable.handleInput("\x1b");
+  await new Promise(resolve => setImmediate(resolve));
+  assert.match(cancellable.render(120).join("\n"), /Fetch cancelled/);
+});
+
+test("full dashboard refuses a series containing unsafe exact numeric evidence", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-full-dashboard-exact-"));
+  const file = join(directory, "exact.json");
+  await writeFile(file, JSON.stringify({ metrics: [
+    { owner_date: "2026-01-01", semantic_id: "x", unit: "count", number: { representation: "unsigned_integer", decimal: "1" } },
+    { owner_date: "2026-01-02", semantic_id: "x", unit: "count", number: { representation: "unsigned_integer", decimal: "18446744073709551615" } },
+  ] }));
+  const model = buildFullDashboardModel(await loadHealthData([file]));
+  const state: FullDashboardState = { screen: "metric", selected: 0, pointWindow: 1, pointOffset: 1, recordOffset: 0 };
+  const rendered = renderFullDashboard(model, state, 120, theme).join("\n");
+  assert.match(rendered, /Latest 18446744073709551615/);
+  assert.match(rendered, /Chart refused: series contains an unsafe exact numeric value/);
+  assert.equal(model.chartableCount, 0);
+  state.screen = "overview";
+  const overview = renderFullDashboard(model, state, 120, theme).join("\n");
+  assert.match(overview, /⚠ unsafe exact: 1 series retained but not charted/);
+
+  const partialText = `{"schema":"healthmd.query_response","schema_version":1,"items":[{"type":"metric","metric":{"metric_id":"x","display_name":"X","owner_date":"2026-01-03","value":{"type":"quantity","value":9223372036854775807,"unit":"count"},"status":"partial","evidence":[],"limitations":[]}}],"coverage":{"status":"partial","days_considered":1,"days_with_values":1,"requested_range":{"start_date":"2026-01-03","end_date":"2026-01-03"},"available_range":{"start_date":"2026-01-03","end_date":"2026-01-03"},"missing":[],"missing_interval_count":0,"missing_truncated":false},"sources":[],"evidence":[],"limitations":[],"next_cursor":null}`;
+  const partialModel = buildFullDashboardModel(loadHealthDataText([{ path: "healthmd-mcp://partial", text: partialText, origin: "healthmd-mcp", operation: "healthmd_metric_chart" }]));
+  assert.equal(partialModel.metrics[0]?.points[0]?.status, "partial");
+  assert.equal(partialModel.chartableCount, 0);
+  assert.match(renderFullDashboard(partialModel, { ...state, screen: "metric", pointOffset: 0 }, 120, theme).join("\n"), /Chart refused/);
+});
+
+test("full dashboard exposes canonical coverage and non-metric typed records", () => {
+  const response = { schema: "healthmd.query_response", schema_version: 1, items: [{ type: "workout", workout: { workout_id: "w1", activity: "Running", start: "2026-08-13T08:00:00Z", end: "2026-08-13T09:00:00Z", details: {}, evidence_ids: [] } }], coverage: { status: "partial", days_considered: 1, days_with_values: 0, requested_range: { start_date: "2026-08-13", end_date: "2026-08-13" }, available_range: null, missing: [{ range: { start_date: "2026-08-13", end_date: "2026-08-13" }, status: "unavailable", reason: "not_recorded" }], missing_interval_count: 1, missing_truncated: false }, sources: [], evidence: [], limitations: [], next_cursor: null };
+  const model = buildFullDashboardModel(loadHealthDataText([{ path: "healthmd-mcp://workout", text: JSON.stringify(response), origin: "healthmd-mcp", operation: "healthmd_workouts" }]));
+  assert.equal(model.typedItemCount, 1);
+  assert.equal(model.typedItems[0]?.label, "Running");
+  assert.deepEqual(model.coverage.statuses, ["partial"]);
+  assert.equal(model.coverage.missingIntervals, 1);
+  const truncated: any = structuredClone(response);
+  truncated.coverage.missing_interval_count = 7; truncated.coverage.missing_truncated = true;
+  const truncatedModel = buildFullDashboardModel(loadHealthDataText([{ path: "healthmd-mcp://truncated", text: JSON.stringify(truncated), origin: "healthmd-mcp", operation: "healthmd_workouts" }]));
+  assert.equal(truncatedModel.coverage.missingIntervals, 7);
+  const compactCoverage = renderFullDashboard(truncatedModel, { screen: "coverage", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 }, 120, theme, 20).join("\n");
+  assert.match(compactCoverage, /Missing\s+7 total • details truncated/);
+  assert.match(compactCoverage, /Sources.*Origins.*Contracts/s);
+  const state: FullDashboardState = { screen: "records", selected: 0, pointWindow: 30, pointOffset: 0, recordOffset: 0 };
+  assert.match(renderFullDashboard(model, state, 120, theme).join("\n"), /Running/);
+  state.screen = "coverage";
+  assert.match(renderFullDashboard(model, state, 120, theme).join("\n"), /partial.*0\/1 days with values/);
+
+  const wider: any = structuredClone(response);
+  wider.items = [];
+  wider.coverage = { status: "partial", days_considered: 3, days_with_values: 2, requested_range: { start_date: "2026-08-12", end_date: "2026-08-14" }, available_range: { start_date: "2026-08-12", end_date: "2026-08-13" }, missing: [{ range: { start_date: "2026-08-14", end_date: "2026-08-14" }, status: "unavailable", reason: "not_recorded" }], missing_interval_count: 1, missing_truncated: false };
+  const merged = buildFullDashboardModel(loadHealthDataText([
+    { path: "healthmd-mcp://workout", text: JSON.stringify(response), origin: "healthmd-mcp", operation: "healthmd_workouts" },
+    { path: "healthmd-mcp://wider", text: JSON.stringify(wider), origin: "healthmd-mcp", operation: "healthmd_metric_chart" },
+  ]));
+  assert.equal(merged.coverage.daysConsidered, 3);
+  assert.equal(merged.coverage.daysWithValues, 2);
+  assert.equal(merged.coverage.requestedRange, "2026-08-12..2026-08-14");
+});
+
+test("dashboard supports direct domains, metric search, and contextual help", async () => {
+  const store = await loadHealthData([fixture]);
+  const component = new FullDashboardComponent({ requestRender() {} }, theme, () => store, () => {});
+  component.handleInput("?");
+  assert.match(component.render(120).join("\n"), /Dashboard help.*1–8.*Search metric/s);
+  component.handleInput("?");
+  component.handleInput("/");
+  for (const character of "steps") component.handleInput(character);
+  assert.match(component.render(120).join("\n"), /Search metrics.*steps.*1 matching metric/s);
+  component.handleInput("\r");
+  assert.match(component.render(120).join("\n"), /search “steps”/);
+  component.handleInput("\x15");
+  assert.doesNotMatch(component.render(120).join("\n"), /search “steps”/);
+  component.handleInput("/");
+  component.handleInput("\x1b[200~Steps\x1b[201~");
+  assert.match(component.render(120).join("\n"), /Search metrics.*Steps.*1 matching metric/s);
+  component.handleInput("\r");
+  component.handleInput("2");
+  assert.match(component.render(120).join("\n"), /navigation available \/ Activity/);
+  component.handleInput("3");
+  assert.match(component.render(120).join("\n"), /navigation available \/ Sleep/);
+});
+
+test("full dashboard keyboard navigation switches screens and refreshes", async () => {
+  const store = await loadHealthData([fixture]);
+  let renders = 0, closed = false;
+  const component = new FullDashboardComponent({ requestRender: () => { renders++; } }, theme, () => store, () => { closed = true; });
+  component.handleInput("d");
+  assert.match(component.render(120).join("\n"), /Snapshot/);
+  component.handleInput("v");
+  assert.match(component.render(120).join("\n"), /BAR/);
+  component.handleInput("v");
+  assert.match(component.render(120).join("\n"), /LINE/);
+  component.handleInput("v");
+  assert.match(component.render(120).join("\n"), /AUTO→SNAPSHOT/);
+  component.handleInput("\x1b[99;2u"); // Kitty protocol Shift+C
+  assert.match(component.render(120).join("\n"), /Coverage & provenance/);
+  component.handleInput("r");
+  assert.ok(renders >= 3);
+  component.handleInput("\x1b");
+  assert.equal(closed, true);
+});

--- a/packages/pi-healthmd-dashboard/test/output-dashboard.test.ts
+++ b/packages/pi-healthmd-dashboard/test/output-dashboard.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { createController } from "../src/extension.js";
+import { jsonStringify, utf8ByteLength } from "../src/json.js";
+import { loadHealthData } from "../src/loader.js";
+import { initialView } from "../src/model.js";
+import { formatEvidence, queryStore } from "../src/query.js";
+import { renderDashboard, selectedEntries, visibleWidth } from "../src/render.js";
+import { updateView } from "../src/view.js";
+
+const repo = resolve(import.meta.dirname, "../../..");
+
+test("actual formatted query result including provenance is strictly within 24k", async () => {
+  const store = await loadHealthData([join(repo, "packages/contracts/proposals/unified-health-data-v9/fixtures/apple-whoop.json")]);
+  const formatted = formatEvidence(queryStore(store, { limit: 100 }));
+  assert.ok(utf8ByteLength(jsonStringify(formatted)) <= 24_000);
+  assert.ok("omittedForSize" in formatted);
+});
+
+test("load result shape used by controller can be bounded below Pi limit", async () => {
+  const controller = createController();
+  await controller.approveAndLoad([join(repo, "packages/contracts/proposals/unified-health-data-v9/fixtures")]);
+  const query = controller.query({ limit: 100 });
+  assert.ok(utf8ByteLength(jsonStringify(query)) <= 24_000);
+});
+
+test("structured Unicode evidence is previewed without defeating byte bounds", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-unicode-bound-"));
+  const file = join(dir, "unicode.json");
+  await writeFile(file, JSON.stringify({ records: Array.from({ length: 500 }, (_, index) => ({ index, note: "健康🫀".repeat(500) })) }));
+  const store = await loadHealthData([file]);
+  const result = queryStore(store, { path: "$", limit: 100 });
+  const formatted = formatEvidence(result);
+  assert.ok(result.evidenceBytes <= 24_000);
+  assert.ok(utf8ByteLength(jsonStringify(formatted)) <= 24_000);
+  assert.ok(queryStore(store, { search: "健康🫀", limit: 5 }).totalMatches > 0);
+});
+
+test("provider path/search targets chart and mixed provider/unit series refuse misleading scale", async () => {
+  const store = await loadHealthData([join(repo, "apps/apple/docs/reference/generated/core/provider-day.json")]);
+  let view = updateView(initialView(), { action: "select", target: "hrv_rmssd_ms", targetKind: "path" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(store, view, 100).join("\n"), /█/);
+  let broad = updateView(initialView(), { action: "select", target: "whoop", targetKind: "search" });
+  broad = updateView(broad, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(store, broad, 100).join("\n"), /mixed contract\/schema\/path\/unit\/statistic\/provider\/platform/);
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-mixed-"));
+  const file = join(dir, "mixed.json");
+  await writeFile(file, JSON.stringify({ providers: { whoop: [{ date: "2026-01-01", unit: "ms", value: 1 }], other: [{ date: "2026-01-02", unit: "seconds", value: 2 }] } }));
+  const mixed = await loadHealthData([file]);
+  view = updateView(initialView(), { action: "select", target: ".value", targetKind: "path" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(mixed, view, 100).join("\n"), /mixed contract\/schema\/path\/unit\/statistic\/provider\/platform/);
+});
+
+test("charts refuse mixed safe/unsafe exact values and cross-contract series", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-chart-safety-"));
+  const exact = join(dir, "exact.json");
+  await writeFile(exact, JSON.stringify({ metrics: [
+    { owner_date: "2026-01-01", semantic_id: "x", statistic: "latest", unit: "count", number: { representation: "unsigned_integer", decimal: "1" } },
+    { owner_date: "2026-01-02", semantic_id: "x", statistic: "latest", unit: "count", number: { representation: "unsigned_integer", decimal: "18446744073709551615" } },
+  ] }));
+  let store = await loadHealthData([exact]);
+  let view = updateView(initialView(), { action: "select", target: "x", targetKind: "metric" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(store, view, 100).join("\n"), /unsafe exact values.*table fallback/i);
+
+  const apple = join(dir, "apple.json"), android = join(dir, "android.json");
+  const record = { owner_date: "2026-01-01", semantic_id: "x", statistic: "latest", unit: "count", value: 1 };
+  await writeFile(apple, JSON.stringify({ schema: "healthmd.health_data", schema_version: 8, records: [record] }));
+  await writeFile(android, JSON.stringify({ type: "health-data", records: [{ ...record, owner_date: "2026-01-02" }] }));
+  store = await loadHealthData([apple, android]);
+  view = updateView(initialView(), { action: "select", target: "x", targetKind: "metric" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(store, view, 100).join("\n"), /mixed contract\/schema\/path\/unit\/statistic\/provider\/platform/);
+});
+
+test("charts retain exact schema identity within the same generic contract kind", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-schema-series-"));
+  const first = join(dir, "v1.json"), second = join(dir, "v2.json");
+  await writeFile(first, JSON.stringify({ schema: "healthmd.example", schema_version: 1, records: [{ owner_date: "2026-01-01", semantic_id: "x", unit: "count", value: 1 }] }));
+  await writeFile(second, JSON.stringify({ schema: "healthmd.example", schema_version: 2, records: [{ owner_date: "2026-01-02", semantic_id: "x", unit: "count", value: 2 }] }));
+  const store = await loadHealthData([first, second]);
+  const evidence = JSON.stringify(formatEvidence(queryStore(store, { metric: "x", limit: 100 })));
+  assert.match(evidence, /"schemaVersion":"1"/);
+  assert.match(evidence, /"schemaVersion":"2"/);
+  let view = updateView(initialView(), { action: "select", target: "x", targetKind: "metric" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(store, view, 100).join("\n"), /mixed contract\/schema\/path/);
+});
+
+test("semantic-ID searches reach exact numeric descendants", async () => {
+  const store = await loadHealthData([join(repo, "packages/contracts/proposals/unified-health-data-v9/fixtures/apple-minimal.json")]);
+  assert.ok(queryStore(store, { search: "steps", limit: 100 }).matches.some(entry => entry.path.endsWith(".number")));
+  let view = updateView(initialView(), { action: "select", target: "steps", targetKind: "search" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(store, view, 100).join("\n"), /█/);
+});
+
+test(">100 records are filtered/sorted before pagination with owner date and timestamp separate", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "healthmd-many-"));
+  const file = join(dir, "many.json");
+  const records = Array.from({ length: 150 }, (_, i) => ({ owner_date: `2026-${String(Math.floor(i / 28) + 1).padStart(2, "0")}-${String(i % 28 + 1).padStart(2, "0")}`, start_time: `2026-01-01T00:${String(i % 60).padStart(2, "0")}:00Z`, semantic_id: "x", statistic: "latest", unit: "count", number: i }));
+  await writeFile(file, JSON.stringify({ records: records.reverse() }));
+  const store = await loadHealthData([file]);
+  let view = updateView(initialView(), { action: "select", target: "x", targetKind: "metric" });
+  view = updateView(view, { action: "date_window", startDate: "2026-01-01", endDate: "2026-06-30" });
+  view = { ...view, windowSize: 120, offset: 0 };
+  const selected = selectedEntries(store, view);
+  assert.ok(selected.length > 100);
+  assert.ok(selected.every(entry => entry.ownerDate && entry.recordTimestamp));
+  assert.ok(selected.every((entry, i) => i === 0 || (selected[i - 1]!.date ?? "") <= (entry.date ?? "")));
+});
+
+test("render respects exact widths including 8 columns and CJK/emoji visible widths and stays compact", async () => {
+  const store = await loadHealthData([join(repo, "packages/contracts/proposals/unified-health-data-v9/fixtures/apple-minimal.json")]);
+  for (const width of [8, 20, 40]) {
+    const lines = renderDashboard(store, initialView(), width);
+    assert.ok(lines.length <= 10);
+    assert.ok(lines.every(line => visibleWidth(line) <= width));
+  }
+  assert.equal(visibleWidth("健康"), 4);
+  assert.equal(visibleWidth("🫀"), 2);
+  assert.equal(visibleWidth("👨‍👩‍👧‍👦"), 2);
+});

--- a/packages/pi-healthmd-dashboard/test/security-bounds.test.ts
+++ b/packages/pi-healthmd-dashboard/test/security-bounds.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { createController } from "../src/extension.js";
+import { canonicalRoot, loadHealthData, requireApprovedPath } from "../src/loader.js";
+
+test("approved realpath roots permit children and reject outside, traversal, and aliases", async () => {
+  const base = await mkdtemp(join(tmpdir(), "healthmd-roots-"));
+  const root = join(base, "approved"), outside = join(base, "outside");
+  await mkdir(root); await mkdir(outside);
+  const child = join(root, "child.json"), secret = join(outside, "secret.json");
+  await writeFile(child, "{}"); await writeFile(secret, "{}");
+  const approved = [await canonicalRoot(root)];
+  assert.equal(await requireApprovedPath(child, approved), await canonicalRoot(child));
+  await assert.rejects(requireApprovedPath(secret, approved), /outside approved/);
+  await assert.rejects(requireApprovedPath(join(root, "..", "outside", "secret.json"), approved), /outside approved/);
+  const alias = join(root, "alias.json"); await symlink(secret, alias);
+  await assert.rejects(requireApprovedPath(alias, approved), /Symbolic-link/);
+  const insideAlias = join(root, "inside-alias.json"); await symlink(child, insideAlias);
+  await assert.rejects(requireApprovedPath(insideAlias, approved), /Symbolic-link/);
+  await assert.rejects(canonicalRoot(insideAlias), /Symbolic-link/);
+  await assert.rejects(loadHealthData([secret], {}, approved), /outside approved/);
+  await assert.rejects(requireApprovedPath(child, []), /No approved/);
+});
+
+test("model load cannot approve but user command/controller approval can", async () => {
+  const base = await mkdtemp(join(tmpdir(), "healthmd-controller-"));
+  const file = join(base, "data.json"); await writeFile(file, "{}");
+  const controller = createController();
+  await assert.rejects(controller.loadApproved([file]), /No approved/);
+  await controller.approveAndLoad([base]);
+  assert.equal((await controller.loadApproved([file])).documents.length, 1);
+  assert.equal(controller.approvedRoots().length, 1);
+  controller.reset();
+  assert.equal(controller.approvedRoots().length, 0);
+  await assert.rejects(controller.loadApproved([file]), /No approved/);
+});
+
+test("bounded loader handles empty containers/deep data and rejects depth, nodes, oversize, symlink input", async () => {
+  const base = await mkdtemp(join(tmpdir(), "healthmd-bounds2-"));
+  const empty = join(base, "empty.json"); await writeFile(empty, '{"a":[],"b":{}}');
+  assert.ok((await loadHealthData([empty])).entries.some(entry => entry.kind === "array"));
+  const deep = join(base, "deep.json"); await writeFile(deep, `${"[".repeat(30)}0${"]".repeat(30)}`);
+  await assert.rejects(loadHealthData([deep], { maxDepth: 10 }), /depth/);
+  await assert.rejects(loadHealthData([empty], { maxNodes: 2 }), /node count/);
+  await assert.rejects(loadHealthData([empty], { maxFileBytes: 2 }), /per-file/);
+  const link = join(base, "link.json"); await symlink(empty, link);
+  await assert.rejects(loadHealthData([link]), /symbolic[- ]link|ELOOP/i);
+  const crowded = join(base, "crowded"); await mkdir(crowded);
+  for (const name of ["a.txt", "b.txt", "c.txt"]) await writeFile(join(crowded, name), "ignored");
+  await assert.rejects(loadHealthData([crowded], { maxDirectoryEntries: 2 }), /Directory entry count/);
+});

--- a/packages/pi-healthmd-dashboard/test/source.test.ts
+++ b/packages/pi-healthmd-dashboard/test/source.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { loadHealthDataText } from "../src/loader.js";
+import { initialView } from "../src/model.js";
+import { formatEvidence, queryStore } from "../src/query.js";
+import { renderDashboard } from "../src/render.js";
+import { fetchHealthMd } from "../src/source.js";
+import { updateView } from "../src/view.js";
+
+const digest = "a".repeat(64);
+const response = {
+  schema: "healthmd.query_response",
+  schema_version: 1,
+  items: [{
+    type: "metric",
+    metric: {
+      metric_id: "steps",
+      display_name: "Steps",
+      owner_date: "2026-03-15",
+      status: "available",
+      value: { type: "count", value: 12_345 },
+      evidence: [{ evidence_id: "evidence-steps", locator: { type: "summary_key", owner_date: "2026-03-15", key: "steps" }, source_id: "apple_health", source: { schema: "healthmd.health_data", schema_version: 8, digest } }],
+      limitations: [],
+    },
+  }],
+  coverage: { status: "available", days_considered: 1, days_with_values: 1, missing: [] },
+  sources: [{ schema: "healthmd.health_data", schema_version: 8, digest }],
+  evidence: [], limitations: [], next_cursor: null,
+};
+
+async function executable(directory: string, name: string, source: string): Promise<string> {
+  const path = join(directory, name);
+  await writeFile(path, `#!/usr/bin/env node\n${source}`);
+  await chmod(path, 0o755);
+  return path;
+}
+
+test("CLI typed queries are fetched without a shell and become provenance-aware dashboard evidence", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-source-cli-"));
+  const log = join(directory, "argv.json");
+  const cli = await executable(directory, "fake healthmd", `
+    const fs = require("node:fs");
+    fs.writeFileSync(${JSON.stringify(log)}, JSON.stringify(process.argv.slice(2)));
+    process.stdout.write(${JSON.stringify(JSON.stringify(response))});
+  `);
+  const fetched = await fetchHealthMd({ cliExecutable: cli, defaultTransport: "cli" }, {
+    operation: "healthmd_metric_chart",
+    arguments: { dates: { type: "all_available" }, metrics: { type: "explicit", metric_ids: ["steps"] } },
+  });
+  assert.equal(fetched.transport, "cli");
+  const argv = JSON.parse(await readFile(log, "utf8"));
+  assert.deepEqual(argv.slice(0, 2), ["query", "healthmd_metric_chart"]);
+  assert.equal(argv.at(-2), "--timeout");
+  assert.equal(argv.at(-1), "1200");
+
+  const store = loadHealthDataText([{ path: fetched.syntheticPath, text: fetched.text, origin: "healthmd-cli", operation: fetched.operation }]);
+  const value = store.entries.find(entry => entry.path.endsWith(".metric.value.value"));
+  assert.equal(value?.semanticId, "steps");
+  assert.equal(value?.unit, "count");
+  assert.equal(value?.source, "apple_health");
+  assert.equal(value?.origin, "healthmd-cli");
+  const evidence = JSON.stringify(formatEvidence(queryStore(store, { metric: "steps", limit: 100 })));
+  assert.match(evidence, /apple_health/);
+  assert.match(evidence, /healthmd-cli/);
+  let view = updateView(initialView(), { action: "select", target: "steps", targetKind: "metric" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  assert.match(renderDashboard(store, view, 100).join("\n"), /12345 count/);
+});
+
+test("standalone read-only MCP stdio queries are initialized, called, and ingested", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-source-mcp-"));
+  const mcp = await executable(directory, "fake-mcp", `
+    const readline = require("node:readline");
+    const payload = ${JSON.stringify(response)};
+    const rl = readline.createInterface({ input: process.stdin });
+    rl.on("line", line => {
+      const request = JSON.parse(line);
+      if (request.method === "initialize") process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { protocolVersion: "2025-11-25", capabilities: { tools: {} }, serverInfo: { name: "fake", version: "1" } } }) + "\\n");
+      if (request.method === "tools/call") process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: request.id, result: { content: [{ type: "text", text: JSON.stringify(payload) }], isError: false } }) + "\\n");
+    });
+  `);
+  const fetched = await fetchHealthMd({ cliExecutable: "unused", mcpExecutable: mcp }, {
+    operation: "healthmd_sleep_sessions", arguments: { dates: { type: "all_available" } }, transport: "mcp",
+  });
+  assert.equal(fetched.transport, "mcp");
+  assert.equal(JSON.parse(fetched.text).schema, "healthmd.query_response");
+  const store = loadHealthDataText([{ path: fetched.syntheticPath, text: fetched.text, origin: "healthmd-mcp", operation: fetched.operation }]);
+  assert.equal(store.documents[0]?.origin, "healthmd-mcp");
+  assert.equal(store.documents[0]?.operation, "healthmd_sleep_sessions");
+});
+
+test("fetch rejects non-canonical query contracts from both CLI and MCP and accepts bounded multipage receipts", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-source-contracts-"));
+  const invalid = { schema: "healthmd.query_response", schema_version: 2, items: "bad" };
+  const invalidCli = await executable(directory, "invalid-cli", `process.stdout.write(${JSON.stringify(JSON.stringify(invalid))});`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: invalidCli, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {} }), /healthmd\.query_response\/1|did not return/);
+  const inventedItem = { ...response, items: [{ type: "invented", invented: {} }] };
+  const inventedCli = await executable(directory, "invented-cli", `process.stdout.write(${JSON.stringify(JSON.stringify(inventedItem))});`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: inventedCli, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {} }), /invalid canonical fields|structurally canonical/);
+  const decimalVersionText = JSON.stringify(response).replace('"schema_version":1', '"schema_version":1.0');
+  const decimalVersion = await executable(directory, "decimal-version", `process.stdout.write(${JSON.stringify(decimalVersionText)});`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: decimalVersion, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {} }), /non-integer JSON token/);
+  const oversizedCounterText = JSON.stringify(response).replace('"days_considered":1', '"days_considered":18446744073709551616');
+  const oversizedCounter = await executable(directory, "oversized-counter", `process.stdout.write(${JSON.stringify(oversizedCounterText)});`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: oversizedCounter, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {} }), /out of range|invalid canonical fields/);
+  const nullProvider = structuredClone(response);
+  (nullProvider.items[0]!.metric.evidence[0] as any).provider_id = null;
+  const nullProviderCli = await executable(directory, "null-provider", `process.stdout.write(${JSON.stringify(JSON.stringify(nullProvider))});`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: nullProviderCli, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {} }), /invalid canonical fields/);
+  const invalidMcp = await executable(directory, "invalid-mcp", `
+    const readline=require("node:readline"); const rl=readline.createInterface({input:process.stdin});
+    rl.on("line",line=>{const r=JSON.parse(line); if(r.method==="initialize") process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:r.id,result:{protocolVersion:"2025-11-25"}})+"\\n"); if(r.method==="tools/call") process.stdout.write(JSON.stringify({jsonrpc:"2.0",id:r.id,result:{content:[{type:"text",text:${JSON.stringify(JSON.stringify(invalid))}}],isError:false}})+"\\n");});
+  `);
+  await assert.rejects(fetchHealthMd({ mcpExecutable: invalidMcp }, { operation: "healthmd_sleep_sessions", arguments: {}, transport: "mcp" }), /healthmd\.query_response\/1|did not return/);
+
+  const pages = { schema: "healthmd.mcp_query_pages", schema_version: 1, pages: [response], receipt: { page_count: 1, item_count: 1, packet_fact_count: 0, traversal_complete: true, next_cursor: null, limit_reason: null } };
+  const multipage = await executable(directory, "multipage", `process.stdout.write(${JSON.stringify(JSON.stringify(pages))});`);
+  const fetched = await fetchHealthMd({ cliExecutable: multipage, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: { all_pages: true } });
+  const store = loadHealthDataText([{ path: fetched.syntheticPath, text: fetched.text, origin: "healthmd-cli", operation: fetched.operation }]);
+  assert.equal(store.documents[0]?.schema, "healthmd.mcp_query_pages");
+  assert.ok(store.entries.some(entry => entry.semanticId === "steps" && entry.value === 12_345));
+  const inconsistentPages: any = structuredClone(pages);
+  inconsistentPages.pages[0].next_cursor = "invented-next";
+  inconsistentPages.receipt.limit_reason = "invented_reason";
+  const inconsistent = await executable(directory, "inconsistent-pages", `process.stdout.write(${JSON.stringify(JSON.stringify(inconsistentPages))});`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: inconsistent, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: { all_pages: true } }), /completed traversal receipt|limited traversal receipt/);
+});
+
+test("fetch rejects unknown operations, subprocess failures, and oversized output", async () => {
+  await assert.rejects(fetchHealthMd({ cliExecutable: "not-run", defaultTransport: "cli" }, {
+    operation: "healthmd_export_files" as never, arguments: {},
+  }), /Unsupported read-only/);
+  await assert.rejects(fetchHealthMd({ cliExecutable: "not-run", defaultTransport: "cli" }, {
+    operation: "healthmd_metrics", arguments: {},
+  }), /requires the MCP transport; no transport fallback/);
+  await assert.rejects(fetchHealthMd({ cliExecutable: "not-run", mcpExecutable: "not-run", deviceId: "00000000-0000-4000-8000-000000000001" }, {
+    operation: "healthmd_metrics", arguments: {}, transport: "mcp",
+  }), /standalone Health.md MCP helper cannot accept.*device\/port/);
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-source-bounds-"));
+  const pidFile = join(directory, "oversized.pid");
+  const oversized = await executable(directory, "oversized", `const fs=require("node:fs"); fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); process.on("SIGTERM",()=>{}); process.stdout.write(JSON.stringify({value:"x".repeat(1000)})); setInterval(()=>{},1000);`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: oversized, defaultTransport: "cli", maxOutputBytes: 100 }, {
+    operation: "healthmd_metric_chart", arguments: {},
+  }), /output exceeds 100 bytes/);
+  if (process.platform !== "win32") {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const pid = Number(await readFile(pidFile, "utf8"));
+    assert.throws(() => process.kill(pid, 0), /ESRCH/);
+  }
+  const failed = await executable(directory, "failed", `process.stdout.write(JSON.stringify({error:"healthmd_unavailable",message:"No paired foreground iPhone."})); process.exitCode=1;`);
+  await assert.rejects(fetchHealthMd({ cliExecutable: failed, defaultTransport: "cli" }, {
+    operation: "healthmd_metric_chart", arguments: {},
+  }), /healthmd_unavailable: No paired foreground iPhone/);
+});
+
+test("fetch cancellation reaps the process tree and subprocesses receive only the source environment allowlist", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-source-process-"));
+  const pidFile = join(directory, "cancel.pid");
+  const hanging = await executable(directory, "hanging", `const fs=require("node:fs"); fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid)); process.on("SIGTERM",()=>{}); setInterval(()=>{},1000);`);
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 500);
+  await assert.rejects(fetchHealthMd({ cliExecutable: hanging, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {}, timeoutSeconds: 30 }, controller.signal), /cancelled/);
+  if (process.platform !== "win32") {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const pidText = await readFile(pidFile, "utf8").catch(error => (error as NodeJS.ErrnoException).code === "ENOENT" ? undefined : Promise.reject(error));
+    if (pidText) assert.throws(() => process.kill(Number(pidText), 0), /ESRCH/);
+  }
+
+  await assert.rejects(fetchHealthMd({ cliExecutable: hanging, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {}, timeoutSeconds: 1 }), /timed out after 1 seconds/);
+  if (process.platform !== "win32") {
+    await new Promise(resolve => setTimeout(resolve, 500));
+    const pid = Number(await readFile(pidFile, "utf8"));
+    assert.throws(() => process.kill(pid, 0), /ESRCH/);
+  }
+
+  const environmentLog = join(directory, "environment.json");
+  const environmentProbe = await executable(directory, "environment", `const fs=require("node:fs"); fs.writeFileSync(${JSON.stringify(environmentLog)},JSON.stringify({unrelated_secret:process.env.HEALTHMD_TEST_SECRET,allowed_data_dir:process.env.HEALTHMD_CLI_DATA_DIR})); process.stdout.write(${JSON.stringify(JSON.stringify(response))});`);
+  const previousSecret = process.env.HEALTHMD_TEST_SECRET, previousData = process.env.HEALTHMD_CLI_DATA_DIR;
+  process.env.HEALTHMD_TEST_SECRET = "must-not-leak";
+  process.env.HEALTHMD_CLI_DATA_DIR = "/tmp/healthmd-test-data";
+  try {
+    const fetched = await fetchHealthMd({ cliExecutable: environmentProbe, defaultTransport: "cli" }, { operation: "healthmd_metric_chart", arguments: {} });
+    assert.equal(JSON.parse(fetched.text).schema, "healthmd.query_response");
+    const childEnvironment = JSON.parse(await readFile(environmentLog, "utf8"));
+    assert.equal(childEnvironment.unrelated_secret, undefined);
+    assert.equal(childEnvironment.allowed_data_dir, "/tmp/healthmd-test-data");
+  } finally {
+    if (previousSecret === undefined) delete process.env.HEALTHMD_TEST_SECRET; else process.env.HEALTHMD_TEST_SECRET = previousSecret;
+    if (previousData === undefined) delete process.env.HEALTHMD_CLI_DATA_DIR; else process.env.HEALTHMD_CLI_DATA_DIR = previousData;
+  }
+});

--- a/packages/pi-healthmd-dashboard/test/view-render.test.ts
+++ b/packages/pi-healthmd-dashboard/test/view-render.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import test from "node:test";
+import { loadHealthData } from "../src/loader.js";
+import { initialView } from "../src/model.js";
+import { renderDashboard } from "../src/render.js";
+import { updateView } from "../src/view.js";
+
+const fixture = resolve(import.meta.dirname, "../../../packages/contracts/proposals/unified-health-data-v9/fixtures/android-minimal.json");
+
+test("view selection, date window, zoom, pan, show/hide and reset are deterministic", () => {
+  let view = initialView();
+  view = updateView(view, { action: "select", target: "steps", targetKind: "metric" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  view = updateView(view, { action: "date_window", startDate: "2026-07-01", endDate: "2026-07-31" });
+  const before = view.windowSize;
+  view = updateView(view, { action: "zoom_in" });
+  assert.ok(view.windowSize < before);
+  view = updateView(view, { action: "pan_right" });
+  assert.ok(view.offset > 0);
+  view = updateView(view, { action: "pan_left" });
+  assert.equal(view.offset, 0);
+  view = updateView(view, { action: "hide" });
+  assert.equal(view.visible, false);
+  view = updateView(view, { action: "reset" });
+  assert.equal(view.visible, false);
+  assert.equal(view.mode, "table");
+  view = updateView(view, { action: "show" });
+  assert.equal(view.visible, true);
+  view = updateView(view, { action: "reset" });
+  assert.equal(view.visible, true);
+});
+
+test("overview shows canonical typed-query metric values without requiring manual selection", async () => {
+  const queryFixture = resolve(import.meta.dirname, "../../../apps/apple/docs/reference/generated/automation/agent-query-response.json");
+  const store = await loadHealthData([queryFixture]);
+  const rendered = renderDashboard(store, initialView(), 100).join("\n");
+  assert.match(rendered, /metric:overview • table • 1 shown/);
+  assert.match(rendered, /12345/);
+  assert.doesNotMatch(rendered, /No matching loaded evidence/);
+});
+
+test("responsive chart and table rendering is width-safe and exposes source/date/coverage/context", async () => {
+  const store = await loadHealthData([fixture]);
+  let view = updateView(initialView(), { action: "select", target: "steps", targetKind: "metric" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  for (const width of [20, 40, 80, 120]) {
+    const lines = renderDashboard(store, view, width);
+    assert.ok(lines.length > 3);
+    assert.ok(lines.every(line => line.length <= Math.max(20, width)), `line overflow at ${width}`);
+    const text = lines.join("\n");
+    assert.match(text, width >= 40 ? /EXPERIMENTAL proposed v9 reader/ : /EXPERIMENTAL/);
+    assert.match(text, width >= 40 ? /Source:/ : /Coverage:/);
+    assert.match(text, /Coverage:/);
+  }
+  const chart = renderDashboard(store, view, 100).join("\n");
+  assert.match(chart, /█/);
+});
+
+test("chart scaling remains finite for binary64 extremes and displays negative zero", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "healthmd-extreme-chart-"));
+  const file = join(directory, "extremes.json");
+  await writeFile(file, '{"points":[{"owner_date":"2026-01-01","semantic_id":"x","statistic":"latest","unit":"count","value":-1.7976931348623157e308},{"owner_date":"2026-01-02","semantic_id":"x","statistic":"latest","unit":"count","value":-0},{"owner_date":"2026-01-03","semantic_id":"x","statistic":"latest","unit":"count","value":1.7976931348623157e308}]}');
+  const store = await loadHealthData([file]);
+  let view = updateView(initialView(), { action: "select", target: "x", targetKind: "metric" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  const rendered = renderDashboard(store, view, 120).join("\n");
+  assert.match(rendered, /█/);
+  assert.match(rendered, /-0/);
+});
+
+test("structured and unsafe exact values use table fallback", async () => {
+  const store = await loadHealthData([fixture]);
+  let view = updateView(initialView(), { action: "select", target: "$.capture", targetKind: "path" });
+  view = updateView(view, { action: "mode", mode: "chart" });
+  const rendered = renderDashboard(store, view, 80).join("\n");
+  assert.match(rendered, /table fallback/i);
+  assert.match(rendered, /PATH/);
+});

--- a/packages/pi-healthmd-dashboard/tsconfig.json
+++ b/packages/pi-healthmd-dashboard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

Experimental, local-first, read-only Pi extension (`@healthmd/pi-health-dashboard`) for inspecting approved Health.md JSON exports and fetching bounded typed query responses through the standalone CLI/MCP server.

**Stacked on the base branch** (`feature/apple-v8-whoop-unified-contract`): the dashboard validates the proposed `healthmd.health_data` v9 unified contract and WHOOP typed daily documents introduced there, and registers itself as a consumer of those manifest entries. Retarget to `main` when the base merges.

## Safety model

- **Approved roots only** — files load exclusively from `--healthmd-data`/`HEALTHMD_DATA_PATH`/user-authored `/healthmd load` roots; `healthmd_load` can only load approved roots or realpath descendants. Traversal, outside paths, and symlink escapes rejected; regular `.json` only.
- **Bounded everywhere** — 256 documents, 32 MiB/file, 128 MiB total, depth 256, node/leaf caps, 24 KB query evidence, 45 KB tool results (under Pi's 50 KB limit).
- **`healthmd_fetch` is a fixed surface** — 13 read-only CLI/MCP operations over stdio with argument-array subprocesses (no shell), allowlisted environment excluding provider secrets, bounded output, cancellation, and fail-closed `healthmd.query_response`/`mcp_query_pages` contract validation. No executable, raw-export, pairing, or file-export operations.
- **Model disclosure is explicit** — README documents that loaded evidence enters model context and Pi session/JSON output.

## Cross-platform policy

- v9 remains marked proposed/experimental reader support; not evidence of a shipped writer.
- Apple primary data must not be relabeled RMSSD; Android primary data must not be relabeled SDNN (enforced in `contracts.ts` + tests).
- WHOOP HRV RMSSD stays provider data; never merged into HealthKit SDNN / Health Connect RMSSD.

## Notes for reviewers

- `schemas/unified-health-data-v9.schema.json` is a byte-identical vendored copy of `packages/contracts/proposals/unified-health-data-v9/unified-health-data-v9.schema.json` for reader-side AJV validation — happy to register it as a manifest mirror if preferred.
- Registers the package in root `AGENTS.md`/`README.md`/`LICENSES.md` (AGPL-3.0-only), root `Makefile` (`test-pi-health-dashboard`), and the contracts manifest consumer lists.

## Verification

- Package: **76 tests pass** on Node 24, `tsc --noEmit` clean
- No secrets, `node_modules/` gitignored; 36 files, +10,467/−5
- New CI workflow: CLI/MCP canonical parity test, fetched-operation registry verification against the built CLI, contracts validation, npm pack contents, and pinned-Pi-runtime extension load with exact tool/command/flag assertions
