### PR TITLE
Explain WorkoutKit.ImportError workout-plan warnings in plain language

### DIFF
--- a/apps/apple/CHANGELOG.md
+++ b/apps/apple/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to Health.md will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- Workouts whose attached WorkoutKit plan cannot be decoded by the device (surfacing as an opaque `WorkoutKit.ImportError error N` partial-export warning) now explain in plain language that the workout and all of its samples exported successfully and only the optional structured plan was omitted, with the likely cause. Partial-export warnings in iPhone, iPad, and Mac export history now wrap fully and can be selected and copied for bug reports.
+
 ## [3.0.5] - 2026-08-09
 
 ### Added

--- a/apps/apple/HealthMd/Shared/Protocols/SystemHealthStoreAdapter+CanonicalWorkouts.swift
+++ b/apps/apple/HealthMd/Shared/Protocols/SystemHealthStoreAdapter+CanonicalWorkouts.swift
@@ -1240,6 +1240,17 @@ extension SystemHealthStoreAdapter {
         try Self.throwIfCancellationError(error)
         let nsError = error as NSError
         let suffix = childUUID.map { " child_uuid=\($0.uuidString)" } ?? ""
+        let queryError: HealthKitQueryError
+        if let importFailureDescription = Self.workoutPlanImportFailureDescription(for: nsError) {
+            queryError = HealthKitQueryError(
+                domain: nsError.domain,
+                code: Int64(nsError.code),
+                description: importFailureDescription,
+                isRecoverable: true
+            )
+        } else {
+            queryError = HealthKitQueryError(error: nsError, isRecoverable: true)
+        }
         return HealthKitQueryResult(
             identifier: identifier,
             objectTypeIdentifier: objectTypeIdentifier,
@@ -1254,9 +1265,28 @@ extension SystemHealthStoreAdapter {
             ),
             status: .failure,
             recordCount: 0,
-            error: HealthKitQueryError(error: nsError, isRecoverable: true),
+            error: queryError,
             statusDescription: "workout_uuid=\(workout.uuid.uuidString)\(suffix)"
         )
+    }
+
+    /// `HKWorkout.workoutPlan` and `WorkoutPlan.dataRepresentation` surface
+    /// WorkoutKit's internal `ImportError` enum as an opaque
+    /// "WorkoutKit.ImportError error N" string with no localized description,
+    /// which otherwise flows straight into partial export warnings users
+    /// cannot act on. Translate that domain into an explanation that states
+    /// what was omitted, what still exported, and the likely cause (a plan
+    /// blob this device's WorkoutKit cannot decode, typically written by
+    /// another app, device, or OS version). Returns nil for every other
+    /// error domain so unrelated failures keep their raw descriptions.
+    static func workoutPlanImportFailureDescription(for error: NSError) -> String? {
+        guard error.domain == "WorkoutKit.ImportError" else { return nil }
+        return "WorkoutKit could not decode the workout plan attached to this "
+            + "workout (WorkoutKit.ImportError error \(error.code)). The workout "
+            + "itself and all of its samples exported successfully; only the "
+            + "optional structured workout plan was omitted. This usually means "
+            + "the plan was saved by another app, device, or OS version whose "
+            + "plan format this device cannot read."
     }
 
     private func canonicalIndoorValue(_ metadata: [String: Any]?) -> HealthKitMetadataValue {

--- a/apps/apple/HealthMd/iOS/Views/ScheduleSettingsView.swift
+++ b/apps/apple/HealthMd/iOS/Views/ScheduleSettingsView.swift
@@ -1820,6 +1820,8 @@ struct ExportHistoryDetailView: View {
                                 Text(failure.summary)
                                     .font(Typography.caption())
                                     .foregroundStyle(Color.textSecondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .textSelection(.enabled)
                             }
                         }
                     } header: {

--- a/apps/apple/HealthMd/iPad/iPadHistoryView.swift
+++ b/apps/apple/HealthMd/iPad/iPadHistoryView.swift
@@ -241,6 +241,8 @@ struct iPadHistoryView: View {
                                     Text(failure.summary)
                                         .font(Typography.caption())
                                         .foregroundStyle(Color.textMuted)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .textSelection(.enabled)
                                 }
                             }
                         }

