### PR TITLE
fix(android): publish shared-setup imports on the main dispatcher

### DIFF
--- a/apps/android/app/src/main/java/com/healthmd/presentation/navigation/HealthMdNavigation.kt
+++ b/apps/android/app/src/main/java/com/healthmd/presentation/navigation/HealthMdNavigation.kt
@@ -60,9 +60,11 @@ import com.healthmd.presentation.theme.GeistRadii
 import com.healthmd.presentation.theme.GeistType
 import com.healthmd.presentation.theme.LocalGeistColors
 import com.healthmd.presentation.theme.Spacing
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.ZoneId
 import java.util.Date
@@ -114,16 +116,23 @@ fun HealthMdNavigation(
     val shouldSkipOnboarding = requireNotNull(initialShouldSkipOnboarding)
     LaunchedEffect(sharedSetupCoordinator) {
         sharedSetupCoordinator.imports.filterNotNull().collect {
-            // Reuse a retained Shared Setup back-stack entry instead of pushing a second
-            // ViewModel. The coordinator keeps the request until Finish/Cancel, so an inactive
-            // entry cannot consume a warm ACTION_VIEW before navigation observes it.
-            if (navController.currentDestination?.route != SubRoutes.SHARED_SETUP) {
-                val revealedExisting = navController.popBackStack(
-                    route = SubRoutes.SHARED_SETUP,
-                    inclusive = false,
-                )
-                if (!revealedExisting) {
-                    navController.navigate(SubRoutes.SHARED_SETUP) { launchSingleTop = true }
+            // A StateFlow resumes a suspended collector undispatched on the publisher's
+            // thread, so this body can run wherever the import was published from.
+            // Pin navigation to the main thread: mutating NavController from a
+            // background thread half-applies a back-stack entry that later crashes
+            // activity destroy ("State must be at least CREATED to move to DESTROYED").
+            withContext(Dispatchers.Main.immediate) {
+                // Reuse a retained Shared Setup back-stack entry instead of pushing a second
+                // ViewModel. The coordinator keeps the request until Finish/Cancel, so an inactive
+                // entry cannot consume a warm ACTION_VIEW before navigation observes it.
+                if (navController.currentDestination?.route != SubRoutes.SHARED_SETUP) {
+                    val revealedExisting = navController.popBackStack(
+                        route = SubRoutes.SHARED_SETUP,
+                        inclusive = false,
+                    )
+                    if (!revealedExisting) {
+                        navController.navigate(SubRoutes.SHARED_SETUP) { launchSingleTop = true }
+                    }
                 }
             }
         }

--- a/apps/android/app/src/main/java/com/healthmd/sharedsetup/SharedSetupCoordinator.kt
+++ b/apps/android/app/src/main/java/com/healthmd/sharedsetup/SharedSetupCoordinator.kt
@@ -5,6 +5,7 @@ import java.util.UUID
 import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -13,11 +14,25 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @Singleton
-class SharedSetupCoordinator @Inject constructor(
+class SharedSetupCoordinator internal constructor(
     private val documentStore: SharedSetupDocumentStore,
+    /**
+     * Dispatcher used to publish import results. A StateFlow resumes suspended
+     * collectors undispatched on the publishing thread, so publishing must land
+     * on the main dispatcher in production to keep collector bodies — navigation
+     * and SavedStateHandle writes — on the main thread. Tests inject an
+     * immediate dispatcher through this constructor.
+     */
+    private val publishDispatcher: CoroutineDispatcher,
 ) {
+    @Inject
+    constructor(documentStore: SharedSetupDocumentStore) : this(
+        documentStore,
+        Dispatchers.Main.immediate,
+    )
     private val ids = AtomicLong()
     private val mutableImport = MutableStateFlow<PendingSharedSetupImport?>(null)
     private val externalReadScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -45,8 +60,18 @@ class SharedSetupCoordinator @Inject constructor(
                     // ContentResolver reads are blocking and may ignore coroutine cancellation.
                     // The newest request gets its own IO job; only its generation may publish.
                     val result = readExternal(uri)
-                    result.onSuccess { bytes -> publishExternalBytes(id, bytes) }
-                        .onFailure { error -> publishExternalFailure(id, error) }
+                    // Publish on the main dispatcher. A StateFlow resumes suspended collectors
+                    // undispatched on the publishing thread, so publishing from this IO worker
+                    // would run collector bodies — navigation and SavedStateHandle writes —
+                    // on the IO thread. NavController mutation from a background thread
+                    // half-applies a back-stack entry and later crashes activity destroy with
+                    // "State must be at least CREATED to move to DESTROYED". Main-thread
+                    // publication keeps every consumer on the main thread.
+                    withContext(publishDispatcher) {
+                        result
+                            .onSuccess { bytes -> publishExternalBytes(id, bytes) }
+                            .onFailure { error -> publishExternalFailure(id, error) }
+                    }
                 } finally {
                     synchronized(externalLock) {
                         if (activeExternalRead === requestJob) activeExternalRead = null

--- a/apps/android/app/src/test/java/com/healthmd/sharedsetup/SharedSetupIntentCoordinatorTest.kt
+++ b/apps/android/app/src/test/java/com/healthmd/sharedsetup/SharedSetupIntentCoordinatorTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.mockk
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -68,7 +69,9 @@ class SharedSetupIntentCoordinatorTest {
             byteArrayOf(1)
         }
         io.mockk.every { store.read(secondUri) } returns byteArrayOf(2)
-        val coordinator = SharedSetupCoordinator(store)
+        // Publish immediately where the read completes so the test observes results
+        // without idling a paused Robolectric main looper.
+        val coordinator = SharedSetupCoordinator(store, publishDispatcher = Dispatchers.Unconfined)
 
         try {
             coordinator.acceptExternalUriAsync(firstUri)
@@ -104,7 +107,9 @@ class SharedSetupIntentCoordinatorTest {
             check(release.await(5, TimeUnit.SECONDS))
             byteArrayOf(9)
         }
-        val coordinator = SharedSetupCoordinator(store)
+        // Publishing unconfined makes this test stronger: a read that wrongly survives
+        // finish() would publish immediately instead of waiting on a paused looper.
+        val coordinator = SharedSetupCoordinator(store, publishDispatcher = Dispatchers.Unconfined)
 
         try {
             coordinator.acceptExternalUriAsync(uri)


### PR DESCRIPTION
## Summary

Fixes the intermittent Android CI crash in `SharedSetupActivityLifecycleTest.warmActionViewRoutesExistingActivityDirectlyToReview` that has been failing **main itself** since at least Aug 23 (also seen blocking PRs, e.g. #144 until a rerun).

## Root cause

`java.lang.IllegalStateException: State must be at least CREATED to move to DESTROYED, but was INITIALIZED in NavBackStackEntry route=shared_setup` during activity destroy.

Reproduced locally on an API 35 emulator with thread diagnostics: `publishExternalBytes` set the `imports` StateFlow from the `Dispatchers.IO` read job. A StateFlow **resumes a suspended collector undispatched on the publishing thread**, so when the provider read won the race against the recompressor (a few ms after `onNewIntent`), the `imports` collector in `HealthMdNavigation` ran `navController.navigate()` **on the IO worker**. `navigate` pushed the `shared_setup` back-stack entry and then threw `Method setCurrentState must be called on the main thread` mid-lifecycle-dispatch, leaving a never-composed `INITIALIZED` entry that crashed activity destroy. Captured evidence:

```
collect fired: ... thread=Thread[DefaultDispatcher-worker-2] looperMain=false
navigate threw: IllegalStateException: Method setCurrentState must be called on the main thread
```

The `SharedSetupViewModel` collector has the same resumption hazard around `SavedStateHandle` writes (not thread-safe).

## Fix

- `SharedSetupCoordinator` publishes accepted imports through an injectable `publishDispatcher` defaulting to `Dispatchers.Main.immediate` (Dagger-friendly `@Inject` secondary constructor) — every collector body now runs on the main thread.
- `HealthMdNavigation` additionally pins the warm-intent navigation to `Dispatchers.Main.immediate` inside the collector, guarding against any future off-main emission path.
- Coordinator tests inject `Dispatchers.Unconfined` to keep observing publishes without idling a paused Robolectric main looper; the cancelled-read test becomes stronger because a wrongly surviving job now publishes immediately.

## Verification (local API 35 emulator)

- Pre-fix: the flaky test failed within 3–9 attempts (3 distinct crash captures).
- Post-fix: **30/30 attempts pass**.
- Full `:app:connectedDebugAndroidTest` (40 tests) and `:app:testDebugUnitTest` suites pass.