### PR TITLE
test(ui): match Geist no-data dialog after native-alert conversion

### DIFF
--- a/apps/apple/HealthMdUITests/ExportJourneyUITests.swift
+++ b/apps/apple/HealthMdUITests/ExportJourneyUITests.swift
@@ -56,14 +56,16 @@ final class ExportJourneyUITests: XCTestCase {
         XCTAssertTrue(exportButton.waitForExistence(timeout: 5))
         exportButton.tap()
 
-        let noDataAlert = app.alerts["No Health Data Found"]
+        // The no-data guidance is a Geist-designed in-app dialog (not a native alert),
+        // matched by its localized title text like the other dialogs in this journey.
+        let noDataDialog = app.staticTexts["No Health Data Found"]
         XCTAssertTrue(
-            noDataAlert.waitForExistence(timeout: 30),
+            noDataDialog.waitForExistence(timeout: 30),
             "An empty Health store should produce a guided empty state, not a generic error"
         )
-        XCTAssertTrue(noDataAlert.buttons["Open Health App"].exists)
-        XCTAssertTrue(noDataAlert.buttons["Done"].exists)
-        XCTAssertFalse(app.alerts["Error"].exists)
+        XCTAssertTrue(app.buttons["Open Health App"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.buttons["Done"].exists)
+        XCTAssertFalse(app.staticTexts["Export Couldn\u{2019}t Finish"].exists)
     }
 
     func testMultiFileExport_hidesCompletionUntilEntireExportFinishes() throws {


### PR DESCRIPTION
## Summary

- `testNoDataExport_showsGuidanceInsteadOfGenericError` still matched the old native alert (`app.alerts["No Health Data Found"]`) after fa5fae90a replaced native alerts with the Geist-designed in-app dialog, so it fails on every Apple CI run — including `main` (verified on runs 32033880337 and 32033515190).
- Match the dialog by its localized title static text, assert the `Open Health App` / `Done` dialog actions, and keep the no-generic-error guarantee by asserting the failure title stays absent.

## Validation

- Single UI test re-run locally on iPhone 17 Pro (iOS 26.5): passed in 11s (previously failed after 82s timeout).
- No production code changes.

## Contract impact

- None (UI test only).