### PR TITLE
ci(apple): require full Apple CI before any store release

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,7 +48,7 @@ The canonical release path starts from a draft GitHub Release whose tag starts w
 - `.github/workflows/release-ios.yml`
 - `.github/workflows/release-macos.yml`
 
-Use `release_tag=v<version>`. The tag version must match `MARKETING_VERSION` in `apps/apple/HealthMd.xcodeproj`; each workflow fails early if it does not. Keep the GitHub Release as a draft while App Store review is in progress. The ASC approval webhook and `apple-announce.yml` publish it.
+Use `release_tag=v<version>`. The tag version must match `MARKETING_VERSION` in `apps/apple/HealthMd.xcodeproj`; each workflow fails early if it does not. Before building, each workflow resolves the exact release SHA and runs the full Apple CI suite (`apple-ci.yml`) against it — a release cannot build or submit until every Apple test job passes on that exact commit, mirroring the Android release's `qualify` gate. Keep the GitHub Release as a draft while App Store review is in progress. The ASC approval webhook and `apple-announce.yml` publish it.
 
 Publishing a release still triggers both workflows as a legacy fallback, but it is not the canonical path because publication must wait for ASC approval.
 

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -4,6 +4,11 @@
 #   - workflow_dispatch with a draft GitHub Release's v* tag (canonical submission path)
 #   - publishing a GitHub Release with a v* tag (legacy fallback)
 #
+# Gate: before any build or submission, the exact release SHA (the tag's commit,
+# or the branch head for branch-mode runs) must pass the full Apple CI suite via
+# the reusable apple-ci.yml workflow. Store submissions never run on an
+# unqualified commit.
+#
 # Effects on a tagged release run:
 #   1. Build, sign, and export iOS App Store .ipa
 #   2. Upload the .ipa to ASC and submit for review (IOS platform)
@@ -64,8 +69,56 @@ env:
   ASC_APP_ID: ${{ secrets.HEALTHMD_ASC_APP_ID }}
 
 jobs:
+  resolve-release-sha:
+    name: Resolve release SHA
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # The release job builds the tag's commit, but workflow_dispatch runs on a
+      # branch head whose SHA can differ from the tag. Qualify the exact commit
+      # that will be archived, not the dispatch ref.
+      - name: Resolve exact release commit
+        id: resolve
+        run: |
+          set -euo pipefail
+          TAG=""
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+          elif [[ -n "${{ github.event.inputs.release_tag || '' }}" ]]; then
+            TAG="${{ github.event.inputs.release_tag }}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          if [[ -n "$TAG" ]]; then
+            SHA="$(git rev-parse -q --verify "${TAG}^{commit}")"
+            if [[ -z "$SHA" ]]; then
+              echo "::error::Release tag '$TAG' not found in this repository"
+              exit 1
+            fi
+          else
+            # Branch-mode manual run: qualify the exact head being built.
+            SHA="$GITHUB_SHA"
+          fi
+          echo "Qualifying $SHA${TAG:+ (tag $TAG)}"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  qualify:
+    name: Qualify exact Apple release SHA
+    needs: resolve-release-sha
+    uses: ./.github/workflows/apple-ci.yml
+    with:
+      release_sha: ${{ needs.resolve-release-sha.outputs.sha }}
+
   release:
     name: Build & Submit iOS
+    needs: qualify
     if: ${{ github.event_name != 'release' || (startsWith(github.event.release.tag_name, 'v') && github.event.release.author.login != 'github-actions[bot]') }}
     # Keep releases available when the optional self-hosted Mac is offline. The
     # Apple CI suite qualifies this same hosted image and its Xcode toolchain.

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -4,6 +4,11 @@
 #   - workflow_dispatch with a draft GitHub Release's v* tag (canonical submission path)
 #   - publishing a GitHub Release with a v* tag (legacy fallback)
 #
+# Gate: before any build or submission, the exact release SHA (the tag's commit,
+# or the branch head for branch-mode runs) must pass the full Apple CI suite via
+# the reusable apple-ci.yml workflow. Store submissions never run on an
+# unqualified commit.
+#
 # Effects on a tagged release run:
 #   1. Build, sign, notarize Developer ID + App Store builds
 #   2. Upload the App Store pkg to ASC and submit for review (MAC_OS platform)
@@ -64,8 +69,56 @@ env:
   ASC_APP_ID: ${{ secrets.HEALTHMD_ASC_APP_ID }}
 
 jobs:
+  resolve-release-sha:
+    name: Resolve release SHA
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # The release job builds the tag's commit, but workflow_dispatch runs on a
+      # branch head whose SHA can differ from the tag. Qualify the exact commit
+      # that will be archived, not the dispatch ref.
+      - name: Resolve exact release commit
+        id: resolve
+        run: |
+          set -euo pipefail
+          TAG=""
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            TAG="${{ github.event.release.tag_name }}"
+          elif [[ -n "${{ github.event.inputs.release_tag || '' }}" ]]; then
+            TAG="${{ github.event.inputs.release_tag }}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          if [[ -n "$TAG" ]]; then
+            SHA="$(git rev-parse -q --verify "${TAG}^{commit}")"
+            if [[ -z "$SHA" ]]; then
+              echo "::error::Release tag '$TAG' not found in this repository"
+              exit 1
+            fi
+          else
+            # Branch-mode manual run: qualify the exact head being built.
+            SHA="$GITHUB_SHA"
+          fi
+          echo "Qualifying $SHA${TAG:+ (tag $TAG)}"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+  qualify:
+    name: Qualify exact Apple release SHA
+    needs: resolve-release-sha
+    uses: ./.github/workflows/apple-ci.yml
+    with:
+      release_sha: ${{ needs.resolve-release-sha.outputs.sha }}
+
   release:
     name: Build & Release
+    needs: qualify
     if: ${{ github.event_name != 'release' || (startsWith(github.event.release.tag_name, 'v') && github.event.release.author.login != 'github-actions[bot]') }}
     # Keep releases available when the optional self-hosted Mac is offline. The
     # Apple CI suite qualifies this same hosted image and its Xcode toolchain.


### PR DESCRIPTION
## Summary

Per the release-policy decision: direct pushes to `main` stay allowed, but **no app-store release may ship without passing checks**. Android releases already qualify the exact release SHA through the reusable `android-ci.yml` call (`qualify` job in `android-release.yml`). The Apple workflows had no equivalent — `release-ios.yml` / `release-macos.yml` went straight from checkout to archive → upload → submit.

## Change

Both Apple release workflows now run a qualification gate before building:

1. **`resolve-release-sha`** — resolves the exact commit being released: the **tag commit** for release/`release_tag` runs (a `workflow_dispatch` runs on a branch head whose SHA can differ from the tag the release job builds), or the branch head for branch-mode manual runs.
2. **`qualify`** — runs the full `apple-ci.yml` suite (test-ios, test-ios-ui, test-macos, connectivity-package, gate) at that SHA via `workflow_call` + `release_sha`, which `apple-ci.yml` already supports.
3. **`release`** — now `needs: qualify`, so no archive, upload, or ASC submission can start on an unqualified commit.

Applies to every trigger (draft-release dispatch, legacy publish, branch-mode manual, dry runs) — a dry run that passes qualification is exactly what you want before flipping to a real submission.

Also documents the gate in `.github/workflows/README.md` and the workflow headers.

## Verification

- YAML parsed + job wiring asserted programmatically (`resolve-release-sha` → `qualify` → `release`).
- The pattern mirrors the already-proven `android-release.yml` qualify job.
- Dry-run validation of the full pipeline happens on the next Apple release (the release workflows themselves only trigger on release events/dispatch).