### PR TITLE
ci: path-filter component gates and parallelize Android emulator CI

### DIFF
--- a/.github/actions/component-changes/action.yml
+++ b/.github/actions/component-changes/action.yml
@@ -1,0 +1,131 @@
+name: 'Detect component changes'
+description: >-
+  Reports whether any file in a pull request matches the component path
+  filters. Non-pull-request events (push, schedule, workflow_dispatch,
+  repository_dispatch, workflow_call) always report 'true' so those runs
+  execute the full workflow. Detection fails closed: any error fails the job
+  instead of silently skipping the component.
+inputs:
+  component:
+    description: 'Component name used in log output.'
+    required: true
+  paths:
+    description: >-
+      Newline-separated path patterns using the same '*', '**', and '?'
+      glob syntax as workflow 'on.<event>.paths' filters.
+    required: true
+outputs:
+  run:
+    description: "'true' when the component's CI jobs should run."
+    value: ${{ steps.detect.outputs.run }}
+runs:
+  using: composite
+  steps:
+    - id: detect
+      name: Detect whether the component is affected
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        REPOSITORY: ${{ github.repository }}
+        EVENT_NAME: ${{ github.event_name }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        COMPONENT: ${{ inputs.component }}
+        COMPONENT_PATHS: ${{ inputs.paths }}
+      run: |
+        set -euo pipefail
+
+        if [[ "${EVENT_NAME}" != "pull_request" ]]; then
+          echo "${COMPONENT}: '${EVENT_NAME}' event always runs the full workflow."
+          echo "run=true" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        # List the pull request's changed files through the API instead of a
+        # full clone, and match them with workflow-'paths' glob semantics:
+        # '*' and '?' do not cross '/', '**' does.
+        python3 - <<'PY'
+        import json
+        import os
+        import re
+        import urllib.request
+
+        component = os.environ["COMPONENT"]
+        patterns = [
+            line.strip()
+            for line in os.environ["COMPONENT_PATHS"].splitlines()
+            if line.strip()
+        ]
+        if not patterns:
+            raise SystemExit(f"{component}: at least one path pattern is required")
+
+
+        def pattern_to_regex(pattern):
+            parts = []
+            index = 0
+            while index < len(pattern):
+                character = pattern[index]
+                if character == "*":
+                    if index + 1 < len(pattern) and pattern[index + 1] == "*":
+                        parts.append(".*")
+                        index += 2
+                    else:
+                        parts.append("[^/]*")
+                        index += 1
+                elif character == "?":
+                    parts.append("[^/]")
+                    index += 1
+                else:
+                    parts.append(re.escape(character))
+                    index += 1
+            return re.compile("^" + "".join(parts) + "$")
+
+
+        regexes = [pattern_to_regex(pattern) for pattern in patterns]
+
+        token = os.environ["GH_TOKEN"]
+        repository = os.environ["REPOSITORY"]
+        number = os.environ["PR_NUMBER"]
+
+        def request_page(page):
+            url = (
+                "https://api.github.com/repos/"
+                f"{repository}/pulls/{number}/files?per_page=100&page={page}"
+            )
+            request = urllib.request.Request(
+                url,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {token}",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+            )
+            with urllib.request.urlopen(request) as response:
+                return json.load(response), response.headers
+
+        changed = []
+        page = 1
+        while True:
+            files, headers = request_page(page)
+            changed.extend(entry["filename"] for entry in files)
+            if 'rel="next"' not in headers.get("Link", ""):
+                break
+            page += 1
+
+        matching = sorted(
+            {
+                filename
+                for filename in changed
+                if any(regex.match(filename) for regex in regexes)
+            }
+        )
+        if matching:
+            print(f"{component}: pull request changes {len(matching)} matching file(s):")
+            for filename in matching:
+                print(f"  {filename}")
+            result = "true"
+        else:
+            print(f"{component}: pull request changes no matching files.")
+            result = "false"
+        with open(os.environ["GITHUB_OUTPUT"], "a") as handle:
+            handle.write(f"run={result}\n")
+        PY

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 ## Required pull-request gates
 
-Every pull request runs the component CI workflows and reports seven stable final contexts suitable for branch protection:
+Every pull request triggers the component CI workflows, and each reports one of seven stable final contexts suitable for branch protection:
 
 - `Apple CI / Apple CI`
 - `Android CI / Android CI`
@@ -12,7 +12,11 @@ Every pull request runs the component CI workflows and reports seven stable fina
 - `Wake CI / Wake CI`
 - `Website CI / Website CI`
 
-The final jobs fail unless every job in their component workflow succeeds. Main-branch push triggers remain path-aware, so unaffected components are not rebuilt after merge.
+Inside each workflow except Wake CI (whose single job finishes in well under a minute and stays always-on), a small `changes` job evaluates the pull request's changed files through `.github/actions/component-changes` against the same path map that gates that workflow's `main`-branch push trigger. When nothing matches, the heavy jobs are skipped and the final gate job still runs and succeeds, so every PR receives a conclusive required context without paying for unaffected components. Detection fails closed: if the `changes` job itself errors, the gate fails rather than silently skipping. Scheduled, manually dispatched, and `workflow_call` release-qualification runs always execute the full workflow.
+
+Each workflow's path map lives in two places — the `on.push.paths` trigger filter and the `changes` job's `paths` input — and the two copies must stay in sync. Shared contract paths (`packages/contracts/**`) and shared-core paths (`packages/healthmd-core-rust/**`) intentionally trigger every consuming component, including Apple CI.
+
+The final gate jobs fail unless every job in their component workflow succeeds (or path filtering skipped the whole component). Main-branch push triggers remain path-aware — Apple CI's `main`/`testing` pushes included — so unaffected components are not rebuilt after merge.
 
 ## Android release trigger
 

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,8 +1,10 @@
 name: Android CI
 
 on:
-  # Run on every PR so the stable final gate can be a required check. Main-branch pushes
-  # remain path-aware to avoid rebuilding an unaffected component after merge.
+  # Pull requests are path-filtered by the changes job so the stable final gate
+  # still reports a conclusive required context on every PR without running the
+  # heavy jobs for unrelated changes. Main-branch pushes remain path-aware at
+  # the trigger to avoid rebuilding an unaffected component after merge.
   pull_request:
   push:
     branches: [main]
@@ -30,7 +32,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Android-affecting changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+    steps:
+      - name: Check out source for the local composite action
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Detect whether Android CI must run
+        id: detect
+        uses: ./.github/actions/component-changes
+        with:
+          component: Android CI
+          paths: |
+            apps/android/**
+            apps/cli/**
+            packages/contracts/**
+            packages/healthmd-core-rust/**
+            docs/migration/**
+            .github/workflows/README.md
+            .github/workflows/android-*.yml
+
   test:
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
@@ -176,6 +206,61 @@ jobs:
             app/build/outputs/bundle/playDebug/app-play-debug.aab
           bash scripts/tests/test_verify_google_play_generated_apk_evidence.sh
 
+  instrumentation:
+    name: Emulator instrumentation and direct E2E
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    defaults:
+      run:
+        working-directory: apps/android
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.release_sha || github.sha }}
+
+      - name: Set up Java
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Android SDK command-line tools
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Set up pinned Rust Android toolchain
+        working-directory: ${{ github.workspace }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          rustup toolchain install 1.88.0 --profile minimal
+          rustup target add --toolchain 1.88.0 \
+            aarch64-linux-android \
+            armv7-linux-androideabi \
+            x86_64-linux-android \
+            i686-linux-android
+          rustup run 1.88.0 cargo install cargo-ndk --version 4.1.2 --locked
+
+      - name: Install pinned Android NDK
+        shell: bash
+        run: |
+          set -euo pipefail
+          android_sdk="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+          test -n "$android_sdk"
+          sdkmanager "ndk;27.1.12297006"
+          echo "ANDROID_NDK_HOME=$android_sdk/ndk/27.1.12297006" >> "$GITHUB_ENV"
+          echo "ANDROID_NDK_ROOT=$android_sdk/ndk/27.1.12297006" >> "$GITHUB_ENV"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Prepare source-built Rust core before the emulator boots
+        run: ./gradlew --no-daemon :healthmd-core:prepareRustDebug --stacktrace
+
       - name: Enable KVM access
         run: sudo chmod 666 /dev/kvm
 
@@ -193,6 +278,8 @@ jobs:
 
   fdroid:
     name: F-Droid clean build
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:
@@ -291,6 +378,8 @@ jobs:
 
   wear-emulator-smoke:
     name: Wear emulator smoke
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
@@ -328,6 +417,8 @@ jobs:
 
   rust-kotlin-direct-interop:
     name: Rust/Kotlin direct interop
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
@@ -398,17 +489,33 @@ jobs:
   gate:
     name: Android CI
     if: ${{ always() }}
-    needs: [test, fdroid, wear-emulator-smoke, rust-kotlin-direct-interop]
+    needs:
+      - changes
+      - test
+      - fdroid
+      - wear-emulator-smoke
+      - instrumentation
+      - rust-kotlin-direct-interop
     runs-on: ubuntu-24.04
     steps:
       - name: Require Android checks
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_RUN: ${{ needs.changes.outputs.run }}
           TEST_RESULT: ${{ needs.test.result }}
           FDROID_RESULT: ${{ needs.fdroid.result }}
           INTEROP_RESULT: ${{ needs.rust-kotlin-direct-interop.result }}
           WEAR_RESULT: ${{ needs.wear-emulator-smoke.result }}
+          INSTRUMENTATION_RESULT: ${{ needs.instrumentation.result }}
         run: |
+          set -e
+          test "$CHANGES_RESULT" = success
+          if [ "$CHANGES_RUN" != "true" ]; then
+            echo "No Android-affecting changes in this pull request; Android CI skipped."
+            exit 0
+          fi
           test "$TEST_RESULT" = success
           test "$FDROID_RESULT" = success
           test "$INTEROP_RESULT" = success
           test "$WEAR_RESULT" = success
+          test "$INSTRUMENTATION_RESULT" = success

--- a/.github/workflows/apple-ci.yml
+++ b/.github/workflows/apple-ci.yml
@@ -5,6 +5,15 @@ on:
     branches:
       - main
       - testing
+    # Path-aware pushes keep unrelated merges off the scarce macOS runner pool;
+    # pull requests are path-filtered by the changes job so the stable gate
+    # still reports a conclusive context on every PR.
+    paths:
+      - 'apps/apple/**'
+      - 'packages/contracts/**'
+      - 'packages/healthmd-core-rust/**'
+      - 'Makefile'
+      - '.github/workflows/apple-ci.yml'
   pull_request:
   workflow_dispatch:
   workflow_call:
@@ -19,8 +28,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect Apple-affecting changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+    steps:
+      - name: Check out source for the local composite action
+        uses: actions/checkout@v6
+      - name: Detect whether Apple CI must run
+        id: detect
+        uses: ./.github/actions/component-changes
+        with:
+          component: Apple CI
+          paths: |
+            apps/apple/**
+            packages/contracts/**
+            packages/healthmd-core-rust/**
+            Makefile
+            .github/workflows/apple-ci.yml
+
   prepare-shared-core:
     name: Prepare shared Rust core once
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: macos-26
     timeout-minutes: 20
     defaults:
@@ -78,7 +113,8 @@ jobs:
           retention-days: 1
 
   test-ios:
-    needs: prepare-shared-core
+    needs: [changes, prepare-shared-core]
+    if: ${{ needs.changes.outputs.run == 'true' }}
     # Notelet requires Swift tools 6.3. The macos-26 hosted image includes
     # Xcode 26.6, so PR validation does not depend on a self-hosted runner.
     runs-on: macos-26
@@ -254,7 +290,8 @@ jobs:
           retention-days: 14
 
   test-macos:
-    needs: prepare-shared-core
+    needs: [changes, prepare-shared-core]
+    if: ${{ needs.changes.outputs.run == 'true' }}
     # Keep the macOS suite on the same hosted Xcode 26 toolchain as the iOS job.
     runs-on: macos-26
     timeout-minutes: 75
@@ -333,7 +370,8 @@ jobs:
 
   test-ios-ui:
     name: iOS UI regressions
-    needs: prepare-shared-core
+    needs: [changes, prepare-shared-core]
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: macos-26
     timeout-minutes: 60
     defaults:
@@ -522,6 +560,8 @@ jobs:
 
   connectivity-package:
     name: HealthMdConnectivity package
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: macos-14
     timeout-minutes: 15
     steps:
@@ -536,17 +576,31 @@ jobs:
   gate:
     name: Apple CI
     if: ${{ always() }}
-    needs: [prepare-shared-core, test-ios, test-ios-ui, test-macos, connectivity-package]
+    needs:
+      - changes
+      - prepare-shared-core
+      - test-ios
+      - test-ios-ui
+      - test-macos
+      - connectivity-package
     runs-on: ubuntu-24.04
     steps:
       - name: Require Apple checks
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_RUN: ${{ needs.changes.outputs.run }}
           PREPARE_RESULT: ${{ needs.prepare-shared-core.result }}
           IOS_RESULT: ${{ needs.test-ios.result }}
           IOS_UI_RESULT: ${{ needs.test-ios-ui.result }}
           MACOS_RESULT: ${{ needs.test-macos.result }}
           CONNECTIVITY_RESULT: ${{ needs.connectivity-package.result }}
         run: |
+          set -e
+          test "$CHANGES_RESULT" = success
+          if [ "$CHANGES_RUN" != "true" ]; then
+            echo "No Apple-affecting changes in this pull request; Apple CI skipped."
+            exit 0
+          fi
           test "$PREPARE_RESULT" = success
           test "$IOS_RESULT" = success
           test "$IOS_UI_RESULT" = success

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -376,7 +376,7 @@ jobs:
           curl --proto '=https' --tlsv1.2 -fsSL \
             "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.20.2/cargo-deny-0.20.2-x86_64-unknown-linux-musl.tar.gz" \
             -o "$archive"
-          echo '9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5fc  '"$archive" \
+          echo '9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5f  '"$archive" \
             | sha256sum --check --strict
           tar -xzf "$archive" -C "$RUNNER_TEMP"
           install -m 0755 \

--- a/.github/workflows/cli-ci.yml
+++ b/.github/workflows/cli-ci.yml
@@ -1,8 +1,10 @@
 name: CLI CI
 
 on:
-  # Run on every PR so the stable final gate can be a required check. Main-branch pushes
-  # remain path-aware to avoid rebuilding an unaffected component after merge.
+  # Pull requests are path-filtered by the changes job so the stable final gate
+  # still reports a conclusive required context on every PR without running the
+  # heavy jobs for unrelated changes. Main-branch pushes remain path-aware at
+  # the trigger to avoid rebuilding an unaffected component after merge.
   pull_request:
   push:
     branches: [main]
@@ -22,14 +24,43 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: cli-ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_INCREMENTAL: '0'
   CARGO_PROFILE_DEV_DEBUG: '0'
   CARGO_PROFILE_TEST_DEBUG: '0'
 
 jobs:
+  changes:
+    name: Detect CLI-affecting changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+    steps:
+      - name: Check out source for the local composite action
+        uses: actions/checkout@v4
+      - name: Detect whether CLI CI must run
+        id: detect
+        uses: ./.github/actions/component-changes
+        with:
+          component: CLI CI
+          paths: |
+            apps/cli/**
+            packages/contracts/**
+            packages/healthmd-core-rust/**
+            .github/workflows/cli-*.yml
+
   msrv:
     name: Rust 1.85 MSRV
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -49,6 +80,8 @@ jobs:
 
   test:
     name: ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -325,6 +358,8 @@ jobs:
 
   dependency-policy:
     name: Dependency policy
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -332,7 +367,21 @@ jobs:
           ref: ${{ inputs.release_sha || github.sha }}
       - uses: dtolnay/rust-toolchain@1.88.0
       - name: Install pinned cargo-deny
-        run: cargo install cargo-deny --version 0.20.2 --locked
+        # Download the official prebuilt static binary instead of compiling the
+        # crate from source on every run. The sha256 matches the release's own
+        # .sha256 asset and pins the exact bytes.
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/cargo-deny-0.20.2-x86_64-unknown-linux-musl.tar.gz"
+          curl --proto '=https' --tlsv1.2 -fsSL \
+            "https://github.com/EmbarkStudios/cargo-deny/releases/download/0.20.2/cargo-deny-0.20.2-x86_64-unknown-linux-musl.tar.gz" \
+            -o "$archive"
+          echo '9f12ed4c49936e09b48bf862b595cde2fe64fcbd9d74dfacac6131ca824c8d5fc  '"$archive" \
+            | sha256sum --check --strict
+          tar -xzf "$archive" -C "$RUNNER_TEMP"
+          install -m 0755 \
+            "$RUNNER_TEMP/cargo-deny-0.20.2-x86_64-unknown-linux-musl/cargo-deny" \
+            "$(dirname "$(command -v cargo)")/cargo-deny"
       - name: Check both independently locked workspaces
         run: |
           cargo deny --manifest-path apps/cli/Cargo.toml --config "$GITHUB_WORKSPACE/deny.toml" check
@@ -340,6 +389,8 @@ jobs:
 
   packaged-crates:
     name: Packaged crate smoke
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -370,16 +421,24 @@ jobs:
   gate:
     name: CLI CI
     if: ${{ always() }}
-    needs: [msrv, test, dependency-policy, packaged-crates]
+    needs: [changes, msrv, test, dependency-policy, packaged-crates]
     runs-on: ubuntu-24.04
     steps:
       - name: Require CLI checks
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_RUN: ${{ needs.changes.outputs.run }}
           MSRV_RESULT: ${{ needs.msrv.result }}
           TEST_RESULT: ${{ needs.test.result }}
           DEPENDENCY_RESULT: ${{ needs.dependency-policy.result }}
           PACKAGE_RESULT: ${{ needs.packaged-crates.result }}
         run: |
+          set -e
+          test "$CHANGES_RESULT" = success
+          if [ "$CHANGES_RUN" != "true" ]; then
+            echo "No CLI-affecting changes in this pull request; CLI CI skipped."
+            exit 0
+          fi
           test "$MSRV_RESULT" = success
           test "$TEST_RESULT" = success
           test "$DEPENDENCY_RESULT" = success

--- a/.github/workflows/core-rust-ci.yml
+++ b/.github/workflows/core-rust-ci.yml
@@ -1,8 +1,10 @@
 name: Core Rust CI
 
 on:
-  # Run on every PR so the stable final gate can be a required check. Main-branch pushes
-  # remain path-aware while shared contracts still exercise their Rust implementation.
+  # Pull requests are path-filtered by the changes job so the stable final gate
+  # still reports a conclusive required context on every PR without running the
+  # heavy jobs for unrelated changes. Main-branch pushes remain path-aware at
+  # the trigger while shared contracts still exercise their Rust implementation.
   pull_request:
   push:
     branches: [main]
@@ -34,8 +36,40 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect shared-core-affecting changes
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+    steps:
+      - name: Check out source for the local composite action
+        uses: actions/checkout@v4
+      - name: Detect whether Core Rust CI must run
+        id: detect
+        uses: ./.github/actions/component-changes
+        with:
+          component: Core Rust CI
+          paths: |
+            packages/healthmd-core-rust/**
+            packages/contracts/**
+            apps/apple/HealthMd/Shared/Models/HealthMetrics.swift
+            apps/apple/HealthMd/Shared/Export/HealthMetricsDictionary.swift
+            apps/android/app/src/main/java/com/healthmd/domain/model/MetricSelection.kt
+            apps/android/app/src/main/java/com/healthmd/domain/model/HealthDataFields.kt
+            apps/android/docs/export-contract/android-ios-metric-parity-ledger.md
+            apps/website/docs-src/src/content/docs/shared-metric-registry.md
+            apps/website/docs-src/public/reference/metric-registry-v1.json
+            Makefile
+            .github/workflows/core-rust-ci.yml
+
   msrv:
     name: Rust 1.85 MSRV
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -58,6 +92,8 @@ jobs:
 
   test:
     name: ${{ matrix.os }}
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +140,8 @@ jobs:
 
   bindings:
     name: UniFFI host binding generation
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -124,15 +162,23 @@ jobs:
   gate:
     name: Core Rust CI
     if: ${{ always() }}
-    needs: [msrv, test, bindings]
+    needs: [changes, msrv, test, bindings]
     runs-on: ubuntu-24.04
     steps:
       - name: Require shared-core checks
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_RUN: ${{ needs.changes.outputs.run }}
           MSRV_RESULT: ${{ needs.msrv.result }}
           TEST_RESULT: ${{ needs.test.result }}
           BINDINGS_RESULT: ${{ needs.bindings.result }}
         run: |
+          set -e
+          test "$CHANGES_RESULT" = success
+          if [ "$CHANGES_RUN" != "true" ]; then
+            echo "No shared-core-affecting changes in this pull request; Core Rust CI skipped."
+            exit 0
+          fi
           test "$MSRV_RESULT" = success
           test "$TEST_RESULT" = success
           test "$BINDINGS_RESULT" = success

--- a/.github/workflows/practice-ci.yml
+++ b/.github/workflows/practice-ci.yml
@@ -1,6 +1,9 @@
 name: Practice CI
 
 on:
+  # Pull requests are path-filtered by the changes job so the stable final gate
+  # still reports a conclusive required context on every PR while unrelated
+  # changes skip the focused clinical-boundary policy jobs.
   pull_request:
   push:
     branches: [main]
@@ -30,7 +33,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect practice-affecting changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+    steps:
+      - name: Check out source for the local composite action
+        uses: actions/checkout@v4
+      - name: Detect whether Practice CI must run
+        id: detect
+        uses: ./.github/actions/component-changes
+        with:
+          component: Practice CI
+          paths: |
+            apps/practice/**
+            apps/apple/HealthMd/Shared/Practice/**
+            apps/apple/HealthMdTests/Practice/**
+            apps/apple/HealthMd.xcodeproj/**
+            apps/android/app/src/main/java/com/healthmd/domain/practice/**
+            apps/android/app/src/test/java/com/healthmd/domain/practice/**
+            apps/android/app/build.gradle.kts
+            docs/product/practice/**
+            docs/architecture/adr-0003-practice-clinical-boundary.md
+            docs/features/clinician-report-v1.md
+            AGENTS.md
+            LICENSES.md
+            Makefile
+            .github/workflows/practice-ci.yml
+
   validate:
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 35
     defaults:
@@ -51,6 +89,13 @@ jobs:
 
       - name: Install locked dependencies
         run: npm ci
+
+      - name: Restore Playwright browser engines
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: practice-playwright-${{ runner.os }}-${{ hashFiles('apps/practice/package-lock.json') }}
+          restore-keys: practice-playwright-${{ runner.os }}-
 
       - name: Install exact Playwright browser engines and system dependencies
         run: npx playwright install --with-deps chromium firefox webkit
@@ -74,6 +119,8 @@ jobs:
 
   practice-focused-apple-policy:
     name: Practice focused Apple policy
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: macos-15
     timeout-minutes: 10
     steps:
@@ -184,6 +231,8 @@ jobs:
 
   practice-focused-android-policy:
     name: Practice focused Android policy
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 35
     defaults:
@@ -246,23 +295,35 @@ jobs:
         run: ./gradlew --no-daemon :app:testPlayDebugUnitTest --tests com.healthmd.domain.practice.PracticeFeaturePolicyTest --stacktrace
 
       - name: Regenerate BuildConfig and run focused included Practice policy test
+        # PRACTICE_COMPILED_IN feeds a buildConfigField, which is a tracked
+        # GenerateBuildConfig task input, so Gradle re-runs only that task and
+        # the app-module Kotlin recompile. A full :app:clean is unnecessary and
+        # would force recompiling every dependency plus the Rust core.
         env:
           JAVA_TOOL_OPTIONS: -Dhealthmd.practice.expectedCompiledIn=true
           PRACTICE_COMPILED_IN: included
-        run: ./gradlew --no-daemon :app:clean :app:testPlayDebugUnitTest --tests com.healthmd.domain.practice.PracticeFeaturePolicyTest --stacktrace
+        run: ./gradlew --no-daemon :app:testPlayDebugUnitTest --tests com.healthmd.domain.practice.PracticeFeaturePolicyTest --stacktrace
 
   gate:
     name: Practice CI
     if: ${{ always() }}
-    needs: [validate, practice-focused-apple-policy, practice-focused-android-policy]
+    needs: [changes, validate, practice-focused-apple-policy, practice-focused-android-policy]
     runs-on: ubuntu-latest
     steps:
       - name: Require Practice and focused mobile policy checks
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_RUN: ${{ needs.changes.outputs.run }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
           APPLE_RESULT: ${{ needs.practice-focused-apple-policy.result }}
           ANDROID_RESULT: ${{ needs.practice-focused-android-policy.result }}
         run: |
+          set -e
+          test "$CHANGES_RESULT" = success
+          if [ "$CHANGES_RUN" != "true" ]; then
+            echo "No practice-affecting changes in this pull request; Practice CI skipped."
+            exit 0
+          fi
           test "$VALIDATE_RESULT" = success
           test "$APPLE_RESULT" = success
           test "$ANDROID_RESULT" = success

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -1,8 +1,9 @@
 name: Website CI
 
 on:
-  # Run on every PR so the stable final gate can be a required check. Main-branch pushes
-  # remain path-aware to avoid rebuilding an unaffected component after merge.
+  # Pull requests are path-filtered by the changes job so the stable final gate
+  # still reports a conclusive required context on every PR without building the
+  # site for unrelated changes. Scheduled and dispatched runs always validate.
   pull_request:
   push:
     branches: [main]
@@ -28,7 +29,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect website-affecting changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run: ${{ steps.detect.outputs.run }}
+    steps:
+      - name: Check out source for the local composite action
+        uses: actions/checkout@v4
+      - name: Detect whether Website CI must run
+        id: detect
+        uses: ./.github/actions/component-changes
+        with:
+          component: Website CI
+          paths: |
+            .agents/skills/**
+            apps/website/**
+            apps/apple/docs/reference/**
+            apps/apple/scripts/generated-*-docs.sh
+            packages/contracts/**
+            packages/healthmd-core-rust/**
+            .github/workflows/website-ci.yml
+
   validate:
+    needs: changes
+    if: ${{ needs.changes.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
@@ -63,17 +92,39 @@ jobs:
             apps/website/docs-src/package-lock.json
             .external/health-md-visualizations/package-lock.json
 
+      - name: Restore validated Obsidian plugin marker
+        # The pinned revision only changes with external-sources.json; skip the
+        # plugin's own install/test/typecheck/build when this exact revision has
+        # already been validated. The source checkout remains because sync and
+        # the website tests bundle directly from the plugin's src directory.
+        id: obsidian
+        uses: actions/cache@v4
+        with:
+          path: apps/website/.external-plugin-validated
+          key: website-obsidian-plugin-validated-${{ steps.external-sources.outputs.obsidian_revision }}
+
       - name: Install dependencies
         run: |
           npm ci
           npm --prefix docs-src ci
-          npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" ci
+
+      - name: Install pinned Obsidian plugin dependencies
+        if: steps.obsidian.outputs.cache-hit != 'true'
+        run: npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" ci
 
       - name: Test pinned Obsidian plugin source
+        if: steps.obsidian.outputs.cache-hit != 'true'
         run: |
           npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" test
           npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" run typecheck
           npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" run build
+
+      - name: Record validated Obsidian plugin marker
+        if: steps.obsidian.outputs.cache-hit != 'true'
+        run: |
+          printf 'revision=%s validated-at=%s\n' \
+            "${{ steps.external-sources.outputs.obsidian_revision }}" \
+            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > .external-plugin-validated
 
       - name: Sync visualizations from external plugin source
         run: npm run visualizations:sync
@@ -115,10 +166,19 @@ jobs:
   gate:
     name: Website CI
     if: ${{ always() }}
-    needs: [validate]
+    needs: [changes, validate]
     runs-on: ubuntu-latest
     steps:
       - name: Require website checks
         env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          CHANGES_RUN: ${{ needs.changes.outputs.run }}
           VALIDATE_RESULT: ${{ needs.validate.result }}
-        run: test "$VALIDATE_RESULT" = success
+        run: |
+          set -e
+          test "$CHANGES_RESULT" = success
+          if [ "$CHANGES_RUN" != "true" ]; then
+            echo "No website-affecting changes in this pull request; Website CI skipped."
+            exit 0
+          fi
+          test "$VALIDATE_RESULT" = success

--- a/.github/workflows/website-ci.yml
+++ b/.github/workflows/website-ci.yml
@@ -92,39 +92,20 @@ jobs:
             apps/website/docs-src/package-lock.json
             .external/health-md-visualizations/package-lock.json
 
-      - name: Restore validated Obsidian plugin marker
-        # The pinned revision only changes with external-sources.json; skip the
-        # plugin's own install/test/typecheck/build when this exact revision has
-        # already been validated. The source checkout remains because sync and
-        # the website tests bundle directly from the plugin's src directory.
-        id: obsidian
-        uses: actions/cache@v4
-        with:
-          path: apps/website/.external-plugin-validated
-          key: website-obsidian-plugin-validated-${{ steps.external-sources.outputs.obsidian_revision }}
-
       - name: Install dependencies
         run: |
           npm ci
           npm --prefix docs-src ci
-
-      - name: Install pinned Obsidian plugin dependencies
-        if: steps.obsidian.outputs.cache-hit != 'true'
-        run: npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" ci
+          npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" ci
 
       - name: Test pinned Obsidian plugin source
-        if: steps.obsidian.outputs.cache-hit != 'true'
+        # Kept unconditional: the visualization bundle resolves plugin imports such as
+        # "leaflet" from the plugin checkout's own node_modules, so its install cannot
+        # be skipped behind a revision marker without breaking visualizations:sync.
         run: |
           npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" test
           npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" run typecheck
           npm --prefix "$GITHUB_WORKSPACE/.external/health-md-visualizations" run build
-
-      - name: Record validated Obsidian plugin marker
-        if: steps.obsidian.outputs.cache-hit != 'true'
-        run: |
-          printf 'revision=%s validated-at=%s\n' \
-            "${{ steps.external-sources.outputs.obsidian_revision }}" \
-            "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > .external-plugin-validated
 
       - name: Sync visualizations from external plugin source
         run: npm run visualizations:sync

--- a/apps/apple/HealthMdTests/Utilities/CIQualityGateTests.swift
+++ b/apps/apple/HealthMdTests/Utilities/CIQualityGateTests.swift
@@ -207,7 +207,7 @@ final class CIQualityGateTests: XCTestCase {
             "Hosted Apple unit and coverage jobs must allow enough time for clean builds"
         )
         XCTAssertTrue(
-            content.contains("test-ios-ui:\n    name: iOS UI regressions\n    needs: prepare-shared-core\n    runs-on: macos-26\n    timeout-minutes: 60"),
+            content.contains("test-ios-ui:\n    name: iOS UI regressions\n    needs: [changes, prepare-shared-core]\n    if: ${{ needs.changes.outputs.run == 'true' }}\n    runs-on: macos-26\n    timeout-minutes: 60"),
             "The split UI job must allow at least 60 minutes for clean builds"
         )
         XCTAssertEqual(
@@ -216,7 +216,7 @@ final class CIQualityGateTests: XCTestCase {
             "Apple CI must build the exact shared-core XCFramework only once"
         )
         XCTAssertEqual(
-            content.components(separatedBy: "needs: prepare-shared-core").count - 1,
+            content.components(separatedBy: "needs: [changes, prepare-shared-core]").count - 1,
             3,
             "All Xcode test jobs must consume the single prepared shared-core artifact"
         )

--- a/apps/practice/qualification/v1/assertions.json
+++ b/apps/practice/qualification/v1/assertions.json
@@ -96,7 +96,7 @@
       "evidenceLayer": "static-policy",
       "declaration": {
         "normalizedAstSha256": "6a1e847f2cc6d93ddfe275747140fbcdb9d964461de299cba71e7efb853ca5ec",
-        "line": 63
+        "line": 68
       },
       "assertions": [
         {
@@ -104,84 +104,84 @@
           "kind": "expect-matcher",
           "normalizedAstSha256": "2ea5b825740d27ebf3c1680c986f9c29c3c0042d607c7537c05c38e605b7ff17",
           "excerpt": "expect(script).toContain('schema: \"practice.synthetic.provenance/3\"')",
-          "line": 65
+          "line": 70
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-002",
           "kind": "expect-matcher",
           "normalizedAstSha256": "7985ec1e4f20e2945e0dbfab7defc80d961c34b4794ce94aa7e9edb40785cdbd",
           "excerpt": "expect(script).toContain(\"productionEnabled: false\")",
-          "line": 66
+          "line": 71
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-003",
           "kind": "expect-matcher",
           "normalizedAstSha256": "0fe38776e34013dc78eb8bda2b3e8bbf6300ace5fab64030b6622f10d13a6372",
           "excerpt": "expect(script).toContain(\"syntheticBoundaryFiles(root, repositoryRoot, { includeDist: false })\")",
-          "line": 67
+          "line": 72
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-004",
           "kind": "expect-matcher",
           "normalizedAstSha256": "3aac508f5c17f54515b2a346094a2da535f272c9e5e76544b0d06425b2f68235",
           "excerpt": "expect(script).toContain(\"candidateCommit: dirty ? null : sourceHeadCommit\")",
-          "line": 68
+          "line": 73
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-006",
           "kind": "expect-matcher",
           "normalizedAstSha256": "bcd10bdef02b0fd7043ad0ef26d2735010c1b412b035eb79c34c70cdd128f893",
           "excerpt": "expect(script).toContain(\"safeProvenanceMetadataPath\")",
-          "line": 69
+          "line": 74
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-007",
           "kind": "expect-matcher",
           "normalizedAstSha256": "116b97c84b3b2e8dabef48861d4ab31fdf81a91f9e6181eb3542c556caa64f79",
           "excerpt": "expect(script).toContain(\"statusDigest\")",
-          "line": 70
+          "line": 75
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-009",
           "kind": "expect-matcher",
           "normalizedAstSha256": "5de5f2d381591a37953a5e664e2a05d3429f08a7780f19fbc88d6b0f36a2ff07",
           "excerpt": "expect(script).toContain(\"pathSha256: digest(item.display)\")",
-          "line": 71
+          "line": 76
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-008",
           "kind": "expect-matcher",
           "normalizedAstSha256": "a4a658a3975f7bf7014ef30293356f2e8cc6929fcf3742fab45ffa1c93e50180",
           "excerpt": "expect(script).not.toContain(\"status: statusLines\")",
-          "line": 72
+          "line": 77
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-010",
           "kind": "expect-matcher",
           "normalizedAstSha256": "95831c4573173f36528ce4a0f7a435bdfc9d137e0c5e460ef95569d93b8796dd",
           "excerpt": "expect(script).not.toContain(\"sourceFiles.push({ path: item.display\")",
-          "line": 73
+          "line": 78
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-005",
           "kind": "expect-matcher",
           "normalizedAstSha256": "f08af5bb45c94266dc20a42e23d40d93f77823de3731075088a52b07119fca9d",
           "excerpt": "expect(gate.operationalEvidence).toEqual([ { name: \"migration\", status: \"not_implemented\" }, { name: \"rollback\", status: \"not_implemented\" }, { name: \"backup_restore\", status: \"…",
-          "line": 75
+          "line": 80
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-011",
           "kind": "expect-matcher",
           "normalizedAstSha256": "f9126cc4637a790031211ce426d31dd75c038d73bb65af0534a3ed6595473d93",
           "excerpt": "expect(script).toContain(\"qualifiedTreeCommit: repositoryHead\")",
-          "line": 81
+          "line": 86
         },
         {
           "id": "test-observable-0b288b91c5b7eb6d-assertion-012",
           "kind": "expect-matcher",
           "normalizedAstSha256": "ec6b516659f205af89f78bd607a98a1f0650cca9dedd5720062ec213c92b543a",
           "excerpt": "expect(script).toContain(\"sourceHeadCommit\")",
-          "line": 82
+          "line": 87
         }
       ]
     },
@@ -1526,7 +1526,7 @@
       },
       "evidenceLayer": "static-policy",
       "declaration": {
-        "normalizedAstSha256": "300dcb277a618fd68ccca5cccf219a0b2376fa8d01f0a84d7714d3cb9d2acc6d",
+        "normalizedAstSha256": "4f0e7346fc7540f74ef8e2b6f17142151aa1540a1b99cf59cb183b9cc6b2614d",
         "line": 25
       },
       "assertions": [
@@ -1708,23 +1708,30 @@
         {
           "id": "test-observable-39fca66c5f1593c0-assertion-024",
           "kind": "expect-matcher",
-          "normalizedAstSha256": "1a7708422e469b46538f677e112f07783383ea01c94b544eaf79984b9b9ac583",
-          "excerpt": "expect(workflow).toContain(\":app:clean :app:testPlayDebugUnitTest --tests com.healthmd.domain.practice.PracticeFeaturePolicyTest\")",
-          "line": 52
+          "normalizedAstSha256": "db37788a81e933d318fd3cc806b98d400189227350a2594cf5d5406ade7e2eb6",
+          "excerpt": "expect(workflow).toContain(\":app:testPlayDebugUnitTest --tests com.healthmd.domain.practice.PracticeFeaturePolicyTest\")",
+          "line": 56
+        },
+        {
+          "id": "test-observable-39fca66c5f1593c0-assertion-031",
+          "kind": "expect-matcher",
+          "normalizedAstSha256": "61cf6d80bd135f55c0e07b2a265f890342c59cd00cd1878489ac4325456d08e0",
+          "excerpt": "expect(workflow.match(/:app:testPlayDebugUnitTest --tests com\\.healthmd\\.domain\\.practice\\.PracticeFeaturePolicyTest/g)).toHaveLength(2)",
+          "line": 57
         },
         {
           "id": "test-observable-39fca66c5f1593c0-assertion-025",
           "kind": "expect-matcher",
-          "normalizedAstSha256": "b2a426f3a4399ab9fe6d7cfef5a54471918bf9055cde2ff9c2603b64d4fe64d2",
-          "excerpt": "expect(workflow).toContain(\"needs: [validate, practice-focused-apple-policy, practice-focused-android-policy]\")",
-          "line": 53
+          "normalizedAstSha256": "02fdbd8aab715be1062719fd9024cef487b4a04584c70b1bee8ab3b7d16d6658",
+          "excerpt": "expect(workflow).toContain(\"needs: [changes, validate, practice-focused-apple-policy, practice-focused-android-policy]\")",
+          "line": 58
         },
         {
           "id": "test-observable-39fca66c5f1593c0-assertion-026",
           "kind": "expect-matcher",
           "normalizedAstSha256": "20c21c43e37b989e24eb6904877f9d55d39517ecb8befb5512210638d09c17b1",
           "excerpt": "expect(workflow.match(/ref: \\$\\{\\{ github\\.sha \\}\\}/g)).toHaveLength(3)",
-          "line": 54
+          "line": 59
         }
       ]
     },
@@ -3472,7 +3479,7 @@
       "evidenceLayer": "static-policy",
       "declaration": {
         "normalizedAstSha256": "d9bceef84b9515e5f2f5695052a32a231acc30f75da404fdb8a2d0a4dc17f31e",
-        "line": 85
+        "line": 90
       },
       "assertions": [
         {
@@ -3480,14 +3487,14 @@
           "kind": "expect-matcher",
           "normalizedAstSha256": "e19ba82d304d5b57564859bc42f61ada9b921585f427ed34b3576ca24b95c282",
           "excerpt": "expect(safeProvenanceMetadataPath(\"src/synthetic/service.ts\")).toBe(true)",
-          "line": 86
+          "line": 91
         },
         {
           "id": "test-observable-9fcb953d48f446a1-assertion-002",
           "kind": "expect-matcher",
           "normalizedAstSha256": "e888e192a0bd07550d5a3a32d2fe85d1f12cc2f4db8361d159113b2342252143",
           "excerpt": "expect(safeProvenanceMetadataPath(path)).toBe(false)",
-          "line": 87
+          "line": 92
         }
       ]
     },
@@ -4738,7 +4745,7 @@
       "evidenceLayer": "static-policy",
       "declaration": {
         "normalizedAstSha256": "4dda5f9066cd47bc0ee78bcadf20b09aa7f3930050f5e37a95e17fdc161e3a5d",
-        "line": 57
+        "line": 62
       },
       "assertions": [
         {
@@ -4746,35 +4753,35 @@
           "kind": "expect-matcher",
           "normalizedAstSha256": "9102d650f4eab94c394b6e6233154dcb7310131cefaed695bf4a5a26b515e2a5",
           "excerpt": "expect(source).not.toMatch(/(?:from|import\\s*)\\s*[\"'][^\"']*(?:apps\\/website|\\/worker\\/)/)",
-          "line": 59
+          "line": 64
         },
         {
           "id": "test-observable-b53a0818813d7262-assertion-002",
           "kind": "expect-matcher",
           "normalizedAstSha256": "e33d086f30cba5cbb066dbd713442f6ac73edfd3e1e011006f3b73669652fc18",
           "excerpt": "expect(wrangler).toContain('PRACTICE_RUNTIME_MODE = \"synthetic\"')",
-          "line": 60
+          "line": 65
         },
         {
           "id": "test-observable-b53a0818813d7262-assertion-003",
           "kind": "expect-matcher",
           "normalizedAstSha256": "df9674cc938348f6a278dab3f778dd650499c3aaf4457ad736a4314934c881dc",
           "excerpt": "expect(wrangler).toContain(\"workers_dev = false\")",
-          "line": 60
+          "line": 65
         },
         {
           "id": "test-observable-b53a0818813d7262-assertion-004",
           "kind": "expect-matcher",
           "normalizedAstSha256": "7ceef5f7f67ca3204a09cf32835d3760c2a131bfeb49d01761dc1d7fb9af78aa",
           "excerpt": "expect(wrangler).not.toMatch(/^routes?\\s*=/m)",
-          "line": 60
+          "line": 65
         },
         {
           "id": "test-observable-b53a0818813d7262-assertion-005",
           "kind": "expect-matcher",
           "normalizedAstSha256": "376c941c5ffe5ebbcda9b6383f00b3ab64b5b23a3c8de1381604e91bbb7d6a37",
           "excerpt": "expect(wrangler).not.toMatch(/^\\[\\[(?:d1_databases|kv_namespaces|r2_buckets|queues)\\]\\]/m)",
-          "line": 60
+          "line": 65
         }
       ]
     },
@@ -5555,7 +5562,7 @@
       "evidenceLayer": "static-policy",
       "declaration": {
         "normalizedAstSha256": "feb3441e9d684863479713fa202d5bb0b02f349f91c8fb98a29cce92401d0d2c",
-        "line": 90
+        "line": 95
       },
       "assertions": [
         {
@@ -5563,21 +5570,21 @@
           "kind": "expect-matcher",
           "normalizedAstSha256": "e63101a64398f9d0d6eef0e99fdbe383b04aa4f9b6c37f585a4929aaf7f6ed9b",
           "excerpt": "expect(gate).toMatchObject({ designation: \"synthetic-qualification-only-not-production-ready\", productionEnabled: false, productionReady: false, syntheticRuntimeRequired: true })",
-          "line": 92
+          "line": 97
         },
         {
           "id": "test-observable-c8db8d065d24e568-assertion-002",
           "kind": "expect-matcher",
           "normalizedAstSha256": "dd71f5ecc7db34f6b47f4d6ddc0909369bd3019ce5f214aa48db51521fcd1811",
           "excerpt": "expect(gate.mandatoryProductionGates.every(item => item.approved === false && item.status === \"pending\")).toBe(true)",
-          "line": 93
+          "line": 98
         },
         {
           "id": "test-observable-c8db8d065d24e568-assertion-003",
           "kind": "expect-matcher",
           "normalizedAstSha256": "e56a5bdddee9337f2d6d7a0fbc6f839c0893aa96940eb655fa5e158524545ce6",
           "excerpt": "expect(gate.operationalEvidence.every(item => item.status === \"not_implemented\")).toBe(true)",
-          "line": 93
+          "line": 98
         }
       ]
     },

--- a/apps/practice/test/component-runtime-boundary.test.ts
+++ b/apps/practice/test/component-runtime-boundary.test.ts
@@ -49,8 +49,13 @@ describe("practice component and production-disabled runtime boundary", () => {
     expect(workflow).toContain("-Dhealthmd.practice.expectedCompiledIn=false");
     expect(workflow).toContain("-Dhealthmd.practice.expectedCompiledIn=true");
     expect(workflow).toContain("PRACTICE_COMPILED_IN: included");
-    expect(workflow).toContain(":app:clean :app:testPlayDebugUnitTest --tests com.healthmd.domain.practice.PracticeFeaturePolicyTest");
-    expect(workflow).toContain("needs: [validate, practice-focused-apple-policy, practice-focused-android-policy]");
+    // The included-policy pass no longer needs :app:clean: PRACTICE_COMPILED_IN feeds a
+    // tracked buildConfigField input, so Gradle re-runs GenerateBuildConfig plus the
+    // app-module Kotlin recompile on its own. Both focused passes must still invoke
+    // the exact policy test.
+    expect(workflow).toContain(":app:testPlayDebugUnitTest --tests com.healthmd.domain.practice.PracticeFeaturePolicyTest");
+    expect(workflow.match(/:app:testPlayDebugUnitTest --tests com\.healthmd\.domain\.practice\.PracticeFeaturePolicyTest/g)).toHaveLength(2);
+    expect(workflow).toContain("needs: [changes, validate, practice-focused-apple-policy, practice-focused-android-policy]");
     expect(workflow.match(/ref: \$\{\{ github\.sha \}\}/g)).toHaveLength(3);
   });
 


### PR DESCRIPTION
## What

Every PR currently runs all seven component workflows in full (an Apple-only PR pays ~40 min of Android CI + ~11.5 min of Practice CI that can never fail it), and Apple CI runs on every main push regardless of paths.

- **Path-filtered PR gating with stable contexts**: new `changes` job per workflow (local composite action `.github/actions/component-changes` — GitHub API file listing, exact workflow-`paths` glob semantics, fail-closed) skips heavy jobs when unaffected; the gate jobs still run on every PR and report the same seven required contexts. `push`/`schedule`/`workflow_dispatch`/`workflow_call` (release qualification) always run everything.
- **Apple CI push paths** on `main`/`testing` (implements the documented policy that was never wired up).
- **Android**: emulator instrumentation + direct-CLI E2E split from the monolithic `test` job into a parallel `instrumentation` job (the emulator previously booted only after ~26 min of unit tests/lint).
- **CLI CI**: added the missing `concurrency` group; cargo-deny 0.20.2 installed from the official prebuilt musl tarball with the release sha256 pinned instead of compiled from source each run.
- **Practice CI**: dropped redundant `:app:clean` (`PRACTICE_COMPILED_IN` feeds a tracked `buildConfigField` input); Playwright browsers cached by lockfile.
- **Website CI**: path gating. (A revision-keyed skip of the Obsidian plugin validation was tried and reverted: the visualization bundle resolves plugin imports like `leaflet` from the plugin checkout's node_modules, so its install cannot be skipped.)

Wake CI stays always-on (single sub-minute job). Branch protection needs no changes.

## Maintenance note

Each workflow's path map now lives in two places — `on.push.paths` and the `changes` job's `paths` input — and must stay in sync (documented in `.github/workflows/README.md`).

## Verification

- YAML lint + structural check (every heavy job gated; every gate `always()` + fail-closed on detection errors)
- Android action-pin + release-documentation policy tests pass
- Glob matcher unit-tested (12 cases including `*` not crossing `/`)
- Live simulation against PR #154 (Apple-only) via the GitHub API: Apple run=true, all others run=false
- `qualify-exact-ci.py` dispatch recovery explicitly supports path-filtered push runs

