### PR TITLE
fix(apple): stop test-ios deinit crashes on CI's iOS 26.2 simulator

### DIFF
--- a/apps/apple/HealthMd/Shared/Models/ConfigurationProtection.swift
+++ b/apps/apple/HealthMd/Shared/Models/ConfigurationProtection.swift
@@ -61,6 +61,12 @@ final class ConfigurationProtectionManager: ObservableObject {
         let toastID = UUID()
         blockedChangeToastID = toastID
         toastDismissTask?.cancel()
+        // UI tests pin the toast: the 4-second auto-dismiss clock starts at
+        // tap time, before the presentation transition settles, so a slow CI
+        // runner can lose the entire hittable window before the polling
+        // helper ever sees a tappable element. Tests dismiss the toast
+        // explicitly by tapping it.
+        guard !TestMode.isUITesting else { return }
         toastDismissTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(4))
             guard !Task.isCancelled, self?.blockedChangeToastID == toastID else { return }

--- a/apps/apple/HealthMd/iOS/SharedSetup/SharedSetupCoordinator.swift
+++ b/apps/apple/HealthMd/iOS/SharedSetup/SharedSetupCoordinator.swift
@@ -1776,6 +1776,11 @@ struct SharedSetupConfigurationCard: View {
 /// and every persistence decision live in the coordinator's verified path.
 @MainActor
 final class SharedSetupV2CredentialEntryModel: ObservableObject {
+    /// `nonisolated deinit` keeps teardown off the MainActor back-deployed
+    /// task-deinit path that aborts older simulator runtimes (see the
+    /// matching annotations on the export stores and coordinators).
+    nonisolated deinit {}
+
     @Published var authorization = ""
 
     var canConfirm: Bool {

--- a/apps/apple/HealthMdTests/SharedSetup/SharedSetupV2ConfirmationFlowTests.swift
+++ b/apps/apple/HealthMdTests/SharedSetup/SharedSetupV2ConfirmationFlowTests.swift
@@ -17,13 +17,11 @@ import XCTest
 final class SharedSetupV2ConfirmationFlowTests: XCTestCase {
     // STATIC RETENTION JUSTIFICATION: MainActor-isolated deinits take the
     // back-deployed task path on older simulator runtimes (CI's iOS 26.2
-    // simulator) where nested store release aborts; retain for the process
-    // lifetime. See docs/testing/lifecycle-audit.md.
-    private static var retainedSettings: [AdvancedExportSettings] = []
-    // STATIC RETENTION JUSTIFICATION: same deinit-crash workaround as above
-    // for the nested ObservableObject instances the real-coordinator test
-    // constructs (ExportProfileCoordinator + VaultManager).
-    private static var retainedInstances: [AnyObject] = []
+    // simulator) where ObservableObject and nested-store release aborts with
+    // `malloc: pointer being freed was not allocated` /
+    // `swift_task_deinitOnExecutorMainActorBackDeploy`; every ObservableObject
+    // this suite constructs is retained for the process lifetime through
+    // LifecycleHarness. See docs/testing/lifecycle-audit.md.
 
     private var defaults: UserDefaults!
     private var suiteName: String!
@@ -460,7 +458,9 @@ final class SharedSetupV2ConfirmationFlowTests: XCTestCase {
     }
 
     func testCredentialEntryModelGatesAndResetsAfterSuccessAndFailure() {
-        let entry = SharedSetupV2CredentialEntryModel()
+        // STATIC RETENTION JUSTIFICATION: ObservableObject deinit aborts on
+        // CI's older iOS 26.2 simulator runtime (lifecycle-audit.md).
+        let entry = LifecycleHarness.retain(SharedSetupV2CredentialEntryModel())
         XCTAssertTrue(entry.authorization.isEmpty)
         XCTAssertFalse(entry.canConfirm)
 
@@ -485,28 +485,7 @@ final class SharedSetupV2ConfirmationFlowTests: XCTestCase {
     // MARK: - Full production loop over the real export profile coordinator
 
     func testFullProductionLoopConfirmsEndpointWithRealExportProfileCoordinator() throws {
-        let keychain = FakeKeychainStore()
-        let vaultManager = VaultManager(
-            defaults: SystemUserDefaults(defaults: defaults),
-            bookmarkResolver: PathMappingBookmarkResolver(),
-            identityProbe: FakeVaultFolderIdentityProbe()
-        )
-        let settings = AdvancedExportSettings(userDefaults: defaults)
-        Self.retainedSettings.append(settings)
-        let apiExportSettings = APIExportSettings(userDefaults: defaults, keychain: keychain)
-        let exportProfiles = ExportProfileCoordinator(
-            profileStore: ExportProfileStore(userDefaults: defaults),
-            destinationStore: ProfileDestinationStore(userDefaults: defaults, keychain: keychain),
-            scheduledEntryStore: ScheduledExportEntryStore(userDefaults: defaults),
-            settings: settings,
-            vaultManager: vaultManager,
-            apiExportSettings: apiExportSettings,
-            initialTarget: .localIPhoneFolder,
-            sharedSetupV2ExecutionGate: SharedSetupV2ExecutionGate(userDefaults: defaults)
-        )
-        Self.retainedInstances.append(exportProfiles)
-        Self.retainedInstances.append(vaultManager)
-
+        let exportProfiles = makeRetainedExportProfileCoordinator()
         let service = makeService(profileIDs: [uuid(101)], scheduleIDs: [uuid(201)])
         let adapter = SharedSetupV2CoordinatorAdapter.production(
             service,
@@ -1108,8 +1087,9 @@ final class SharedSetupV2ConfirmationFlowTests: XCTestCase {
     func testProductionConnectedMacFactChangesFireOnlyOnDisplayedFacts() throws {
         // The production signal derives purely from the shared sync service's
         // published facts the review rows display — no transport work.
-        let syncService = SyncService()
-        Self.retainedInstances.append(syncService)
+        // STATIC RETENTION JUSTIFICATION: ObservableObject deinit aborts on
+        // CI's older iOS 26.2 simulator runtime (lifecycle-audit.md).
+        let syncService = LifecycleHarness.retain(SyncService())
         let signalCount = SignalCounter()
         let cancellable = SharedSetupV2CoordinatorAdapter
             .connectedMacFactChanges(syncService: syncService)
@@ -1163,30 +1143,36 @@ final class SharedSetupV2ConfirmationFlowTests: XCTestCase {
     }
 
     /// The real production export-profile coordinator over this test's
-    /// isolated suite — the exact editor path, retained for the process
-    /// lifetime per the sanitizer-gate lifecycle audit.
+    /// isolated suite — the exact editor path. Every ObservableObject in
+    /// the nested graph is retained for the process lifetime per the
+    /// sanitizer-gate lifecycle audit (docs/testing/lifecycle-audit.md):
+    /// unreleased-in-time ObservableObject deinits abort CI's iOS 26.2
+    /// simulator with `pointer being freed was not allocated`.
     private func makeRetainedExportProfileCoordinator() -> ExportProfileCoordinator {
         let keychain = FakeKeychainStore()
-        let vaultManager = VaultManager(
+        let vaultManager = LifecycleHarness.retain(VaultManager(
             defaults: SystemUserDefaults(defaults: defaults),
             bookmarkResolver: PathMappingBookmarkResolver(),
             identityProbe: FakeVaultFolderIdentityProbe()
+        ))
+        let settings = LifecycleHarness.retain(AdvancedExportSettings(userDefaults: defaults))
+        let apiExportSettings = LifecycleHarness.retain(
+            APIExportSettings(userDefaults: defaults, keychain: keychain)
         )
-        let settings = AdvancedExportSettings(userDefaults: defaults)
-        Self.retainedSettings.append(settings)
-        let exportProfiles = ExportProfileCoordinator(
-            profileStore: ExportProfileStore(userDefaults: defaults),
-            destinationStore: ProfileDestinationStore(userDefaults: defaults, keychain: keychain),
-            scheduledEntryStore: ScheduledExportEntryStore(userDefaults: defaults),
+        return LifecycleHarness.retain(ExportProfileCoordinator(
+            profileStore: LifecycleHarness.retain(ExportProfileStore(userDefaults: defaults)),
+            destinationStore: LifecycleHarness.retain(
+                ProfileDestinationStore(userDefaults: defaults, keychain: keychain)
+            ),
+            scheduledEntryStore: LifecycleHarness.retain(
+                ScheduledExportEntryStore(userDefaults: defaults)
+            ),
             settings: settings,
             vaultManager: vaultManager,
-            apiExportSettings: APIExportSettings(userDefaults: defaults, keychain: keychain),
+            apiExportSettings: apiExportSettings,
             initialTarget: .localIPhoneFolder,
             sharedSetupV2ExecutionGate: SharedSetupV2ExecutionGate(userDefaults: defaults)
-        )
-        Self.retainedInstances.append(exportProfiles)
-        Self.retainedInstances.append(vaultManager)
-        return exportProfiles
+        ))
     }
 
     private func makeService(
@@ -1202,21 +1188,28 @@ final class SharedSetupV2ConfirmationFlowTests: XCTestCase {
             makeProfileID: { profileIterator.next() ?? self.uuid(8_001) },
             makeScheduleID: { scheduleIterator.next() ?? self.uuid(8_002) }
         )
-        return SharedSetupV2TransactionAdapter(
+        // STATIC RETENTION JUSTIFICATION: the adapter (and its transaction
+        // + execution gate) participates in the coordinator graph whose
+        // ObservableObject deinits abort CI's iOS 26.2 simulator runtime
+        // (lifecycle-audit.md); retain for the process lifetime.
+        return LifecycleHarness.retain(SharedSetupV2TransactionAdapter(
             transaction: transaction,
             executionGate: SharedSetupV2ExecutionGate(userDefaults: defaults)
-        )
+        ))
     }
 
     private func makeCoordinator(
         adapter: SharedSetupV2CoordinatorAdapter?,
         announcer: @escaping @MainActor @Sendable (String) -> Void = { _ in }
     ) -> SharedSetupCoordinator {
-        SharedSetupCoordinator(
+        // STATIC RETENTION JUSTIFICATION: the coordinator is an
+        // ObservableObject whose deinit aborts CI's iOS 26.2 simulator
+        // runtime (lifecycle-audit.md); retain for the process lifetime.
+        LifecycleHarness.retain(SharedSetupCoordinator(
             registry: fixtureRegistry(),
             accessibilityAnnouncer: announcer,
             v2Adapter: adapter
-        )
+        ))
     }
 
     private func storedBlockedIDs() throws -> [UUID] {

--- a/apps/apple/HealthMdTests/SharedSetup/SharedSetupV2ConfirmationFlowTests.swift
+++ b/apps/apple/HealthMdTests/SharedSetup/SharedSetupV2ConfirmationFlowTests.swift
@@ -1087,31 +1087,34 @@ final class SharedSetupV2ConfirmationFlowTests: XCTestCase {
     func testProductionConnectedMacFactChangesFireOnlyOnDisplayedFacts() throws {
         // The production signal derives purely from the shared sync service's
         // published facts the review rows display — no transport work.
-        // STATIC RETENTION JUSTIFICATION: ObservableObject deinit aborts on
-        // CI's older iOS 26.2 simulator runtime (lifecycle-audit.md).
+        // STATIC RETENTION JUSTIFICATION: both the ObservableObject and the
+        // subscription's AnyCancellable must survive the test: releasing the
+        // cancellable tears down the CombineLatest4 subscription chain over
+        // the service's @Published projections, which aborts CI's older
+        // iOS 26.2 simulator runtime (lifecycle-audit.md).
         let syncService = LifecycleHarness.retain(SyncService())
         let signalCount = SignalCounter()
-        let cancellable = SharedSetupV2CoordinatorAdapter
-            .connectedMacFactChanges(syncService: syncService)
-            .sink { _ in signalCount.value += 1 }
+        let cancellable = LifecycleHarness.retain(
+            SharedSetupV2CoordinatorAdapter
+                .connectedMacFactChanges(syncService: syncService)
+                .sink { _ in signalCount.value += 1 }
+        )
 
-        withExtendedLifetime(cancellable) {
-            // No initial replay of current values fires a signal.
-            XCTAssertEqual(signalCount.value, 0)
+        // No initial replay of current values fires a signal.
+        XCTAssertEqual(signalCount.value, 0)
 
-            syncService.connectionState = .connecting
-            XCTAssertEqual(signalCount.value, 1)
-            syncService.connectionState = .connected
-            XCTAssertEqual(signalCount.value, 2)
-            syncService.connectedPeerName = "Test Mac"
-            XCTAssertEqual(signalCount.value, 3)
+        syncService.connectionState = .connecting
+        XCTAssertEqual(signalCount.value, 1)
+        syncService.connectionState = .connected
+        XCTAssertEqual(signalCount.value, 2)
+        syncService.connectedPeerName = "Test Mac"
+        XCTAssertEqual(signalCount.value, 3)
 
-            // Unrelated published sync-service state never re-renders the
-            // review rows.
-            syncService.lastError = "unrelated"
-            syncService.discoveredPeers = []
-            XCTAssertEqual(signalCount.value, 3)
-        }
+        // Unrelated published sync-service state never re-renders the
+        // review rows.
+        syncService.lastError = "unrelated"
+        syncService.discoveredPeers = []
+        XCTAssertEqual(signalCount.value, 3)
 
         let snapshot = SharedSetupV2ConnectedMacState(syncService: syncService)
         XCTAssertEqual(snapshot.liveConnectionCaption, "Mac connection active (Test Mac)")

--- a/apps/apple/HealthMdUITests/ConfigurationProtectionJourneyUITests.swift
+++ b/apps/apple/HealthMdUITests/ConfigurationProtectionJourneyUITests.swift
@@ -21,7 +21,7 @@ final class ConfigurationProtectionJourneyUITests: XCTestCase {
     /// element and querying again after the presentation animation.
     private func waitForHittableToast(
         in app: XCUIApplication,
-        timeout: TimeInterval = 3
+        timeout: TimeInterval = 10
     ) -> XCUIElement? {
         let deadline = Date().addingTimeInterval(timeout)
         let predicate = NSPredicate(format: "identifier == %@", UITestLaunchHelper.ConfigurationProtection.toast)
@@ -39,8 +39,10 @@ final class ConfigurationProtectionJourneyUITests: XCTestCase {
 
     /// Waits until an element both exists and is hittable, so taps land even
     /// while sheet presentation or navigation-push animations are settling.
+    /// Generous by default: loaded CI runners can take several seconds for
+    /// sheet content to settle into a hittable state.
     @discardableResult
-    private func waitHittable(_ element: XCUIElement, timeout: TimeInterval = 5) -> Bool {
+    private func waitHittable(_ element: XCUIElement, timeout: TimeInterval = 10) -> Bool {
         let expectation = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "isHittable == true"),
             object: element

--- a/apps/apple/docs/testing/lifecycle-audit.md
+++ b/apps/apple/docs/testing/lifecycle-audit.md
@@ -20,7 +20,7 @@ The E6 lifecycle stress epic (`TODO-2b0cd43e`) introduced:
 - **All remaining** `static var retained*` arrays now have `STATIC RETENTION JUSTIFICATION` comments.
 
 **Current state:**
-- **7 test files** contain static-retention workarounds (4 original + 3 discovered during E6 scan)
+- **8 test files** contain static-retention workarounds (4 original + 3 discovered during E6 scan + SharedSetupV2ConfirmationFlowTests added 2026-09-06)
 - **9 ObservableObject types** are affected (6 original + VaultManager, PurchaseManager, ReviewManager)
 - **All workarounds are temporary** -- they exist solely to work around the Swift 6 runtime bug
 
@@ -49,6 +49,7 @@ The E6 lifecycle stress epic (`TODO-2b0cd43e`) introduced:
 | ModelTests.swift | 470-491 | `static let` (closures) | `DailyNoteInjectionSettings` | 4 | Immutable read-only fixtures (yearMonthDay, quarter, dailyFolder, emptyFolder). |
 | ModelTests.swift | 580-625 | `static let` (closures) | `IndividualTrackingSettings` | 6 | Immutable read-only fixtures (various configs). |
 | VaultManagerTests.swift | 53-54 | `static var` (arrays) | `VaultManager`, `AdvancedExportSettings` | Dynamic | Manager tests retain per-test instances. |
+| SharedSetupV2ConfirmationFlowTests.swift | `LifecycleHarness.retain()` in `makeService`, `makeCoordinator`, `makeRetainedExportProfileCoordinator`, and per-test constructions | `SharedSetupCoordinator`, `SharedSetupV2CredentialEntryModel`, `APIExportSettings`, `ExportProfileStore`, `ProfileDestinationStore`, `ScheduledExportEntryStore`, `ExportProfileCoordinator`, `VaultManager`, `AdvancedExportSettings`, `SyncService`, `SharedSetupV2TransactionAdapter` | Dynamic | CI iOS 26.2 simulator deinit crashes (2026-09-06): the suite initially retained only the coordinator graph roots; unreleased-in-time ObservableObject deinits aborted the test process 8× with `malloc: pointer being freed was not allocated` (`swift_task_deinitOnExecutorMainActorBackDeploy`). Passes on iOS 26.5+ where the runtime fix landed. |
 | PurchaseManagerTests.swift | 16 | `static var` (array) | `PurchaseManager` | Dynamic | Manager tests retain per-test instances. |
 | ReviewManagerTests.swift | 15 | `static var` (array) | `ReviewManager` | Dynamic | Manager tests retain per-test instances. |
 


### PR DESCRIPTION
## Problem

`test-ios` had failed on every Apple CI run since 2026-09-05 with 8 deterministic test failures, all in `SharedSetupV2ConfirmationFlowTests`:

```
malloc: *** error for object 0x262552740: pointer being freed was not allocated
Crash: HealthMd at swift_task_deinitOnExecutorMainActorBackDeploy
```

xcodebuild restarted the test process 8 times; each restart re-crashed at the same address.

## Why it passed locally but not in CI

- CI's `macos-26` runner devices (iPhone 17 Pro) run the **iOS 26.2** simulator runtime; local machines are on **iOS 26.5**, which ships the Swift runtime fix.
- iOS 26.2's back-deployed MainActor task-deinit path double-frees when `ObservableObject` instances (or their Combine subscriptions) release mid-run — the exact bug documented in `apps/apple/docs/testing/lifecycle-audit.md`, with the established workaround being process-lifetime static retention.
- The last green main run (`74bd5fdc5`) predates this test file; the first failing run (`a1f45e4b3`, a docs-only commit) swept in the shared-setup v2 batch. The file had **never** passed on CI.
- The file landed with retention for only part of its graph, leaving `SharedSetupCoordinator` (every test), `APIExportSettings`, `ExportProfileStore`, `ProfileDestinationStore`, `ScheduledExportEntryStore`, the transaction adapter, the credential entry model, and the connected-Mac Combine subscription to release mid-run.

## Fix (test-ios crashes)

1. **Test**: retain every class instance the suite constructs via `LifecycleHarness` (the E6 pattern from the lifecycle audit), replacing the file-local static arrays. Includes `STATIC RETENTION JUSTIFICATION` comments.
2. **Test**: retain the `connectedMacFactChanges` `AnyCancellable` — releasing it tears down the `CombineLatest4` chain over four `@Published` projections, which aborts the old runtime (the residual crash after the first CI validation round).
3. **Production**: `SharedSetupV2CredentialEntryModel` gets `nonisolated deinit {}`, matching the 29 other collaborators annotated against this runtime bug.
4. **Docs**: record the suite in the lifecycle audit matrix per its own recommendation #3.

## Fix (pre-existing UI toast flake blocking the gate)

While validating, the `iOS UI regressions` job flaked on `ConfigurationProtectionJourneyUITests` — a pre-existing issue (failed on main-adjacent runs 33995197321 / 33999529122 before this PR, a different test each time). Root cause: `presentBlockedChangeToast()` starts its 4-second auto-dismiss clock at tap time — before the presentation transition settles — while the UI-test helper polled for a hittable toast for only 3 seconds, so slow CI runners lost the hittable window entirely.

- Under `--uitesting` the toast no longer auto-dismisses (every test already dismisses it by tapping; unit tests are unaffected and never relied on the timer).
- Toast poll 3s → 10s, `waitHittable` default 5s → 10s for the suite.
- Tracked and closed as TODO-1a49d5a9.

## Validation

- **CI run 34038032510**: test-ios **SUCCESS** on the iOS 26.2 simulator — 2278 tests, 0 failures; first commit cut 8 crashes → 1, second closed the last one.
- **CI run 34043396564**: **Apple CI fully green** — test-ios, test-macos, iOS UI regressions (all three previously-flaking ConfigurationProtection tests pass), connectivity, and shared-core.
- Full iOS unit suite locally: 2278 tests, 0 failures; no new compiler warnings.

## Note: one-off infra flake observed

One validation run hit a rare runner-level hang: the second sequential `xcodebuild test` invocation produced no output for ~24 min until the step's 35-min timeout (teardown: "Terminate orphan process: (xcodebuild)"). A rerun passed cleanly. Recorded in TODO-1a49d5a9 with a suggested workflow hardening (`simctl shutdown` between invocations) if it recurs.
