### PR TITLE
ci: verify path-filter skip behavior (draft, do not merge)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,3 +40,5 @@ Exporter shapes and direct-device protocols have multiple producers and consumer
 - Include the component name in the title when practical.
 - Document tests run and any physical-device or deployment checks not run.
 - Do not commit credentials, signing files, health data, local agent state, or generated build output.
+
+<!-- ci-skip-verification marker -->


### PR DESCRIPTION
Throwaway verification PR stacked on #155. Its only changed file (CONTRIBUTING.md) matches no component path map, so every changes job should report run=false, all heavy jobs skip, and every gate must still report success.