--- a/apps/apple/HealthMd/macOS/Views/MacHistoryView.swift
+++ b/apps/apple/HealthMd/macOS/Views/MacHistoryView.swift
@@ -246,6 +246,8 @@ struct MacHistoryView: View {
                                     Text(failure.localizedSummary)
                                         .font(BrandTypography.caption())
                                         .foregroundStyle(Color.textMuted)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                        .textSelection(.enabled)
                                 }
                             }
                         }

--- a/apps/apple/HealthMdTests/Export/CanonicalWorkoutCaptureTests.swift
+++ b/apps/apple/HealthMdTests/Export/CanonicalWorkoutCaptureTests.swift
@@ -75,6 +75,21 @@ final class CanonicalWorkoutCaptureTests: XCTestCase {
         XCTAssertEqual(average, 145)
     }
 
+    func testWorkoutPlanImportFailureDescriptionTranslatesWorkoutKitImportErrors() {
+        let importError = NSError(domain: "WorkoutKit.ImportError", code: 3)
+        let description = SystemHealthStoreAdapter.workoutPlanImportFailureDescription(for: importError)
+        XCTAssertNotNil(description)
+        XCTAssertTrue(description!.contains("WorkoutKit.ImportError error 3"),
+                      "description should preserve the raw error identity")
+        XCTAssertTrue(description!.contains("exported successfully"),
+                      "description should reassure that the workout data itself exported")
+        XCTAssertTrue(description!.contains("workout plan"),
+                      "description should name what was omitted")
+
+        let unrelatedError = NSError(domain: HKErrorDomain, code: HKError.Code.errorNoData.rawValue)
+        XCTAssertNil(SystemHealthStoreAdapter.workoutPlanImportFailureDescription(for: unrelatedError))
+    }
+
     @MainActor
     func testPausedWorkoutUsesStableHealthKitIdentityAndActualEndAcrossExports() async throws {
         let dayStart = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 1_800_000_000))


### PR DESCRIPTION
## Summary

User-submitted issue: every Shortcut export reported an opaque warning like:

> `Warning: HealthKit workout child F4D54D53-8151-4140-A23B-AA693F991379:workoutPlan for 2026-08-09 [...]: The operation couldn't be completed. (WorkoutKit.ImportError error 3.)`

**Root cause:** `HKWorkout.workoutPlan` throws WorkoutKit internal, undocumented `ImportError` when the device cannot decode a workout's attached plan blob. `WorkoutKit.ImportError` is not in the public swiftinterface, so its NSError description carries no actionable meaning — and it flowed straight into partial-export warnings. The workout itself and all of its samples still export successfully; only the optional structured plan is omitted, but any partial failure flips `isFullSuccess` and surfaces the warning everywhere (Shortcut dialog, history, export JSON).

## Changes

- **`SystemHealthStoreAdapter+CanonicalWorkouts.swift`** — `canonicalWorkoutChildFailure` now maps the `WorkoutKit.ImportError` domain to a plain-language explanation:
  > *"WorkoutKit could not decode the workout plan attached to this workout (WorkoutKit.ImportError error 3). The workout itself and all of its samples exported successfully; only the optional structured workout plan was omitted. This usually means the plan was saved by another app, device, or OS version whose plan format this device cannot read."*

  Domain/code identity and the raw error code are preserved for support; all other error domains keep their raw descriptions unchanged.

- **History UIs (iOS `ScheduleSettingsView`, iPad `iPadHistoryView`, macOS `MacHistoryView`)** — Partial Export Warning rows now wrap fully (`.fixedSize`) and support text selection/copy, answering the reporter's question "Is there any way for me to see more details?"

- **Test** — `testWorkoutPlanImportFailureDescriptionTranslatesWorkoutKitImportErrors` covers domain detection, raw-code preservation, and nil for unrelated domains.

- **`apps/apple/CHANGELOG.md`** — Unreleased entry.

## Contract impact

None. `ExportPartialFailure.errorDescription` is a free-text diagnostic field; no export schema shape, mapping, unit, or fixture changed. `ExportSchemaSignatureTests` passes unchanged — no schema version bump required.

## Testing

- [x] `CanonicalWorkoutCaptureTests` (incl. new test + pre-existing `testWorkoutChildFailureIsExplicitAndDoesNotDropSuccessfulGraph` exercising the modified builder) — passed on iOS Simulator
- [x] `CanonicalWorkoutCaptureTests` — passed on macOS
- [x] macOS test target builds (`HealthMd-Tests-macOS`)
- [x] `ExportSchemaSignatureTests` — passed
- [ ] Full `make test` (iOS + macOS suite) — left to CI
