### PR TITLE
fix(ci): run Wear emulator smoke script as one shell invocation

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -201,21 +201,18 @@ jobs:
           arch: x86_64
           profile: wearos_small_round
           avd-name: healthmd-wear-ci
-          pre-emulator-launch-script: |
-            config="$HOME/.android/avd/healthmd-wear-ci.avd/config.ini"
-            test -f "$config"
-            if grep -q '^hw.rotaryInput' "$config"; then
-              sed -i 's/^hw\.rotaryInput.*/hw.rotaryInput = yes/' "$config"
-            else
-              echo 'hw.rotaryInput = yes' >> "$config"
-            fi
-          script: |
+          pre-emulator-launch-script: >-
+            config="$HOME/.android/avd/healthmd-wear-ci.avd/config.ini" && test -f "$config" &&
+            { grep -q '^hw.rotaryInput' "$config" &&
+            sed -i 's/^hw\.rotaryInput.*/hw.rotaryInput = yes/' "$config" ||
+            printf 'hw.rotaryInput = yes\n' >> "$config"; }
+          script: >-
             adb shell dumpsys input | grep -q 'Sources: ROTARY_ENCODER'
-            cd apps/android
-            ./gradlew :wear:assembleDebug :wear:bundleDebug --stacktrace
-            ./scripts/run-wear-emulator-smoke.sh wear/build/outputs/apk/debug/wear-debug.apk
-            ./scripts/validate-wear-artifact.sh wear/build/outputs/apk/debug/wear-debug.apk
-            ./scripts/test-wear-bundle-manifest-verifier.sh wear/build/outputs/bundle/debug/wear-debug.aab
+            && cd apps/android
+            && ./gradlew :wear:assembleDebug :wear:bundleDebug --stacktrace
+            && ./scripts/run-wear-emulator-smoke.sh wear/build/outputs/apk/debug/wear-debug.apk
+            && ./scripts/validate-wear-artifact.sh wear/build/outputs/apk/debug/wear-debug.apk
+            && ./scripts/test-wear-bundle-manifest-verifier.sh wear/build/outputs/bundle/debug/wear-debug.aab
 
   rust-kotlin-direct-interop:
     name: Rust/Kotlin direct interop


### PR DESCRIPTION
## Summary

- `reactivecircus/android-emulator-runner` runs each `script:`/`pre-emulator-launch-script:` line as a **separate `sh -c` invocation**, so shell state does not persist between lines.
- Evidence from failed runs: the pre-launch script failed at `test -f "$config"` because `config=` ran in a different shell, and the smoke script failed with `./gradlew: not found` (exit 127) because `cd apps/android` ran in a different shell. Failing on every PR branch and on `main` since the job was added.
- Fix: chain each script into a single shell command using a folded (`>-`) block scalar.

## Validation

- `yaml-lint` passes on the workflow
- `sh -n` syntax check passes for both expanded scripts
- Wear emulator smoke job should now reach the actual gradle build and smoke checks

## Contract impact

- CI-only change; no app, protocol, or export-schema changes